### PR TITLE
CLI robustness improvements

### DIFF
--- a/src/consist/core/identity.py
+++ b/src/consist/core/identity.py
@@ -454,15 +454,11 @@ class IdentityManager:
 
         # 5. Handle Numpy conversions (Existing logic)
         if np:
-            if isinstance(obj, np.integer):
-                return int(obj)
-            elif isinstance(obj, np.floating):
-                return float(obj)
-            elif isinstance(obj, np.ndarray):
+            if isinstance(obj, np.ndarray):
                 # Recursive call ensures arrays of Pydantic objects or sets are handled
                 return self._clean_structure(obj.tolist(), exclude_keys)
-            elif isinstance(obj, np.bool_):
-                return bool(obj)
+            if isinstance(obj, np.generic):
+                return self._clean_structure(obj.item(), exclude_keys)
 
         return obj
 

--- a/tests/unit/cli/test_mount_inference.py
+++ b/tests/unit/cli/test_mount_inference.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from consist import Tracker
+from consist.cli import _ensure_tracker_mounts_for_artifact
+
+
+def test_cli_infers_mounts_from_run_metadata(tmp_path: Path) -> None:
+    inputs_root = tmp_path / "inputs_root"
+    inputs_root.mkdir(parents=True)
+    data_path = inputs_root / "data.csv"
+    data_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    db_path = tmp_path / "provenance.duckdb"
+
+    tracker = Tracker(
+        run_dir=tmp_path / "producer",
+        db_path=str(db_path),
+        mounts={"inputs": str(inputs_root)},
+    )
+    with tracker.start_run(run_id="producer", model="test"):
+        logged = tracker.log_artifact(data_path, key="data", direction="input")
+
+    inspector = Tracker(run_dir=tmp_path / "inspector", db_path=str(db_path))
+    artifact = inspector.get_artifact(logged.id)
+    assert artifact is not None
+
+    _ensure_tracker_mounts_for_artifact(inspector, artifact)
+
+    assert inspector.mounts["inputs"] == str(inputs_root.resolve())
+    assert inspector.resolve_uri(artifact.uri) == str(data_path.resolve())

--- a/tests/unit/cli/test_schema_db_profile.py
+++ b/tests/unit/cli/test_schema_db_profile.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from sqlmodel import Session
+
+from consist import Tracker
+from consist.cli import ConsistShell
+from consist.models.artifact import Artifact
+from consist.models.artifact_schema import ArtifactSchema, ArtifactSchemaField
+
+
+def test_schema_command_uses_db_profile_when_available(tmp_path: Path, capsys) -> None:
+    db_path = tmp_path / "schema.db"
+    tracker = Tracker(run_dir=tmp_path / "run", db_path=str(db_path))
+
+    schema_id = "schema123"
+    artifact_id = uuid.uuid4()
+
+    schema = ArtifactSchema(
+        id=schema_id, summary_json={"column_count": 1}, profile_version=1
+    )
+    field = ArtifactSchemaField(
+        schema_id=schema_id,
+        ordinal_position=1,
+        name="col",
+        logical_type="integer",
+        nullable=False,
+    )
+    artifact = Artifact(
+        id=artifact_id,
+        key="test_artifact",
+        uri="inputs://data.csv",
+        driver="csv",
+        hash="abc",
+        meta={"schema_id": schema_id},
+    )
+
+    with Session(tracker.engine) as session:
+        session.add(schema)
+        session.add(field)
+        session.add(artifact)
+        session.commit()
+
+    shell = ConsistShell(tracker)
+    shell.do_schema("test_artifact")
+
+    captured = capsys.readouterr().out
+    assert "Schema: test_artifact" in captured
+    assert "col" in captured
+    assert "integer" in captured


### PR DESCRIPTION
Allow CLI to better guess mount directories when it's launched without an active Tracker.

Relatedly, now we get schema data in CLI from the database where possible if we can't load the file directly.