### PR TITLE
Add first-class historical output hydration API

### DIFF
--- a/docs/api/materialize.md
+++ b/docs/api/materialize.md
@@ -1,15 +1,96 @@
 # Materialization
 
+For historical output recovery, start with `hydrate_run_outputs(...)`.
+
+It is the clearest API for restart, archive-mirror recovery, and
+cross-workspace reuse because it answers the practical questions in one call:
+
+- Which keys did I ask for?
+- Where did each one land?
+- Can I use the returned artifact right now?
+
+`materialize_run_outputs(...)` performs the same underlying copy/export work
+but returns the older aggregate
+[`MaterializationResult`](#consist.core.materialize.MaterializationResult).
+Keep it for compatibility or summary-style reporting; use
+`hydrate_run_outputs(...)` for new workflows.
+
+## Recommended Workflow
+
+Hydrate only the outputs you need into a fresh workspace root:
+
+```python
+from pathlib import Path
+
+hydrated = tracker.hydrate_run_outputs(
+    "prior_run_id",
+    keys=["persons", "households"],
+    target_root=Path("restored_workspace"),
+    source_root=Path("/archive/outputs_mirror"),  # optional
+)
+```
+
+Inspect the keyed results and reuse the detached artifacts directly:
+
+```python
+persons = hydrated["persons"]
+
+print(persons.status)
+print(persons.path)
+
+if persons.resolvable:
+    path = persons.artifact.as_path()
+    print(path)
+```
+
+In this flow:
+
+- `hydrated["persons"].status` tells you what happened for that key.
+- `hydrated["persons"].path` tells you where Consist expected or created the
+  destination.
+- `hydrated["persons"].artifact` is a detached artifact view. When
+  `resolvable` is `True`, `artifact.as_path()` points at the hydrated
+  destination in the new workspace.
+
+## Status Meanings
+
+| Status | Meaning |
+|---|---|
+| `materialized_from_filesystem` | Copied from historical cold bytes on disk |
+| `materialized_from_db` | Exported from DuckDB for an ingested CSV/Parquet artifact |
+| `preserved_existing` | Destination already existed and was reused |
+| `skipped_unmapped` | No safe historical relative-path mapping was available |
+| `missing_source` | Historical bytes were unavailable and no DB fallback applied |
+| `failed` | Recovery was attempted but failed due to a collision, policy check, or copy/export error |
+
+## When To Use `materialize_run_outputs(...)`
+
+Use `materialize_run_outputs(...)` only when you intentionally want the older
+aggregate summary buckets:
+
+- `materialized_from_filesystem`
+- `materialized_from_db`
+- `skipped_existing`
+- `skipped_unmapped`
+- `skipped_missing_source`
+- `failed`
+
+If you are writing new restart or recovery logic, prefer
+`hydrate_run_outputs(...)`.
+
+## Reference
+
+This page keeps the story focused on the recommended workflow. For full API
+signatures and attribute details, use the generated reference below.
+
 ::: consist.core.materialize
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
       members:
+        - HydratedRunOutput
+        - HydratedRunOutputsResult
         - MaterializationResult
-        - materialize_artifacts
-        - materialize_artifacts_from_sources
-        - build_materialize_items_for_keys
-        - materialize_ingested_artifact_from_db
       filters:
         - "!^_"

--- a/docs/api/public_api.md
+++ b/docs/api/public_api.md
@@ -81,6 +81,8 @@ with tracker.scenario("baseline") as sc:
 - [`consist.Tracker`](tracker.md)
 - [`consist.Run`](run.md)
 - [`consist.Artifact`](artifact.md)
+- [`consist.HydratedRunOutput`](materialize.md#consist.core.materialize.HydratedRunOutput)
+- [`consist.HydratedRunOutputsResult`](materialize.md#consist.core.materialize.HydratedRunOutputsResult)
 - [`consist.MaterializationResult`](materialize.md#consist.core.materialize.MaterializationResult)
 - [`consist.RunSet`](runset.md#consist.runset.RunSet)
 - [`consist.AlignedPair`](runset.md#consist.runset.AlignedPair)
@@ -119,7 +121,8 @@ Scenario defaults like `name_template` and `cache_epoch` are configured via `con
 - [`consist.load`](api_helpers.md#consist.api.load)
 - [`consist.capture_outputs`](api_helpers.md#consist.api.capture_outputs)
 - [`consist.get_artifact`](api_helpers.md#consist.api.get_artifact)
-- [`consist.materialize_run_outputs`](api_helpers.md#consist.api.materialize_run_outputs)
+- [`consist.hydrate_run_outputs`](api_helpers.md#consist.api.hydrate_run_outputs) (recommended historical output recovery API)
+- [`consist.materialize_run_outputs`](api_helpers.md#consist.api.materialize_run_outputs) (aggregate compatibility wrapper)
 - [`consist.register_artifact_facet_parser`](api_helpers.md#consist.api.register_artifact_facet_parser)
 - [`consist.cached_output`](api_helpers.md#consist.api.cached_output)
 - [`consist.cached_artifacts`](api_helpers.md#consist.api.cached_artifacts)
@@ -180,6 +183,7 @@ as needed.
 - `find_artifacts`, `get_artifact`, `get_artifacts_for_run`
 - `find_artifacts_by_params`, `get_artifact_kv`, `register_artifact_facet_parser`
 - `get_run`, `get_run_config`, `get_run_inputs`, `get_run_outputs`
+- `hydrate_run_outputs`, `materialize_run_outputs`
 - `get_artifact_lineage`, `print_lineage`, `history`
 - `diff_runs`, `get_config_facet`, `get_config_facets`, `get_run_config_kv`
 - `get_config_values`, `get_config_value`, `find_runs_by_facet_kv`

--- a/docs/concepts/caching-and-hydration.md
+++ b/docs/concepts/caching-and-hydration.md
@@ -495,14 +495,21 @@ reconstruction. It raises only when the requested bytes still cannot be
 recovered.
 
 For archive-mirror recovery or export workflows, use the explicit run-scoped
-API instead of cache hydration:
+API instead of cache hydration. In almost all new code, that means
+`hydrate_run_outputs(...)`:
 
 ```python
-result = tracker.materialize_run_outputs(
+hydrated = tracker.hydrate_run_outputs(
     "prior_run_id",
+    keys=["features"],
     target_root=Path("restored_outputs"),
     source_root=Path("/archive/outputs_mirror"),
 )
+
+features = hydrated["features"]
+assert features.resolvable
+print(features.status)
+print(features.artifact.as_path())
 ```
 
 Cache hydration exposes an archive-mirror override via
@@ -513,9 +520,13 @@ Cache hydration exposes an archive-mirror override via
 also available on low-level `tracker.start_run(...)` /
 `tracker.begin_run(...)` flows.
 
-For explicit historical output recovery, `tracker.materialize_run_outputs(...)`
-accepts `target_root` under either the tracker `run_dir` or any configured
-tracker mount root without requiring `allow_external_paths=True`.
+For explicit historical output recovery,
+`tracker.hydrate_run_outputs(...)` accepts `target_root` under either the
+tracker `run_dir` or any configured tracker mount root without requiring
+`allow_external_paths=True`.
+
+Keep `tracker.materialize_run_outputs(...)` for compatibility if you only need
+aggregate summary buckets rather than keyed per-output results.
 
 ### Containers Integration
 

--- a/docs/mounts-and-portability.md
+++ b/docs/mounts-and-portability.md
@@ -195,8 +195,9 @@ When Consist needs bytes from a historical run (e.g., cache hydration or
 If a mount is missing or points somewhere else, materialization will warn and skip
 missing files rather than crashing (unless explicitly set to raise).
 
-For the newer `tracker.materialize_run_outputs(...)` recovery path, output layout
-resolution is more conservative and history-aware:
+For the newer historical output recovery flow
+(`tracker.hydrate_run_outputs(...)`), output layout resolution is more
+conservative and history-aware:
 
 1) `workspace://...` and `./...` are re-rooted under the producing run's
    `_physical_run_dir`.
@@ -265,11 +266,14 @@ for non-container run policies.
   `run(...)` / scenario steps, or pass
   `materialize_cached_outputs_source_root=...` on low-level
   `tracker.start_run(...)` / `tracker.begin_run(...)` workflows.
-- Use `tracker.materialize_run_outputs(..., source_root=...)` when you need to
-  restore historical outputs from an archive mirror into a new root.
-- `tracker.materialize_run_outputs(...)` accepts `target_root` under either the
-  tracker `run_dir` or a configured mount root. Other destinations still require
-  `allow_external_paths=True`.
+- Use `tracker.hydrate_run_outputs(..., source_root=...)` when you want
+  key-indexed recovery results and detached artifacts that are immediately
+  usable in the new workspace.
+- Keep `tracker.materialize_run_outputs(..., source_root=...)` only for
+  compatibility when you intentionally want the aggregate summary buckets.
+- `tracker.hydrate_run_outputs(...)` accepts `target_root` under either the
+  tracker `run_dir` or a configured mount root. Other destinations still
+  require `allow_external_paths=True`.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,11 +259,15 @@ run's outputs into a new directory or recover from an archive mirror:
 ```python
 from pathlib import Path
 
-restored = tracker.materialize_run_outputs(
+hydrated = tracker.hydrate_run_outputs(
     "prior_run_id",
+    keys=["persons", "households"],
     target_root=Path("rehydrated"),
     source_root=Path("/archive/outputs_mirror"),  # optional
 )
+
+for key, output in hydrated.items():
+    print(key, output.status, output.path)
 ```
 
 This preserves historical relative layout under `target_root`. If the original
@@ -276,8 +280,12 @@ on `run(...)` / scenario steps, or use the same
 `materialize_cached_outputs_source_root=Path(...)` override on low-level
 `tracker.start_run(...)` flows.
 
-`tracker.materialize_run_outputs(...)` can also restore into a configured mount
-root without enabling `allow_external_paths=True`.
+`tracker.hydrate_run_outputs(...)` can restore into a configured mount root
+without enabling `allow_external_paths=True`.
+
+Keep `tracker.materialize_run_outputs(...)` for compatibility when you only
+need aggregate summary buckets rather than the keyed per-output result shown
+above.
 
 ---
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1027,8 +1027,13 @@ the prior run's files or reconstruct ingested tables.
 When cache-hit output files are gone, `outputs-all` and the new run-scoped
 output recovery API can reconstruct ingested CSV/Parquet outputs from DuckDB.
 For archive-mirror recovery or debug/export workflows, prefer the explicit
-`tracker.materialize_run_outputs(...)` API instead of overloading cache
-hydration.
+historical output recovery API instead of overloading cache hydration:
+
+- `tracker.hydrate_run_outputs(...)` is the recommended path. It gives you a
+  keyed result with detached artifacts, statuses, and directly usable hydrated
+  paths.
+- `tracker.materialize_run_outputs(...)` remains available when you
+  specifically want the older aggregate summary buckets.
 
 For archive-mirror recovery, cache hydration supports
 `materialize_cached_outputs_source_root=Path(...)` for `outputs-requested` and
@@ -1037,9 +1042,24 @@ For archive-mirror recovery, cache hydration supports
 `consist.run(...)`, `Tracker.run(...)`, and scenario steps, or via the low-level
 `tracker.start_run(...)` / `tracker.begin_run(...)` APIs directly.
 
-When you use the explicit `tracker.materialize_run_outputs(...)` API, `target_root`
-may be either the tracker `run_dir` or any configured tracker mount root without
-needing `allow_external_paths=True`.
+When you use `tracker.hydrate_run_outputs(...)`, `target_root` may be either
+the tracker `run_dir` or any configured tracker mount root without needing
+`allow_external_paths=True`.
+
+Example:
+
+```python
+hydrated = tracker.hydrate_run_outputs(
+    "prior_run_id",
+    keys=["results"],
+    target_root=Path("restored_outputs"),
+)
+
+result = hydrated["results"]
+print(result.status)
+if result.resolvable:
+    print(result.artifact.as_path())
+```
 
 Set per-run via `cache_options=CacheOptions(cache_hydration=...)` (for `run(...)`)
 or for scenario defaults via `step_cache_hydration=...`:

--- a/src/consist/__init__.py
+++ b/src/consist/__init__.py
@@ -54,6 +54,7 @@ from consist.api import (
     cached_output,
     cached_artifacts,
     get_run_result,
+    hydrate_run_outputs,
     materialize_run_outputs,
     get_artifact,
     register_artifact_facet_parser,
@@ -94,7 +95,11 @@ from consist.core.noop import (
     NoopScenarioContext,
     NoopTracker,
 )
-from consist.core.materialize import MaterializationResult
+from consist.core.materialize import (
+    HydratedRunOutput,
+    HydratedRunOutputsResult,
+    MaterializationResult,
+)
 from consist.runtime import create_tracker
 from consist.protocols import (
     ArtifactLike,
@@ -124,6 +129,8 @@ __all__ = [
     "NoopRunResult",
     "NoopScenarioContext",
     "NoopTracker",
+    "HydratedRunOutput",
+    "HydratedRunOutputsResult",
     "MaterializationResult",
     "create_tracker",
     "ArtifactLike",
@@ -169,6 +176,7 @@ __all__ = [
     "cached_output",
     "cached_artifacts",
     "get_run_result",
+    "hydrate_run_outputs",
     "materialize_run_outputs",
     "get_artifact",
     "register_artifact_facet_parser",

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -48,6 +48,12 @@ from consist.core.decorators import (
 )
 from consist.core.drivers import ARRAY_DRIVERS, TABLE_DRIVERS, ArrayInfo, TableInfo
 from consist.core.noop import NoopRunContext, NoopScenarioContext
+from consist.core.materialize_options import (
+    VALID_MATERIALIZE_DB_FALLBACK as _VALID_MATERIALIZE_DB_FALLBACK,
+    VALID_MATERIALIZE_ON_MISSING as _VALID_MATERIALIZE_ON_MISSING,
+    normalize_materialize_output_keys,
+    validate_materialize_option,
+)
 from consist.core.run_options import raise_legacy_policy_kwargs_error
 from consist.core.stores import get_hot_data_db_path
 from consist.core.views import _quote_ident, create_view_model
@@ -68,7 +74,10 @@ from consist.types import (
 
 if TYPE_CHECKING:
     from consist.core.config_canonicalization import ConfigAdapter
-    from consist.core.materialize import MaterializationResult
+    from consist.core.materialize import (
+        HydratedRunOutputsResult,
+        MaterializationResult,
+    )
     from consist.core.step_context import StepContext
     from consist.runset import RunSet
 
@@ -95,8 +104,6 @@ except ImportError:
     gpd = None
 
 T = TypeVar("T", bound=SQLModel)
-_VALID_MATERIALIZE_ON_MISSING = {"warn", "raise"}
-_VALID_MATERIALIZE_DB_FALLBACK = {"never", "if_ingested"}
 
 
 class OpenMatrixFileLike(Protocol):
@@ -107,38 +114,6 @@ class OpenMatrixFileLike(Protocol):
     def __getitem__(self, key: str) -> Any: ...
 
     def close(self) -> None: ...
-
-
-def _normalize_materialize_output_keys(
-    keys: Sequence[str] | None,
-) -> tuple[str, ...] | None:
-    if keys is None:
-        return None
-    if isinstance(keys, (str, bytes)):
-        raise TypeError(
-            "keys must be a sequence of output-key strings, not a single str/bytes value."
-        )
-
-    normalized: list[str] = []
-    for key in keys:
-        if not isinstance(key, str):
-            raise TypeError(
-                "keys must contain only strings "
-                f"(got {type(key).__name__!s} in materialize_run_outputs)."
-            )
-        normalized.append(key)
-    return tuple(normalized)
-
-
-def _validate_materialize_option(
-    *,
-    name: str,
-    value: str,
-    allowed: set[str],
-) -> None:
-    if value not in allowed:
-        allowed_display = ", ".join(repr(item) for item in sorted(allowed))
-        raise ValueError(f"{name} must be one of: {allowed_display}")
 
 
 LoadResult = Union[
@@ -1080,6 +1055,13 @@ def materialize_run_outputs(
     """
     Materialize the linked outputs of a historical run into a new root.
 
+    This is the top-level convenience wrapper around
+    ``Tracker.materialize_run_outputs(...)``. It restores historical bytes and
+    returns the legacy aggregate ``MaterializationResult`` summary.
+
+    Prefer ``hydrate_run_outputs(...)`` when you want a result keyed by output
+    name, detached hydrated artifacts, or directly usable destination paths.
+
     Parameters
     ----------
     run_id : str
@@ -1103,14 +1085,27 @@ def materialize_run_outputs(
     -------
     MaterializationResult
         Structured materialization outcome for the selected run outputs.
+
+    Examples
+    --------
+    >>> restored = consist.materialize_run_outputs(
+    ...     "prior_run_id",
+    ...     keys=["persons"],
+    ...     target_root="restored",
+    ... )
+    >>> restored.materialized
+    {'persons': '.../restored/.../persons.parquet'}
     """
-    normalized_keys = _normalize_materialize_output_keys(keys)
-    _validate_materialize_option(
+    normalized_keys = normalize_materialize_output_keys(
+        keys,
+        caller="materialize_run_outputs",
+    )
+    validate_materialize_option(
         name="on_missing",
         value=on_missing,
         allowed=_VALID_MATERIALIZE_ON_MISSING,
     )
-    _validate_materialize_option(
+    validate_materialize_option(
         name="db_fallback",
         value=db_fallback,
         allowed=_VALID_MATERIALIZE_DB_FALLBACK,
@@ -1118,6 +1113,88 @@ def materialize_run_outputs(
 
     tr = _resolve_tracker(tracker)
     return tr.materialize_run_outputs(
+        run_id,
+        target_root=target_root,
+        source_root=source_root,
+        keys=normalized_keys,
+        preserve_existing=preserve_existing,
+        on_missing=on_missing,
+        db_fallback=db_fallback,
+    )
+
+
+def hydrate_run_outputs(
+    run_id: str,
+    *,
+    target_root: str | Path,
+    source_root: str | Path | None = None,
+    keys: Sequence[str] | None = None,
+    preserve_existing: bool = True,
+    on_missing: Literal["warn", "raise"] = "warn",
+    db_fallback: Literal["never", "if_ingested"] = "if_ingested",
+    tracker: Optional["Tracker"] = None,
+) -> "HydratedRunOutputsResult":
+    """
+    Hydrate the linked outputs of a historical run into a new root.
+
+    This is the higher-level historical recovery helper. It performs the same
+    physical copy/export work as ``materialize_run_outputs(...)`` but returns a
+    keyed result with detached artifacts, destination paths, statuses, and
+    resolvability information for each requested output.
+
+    Parameters
+    ----------
+    run_id : str
+        Identifier of the run whose outputs should be restored.
+    target_root : str | Path
+        Destination root for hydrated outputs.
+    source_root : str | Path | None, optional
+        Optional alternate source root for filesystem-backed recovery.
+    keys : Sequence[str] | None, optional
+        Optional subset of output keys to restore.
+    preserve_existing : bool, default True
+        If True, existing destinations are preserved and reported as reusable.
+    on_missing : {"warn", "raise"}, default "warn"
+        Missing-source handling policy forwarded to the tracker.
+    db_fallback : {"never", "if_ingested"}, default "if_ingested"
+        DB export fallback policy forwarded to the tracker.
+    tracker : Optional[Tracker], optional
+        Tracker instance to use. If omitted, resolves the active/default tracker.
+
+    Returns
+    -------
+    HydratedRunOutputsResult
+        Keyed hydration outcome for the selected run outputs.
+
+    Examples
+    --------
+    >>> hydrated = consist.hydrate_run_outputs(
+    ...     "prior_run_id",
+    ...     keys=["persons"],
+    ...     target_root="restored",
+    ... )
+    >>> hydrated["persons"].status
+    'materialized_from_filesystem'
+    >>> hydrated["persons"].artifact.as_path()
+    PosixPath('.../restored/.../persons.parquet')
+    """
+    normalized_keys = normalize_materialize_output_keys(
+        keys,
+        caller="hydrate_run_outputs",
+    )
+    validate_materialize_option(
+        name="on_missing",
+        value=on_missing,
+        allowed=_VALID_MATERIALIZE_ON_MISSING,
+    )
+    validate_materialize_option(
+        name="db_fallback",
+        value=db_fallback,
+        allowed=_VALID_MATERIALIZE_DB_FALLBACK,
+    )
+
+    tr = _resolve_tracker(tracker)
+    return tr.hydrate_run_outputs(
         run_id,
         target_root=target_root,
         source_root=source_root,

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -1,5 +1,21 @@
+"""Historical output materialization and hydration helpers.
+
+This module exposes two related recovery layers for prior run outputs:
+
+- ``materialize_run_outputs(...)`` performs the physical copy/export work and
+  returns the legacy aggregate ``MaterializationResult`` summary.
+- ``hydrate_run_outputs(...)`` performs the same recovery work but returns a
+  key-indexed ``HydratedRunOutputsResult`` with detached artifacts, resolved
+  paths, and per-key statuses that are immediately usable in a new workspace.
+
+The keyed hydration result is the higher-level API. The aggregate
+``MaterializationResult`` remains the compatibility wrapper for callers that
+only need summary buckets.
+"""
+
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping as MappingABC
 from dataclasses import dataclass, field
 import logging
 import os
@@ -19,9 +35,45 @@ if TYPE_CHECKING:
     from consist.core.persistence import DatabaseManager
     from consist.core.tracker import Tracker
 
+HydrationStatus = Literal[
+    "materialized_from_filesystem",
+    "materialized_from_db",
+    "preserved_existing",
+    "skipped_unmapped",
+    "missing_source",
+    "failed",
+]
+
 
 @dataclass(slots=True)
 class MaterializationResult:
+    """Aggregate summary for historical run-output materialization.
+
+    This is the compatibility result returned by
+    ``Tracker.materialize_run_outputs(...)`` and the top-level
+    ``consist.materialize_run_outputs(...)`` helper. It groups outcomes into
+    summary buckets rather than returning one object per requested key.
+
+    For new recovery flows, prefer ``HydratedRunOutputsResult`` because it
+    preserves per-key status, detached artifacts, and directly usable paths.
+
+    Attributes
+    ----------
+    materialized_from_filesystem : dict[str, str]
+        Keys restored by copying bytes from historical filesystem locations.
+        Values are the destination paths.
+    materialized_from_db : dict[str, str]
+        Keys reconstructed from DuckDB for ingested CSV/Parquet artifacts.
+        Values are the destination paths.
+    skipped_existing : list[str]
+        Keys whose destination already existed and was preserved.
+    skipped_unmapped : list[str]
+        Keys that could not be mapped back to a historical relative path.
+    skipped_missing_source : list[str]
+        Keys whose historical bytes were unavailable and could not be recovered.
+    failed : list[tuple[str, str]]
+        Keys that failed during recovery, paired with the failure message.
+    """
     materialized_from_filesystem: dict[str, str] = field(default_factory=dict)
     materialized_from_db: dict[str, str] = field(default_factory=dict)
     skipped_existing: list[str] = field(default_factory=list)
@@ -57,6 +109,146 @@ class MaterializationResult:
 
 
 @dataclass(frozen=True, slots=True)
+class HydratedRunOutput:
+    """Per-key outcome for ``hydrate_run_outputs(...)``.
+
+    Attributes
+    ----------
+    key : str
+        Output key requested by the caller.
+    artifact : Artifact
+        Detached copy of the historical artifact record. When ``resolvable`` is
+        ``True``, the detached artifact's runtime ``abs_path`` points at the
+        hydrated destination so helpers like ``artifact.as_path()`` can be used
+        directly in the new workspace.
+    path : Path | None
+        Destination path under the requested target root, when one is known.
+        This can be populated even for non-resolvable outcomes to show the
+        intended restore location.
+    status : HydrationStatus
+        One of:
+
+        - ``"materialized_from_filesystem"``: copied from historical cold bytes.
+        - ``"materialized_from_db"``: exported from DuckDB for an ingested
+          CSV/Parquet artifact.
+        - ``"preserved_existing"``: destination already existed and was reused.
+        - ``"skipped_unmapped"``: no safe historical relative-path mapping was
+          available.
+        - ``"missing_source"``: historical bytes were unavailable and no DB
+          fallback applied.
+        - ``"failed"``: recovery attempted but failed due to a collision,
+          policy check, or copy/export error.
+    message : str | None
+        Optional warning or error detail for ``"missing_source"`` and
+        ``"failed"`` outcomes.
+    resolvable : bool
+        Whether the returned detached artifact is immediately usable from the
+        hydrated workspace. When ``True``, ``path`` exists or is treated as the
+        preserved reusable destination.
+    """
+    key: str
+    artifact: Artifact
+    path: Path | None
+    status: HydrationStatus
+    message: str | None = None
+    resolvable: bool = False
+
+
+@dataclass(slots=True)
+class HydratedRunOutputsResult(MappingABC[str, HydratedRunOutput]):
+    """Key-indexed recovery result for historical run-output hydration.
+
+    This mapping is returned by ``hydrate_run_outputs(...)`` and preserves the
+    caller's requested key order. Each value carries the detached artifact,
+    destination path, and per-key status.
+
+    New users should generally start with this result because it answers the
+    three practical questions in one object: which keys were requested, what
+    path each key resolved to, and whether the returned artifact is immediately
+    usable in the current workspace.
+
+    Examples
+    --------
+    >>> hydrated = tracker.hydrate_run_outputs(
+    ...     "prior_run",
+    ...     keys=["persons", "households"],
+    ...     target_root="restored",
+    ... )
+    >>> hydrated["persons"].status
+    'materialized_from_filesystem'
+    >>> hydrated.paths["persons"].name
+    'persons.parquet'
+    """
+    outputs: dict[str, HydratedRunOutput] = field(default_factory=dict)
+
+    def __getitem__(self, key: str) -> HydratedRunOutput:
+        return self.outputs[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.outputs)
+
+    def __len__(self) -> int:
+        return len(self.outputs)
+
+    def items(self):
+        return self.outputs.items()
+
+    def keys(self):
+        return self.outputs.keys()
+
+    def values(self):
+        return self.outputs.values()
+
+    @property
+    def paths(self) -> dict[str, Path]:
+        return {
+            key: output.path
+            for key, output in self.outputs.items()
+            if output.path is not None and output.resolvable
+        }
+
+    @property
+    def resolvable(self) -> dict[str, HydratedRunOutput]:
+        return {
+            key: output for key, output in self.outputs.items() if output.resolvable
+        }
+
+    @property
+    def failed_keys(self) -> list[str]:
+        return [
+            key for key, output in self.outputs.items() if output.status == "failed"
+        ]
+
+    @property
+    def complete(self) -> bool:
+        incomplete_statuses = {"skipped_unmapped", "missing_source", "failed"}
+        return all(
+            output.status not in incomplete_statuses for output in self.outputs.values()
+        )
+
+    @property
+    def summary(self) -> str:
+        counts: dict[str, int] = {
+            "materialized_from_filesystem": 0,
+            "materialized_from_db": 0,
+            "preserved_existing": 0,
+            "skipped_unmapped": 0,
+            "missing_source": 0,
+            "failed": 0,
+        }
+        for output in self.outputs.values():
+            counts[output.status] += 1
+        return (
+            f"materialized_fs={counts['materialized_from_filesystem']} "
+            f"materialized_db={counts['materialized_from_db']} "
+            f"preserved_existing={counts['preserved_existing']} "
+            f"skipped_unmapped={counts['skipped_unmapped']} "
+            f"missing_source={counts['missing_source']} "
+            f"failed={counts['failed']}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class PlannedMaterialization:
     artifact: Artifact
     keys: tuple[str, ...]
@@ -64,6 +256,125 @@ class PlannedMaterialization:
     source_path: Path | None
     destination: Path
     relative_path: Path
+    artifacts_by_key: Mapping[str, Artifact] | None = None
+
+    def __post_init__(self) -> None:
+        if self.artifacts_by_key is None:
+            object.__setattr__(
+                self,
+                "artifacts_by_key",
+                {key: self.artifact for key in self.keys},
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedRunOutputHydration:
+    key_order: tuple[str, ...]
+    plan: list[PlannedMaterialization]
+    preflight_results: HydratedRunOutputsResult
+
+
+def _detach_artifact_for_hydration(
+    artifact: Artifact,
+    *,
+    hydrated_path: Path | None,
+) -> Artifact:
+    clone = artifact.model_copy(deep=True)
+    private_state = getattr(clone, "__pydantic_private__", None)
+    if private_state is None:
+        try:
+            object.__setattr__(clone, "__pydantic_private__", {})
+        except Exception:
+            pass
+        private_state = getattr(clone, "__pydantic_private__", None)
+    if isinstance(private_state, dict):
+        private_state["_tracker"] = None
+        private_state["_abs_path"] = (
+            str(hydrated_path.resolve()) if hydrated_path is not None else None
+        )
+    try:
+        object.__setattr__(clone, "_tracker", None)
+    except Exception:
+        pass
+    try:
+        object.__setattr__(
+            clone,
+            "_abs_path",
+            str(hydrated_path.resolve()) if hydrated_path is not None else None,
+        )
+    except Exception:
+        pass
+    return clone
+
+
+def _make_hydrated_output(
+    artifact: Artifact,
+    *,
+    status: HydrationStatus,
+    path: Path | None,
+    message: str | None = None,
+    resolvable: bool,
+) -> HydratedRunOutput:
+    normalized_path = path.resolve() if path is not None else None
+    detached = _detach_artifact_for_hydration(
+        artifact,
+        hydrated_path=normalized_path if resolvable else None,
+    )
+    return HydratedRunOutput(
+        key=artifact.key,
+        artifact=detached,
+        path=normalized_path,
+        status=status,
+        message=message,
+        resolvable=resolvable,
+    )
+
+
+def _ordered_hydrated_results(
+    key_order: Sequence[str],
+    outputs: Mapping[str, HydratedRunOutput],
+) -> HydratedRunOutputsResult:
+    ordered: dict[str, HydratedRunOutput] = {}
+    for key in key_order:
+        output = outputs.get(key)
+        if output is not None:
+            ordered[key] = output
+    for key, output in outputs.items():
+        if key not in ordered:
+            ordered[key] = output
+    return HydratedRunOutputsResult(outputs=ordered)
+
+
+def fold_hydrated_run_outputs_result(
+    result: HydratedRunOutputsResult,
+) -> MaterializationResult:
+    """Fold keyed hydration outcomes into the legacy summary result.
+
+    Parameters
+    ----------
+    result : HydratedRunOutputsResult
+        Key-indexed hydration outcomes produced by the shared recovery core.
+
+    Returns
+    -------
+    MaterializationResult
+        Aggregate summary that preserves the older materialization API shape.
+    """
+    folded = MaterializationResult()
+    for key, output in result.items():
+        if output.status == "materialized_from_filesystem" and output.path is not None:
+            folded.materialized_from_filesystem[key] = str(output.path)
+        elif output.status == "materialized_from_db" and output.path is not None:
+            folded.materialized_from_db[key] = str(output.path)
+        elif output.status == "preserved_existing":
+            folded.skipped_existing.append(key)
+        elif output.status == "skipped_unmapped":
+            folded.skipped_unmapped.append(key)
+        elif output.status == "missing_source":
+            folded.skipped_missing_source.append(key)
+        elif output.status == "failed":
+            folded.failed.append((key, output.message or "unknown failure"))
+    return folded
 
 
 def _ensure_destination_not_symlink(path: Path) -> None:
@@ -329,7 +640,7 @@ def _source_identity(item: PlannedMaterialization) -> tuple[str, str]:
     return ("db_export", str(item.artifact.id))
 
 
-def build_run_output_materialize_plan(
+def plan_run_output_hydration(
     tracker: "Tracker",
     run,
     *,
@@ -338,8 +649,40 @@ def build_run_output_materialize_plan(
     keys: Sequence[str] | None,
     preserve_existing: bool,
     db_fallback: Literal["never", "if_ingested"],
-) -> tuple[list[PlannedMaterialization], MaterializationResult]:
-    result = MaterializationResult()
+) -> PlannedRunOutputHydration:
+    """Plan historical output hydration for a run without mutating the target.
+
+    The planner resolves which artifacts belong to the requested keys, derives
+    their historical relative paths, chooses a recovery source for each output,
+    and emits preflight results for outcomes that do not need execution.
+
+    Preflight outcomes include:
+
+    - unknown keys (raised immediately)
+    - ambiguous duplicate output keys on the run (raised immediately)
+    - unmapped historical outputs
+    - destination collisions
+    - ``preserve_existing=True`` short-circuits
+
+    Parameters
+    ----------
+    tracker : Tracker
+        Tracker providing DB access, filesystem remapping, and mount policy.
+    run
+        Historical run record whose outputs are being restored.
+    target_root : Path
+        Root directory under which historical relative layout is recreated.
+    source_root : Path | None
+        Optional override root to probe before the original historical source.
+    keys : Sequence[str] | None
+        Specific output keys to restore. ``None`` means all run outputs.
+    preserve_existing : bool
+        Whether existing destinations should be treated as reusable.
+    db_fallback : {"never", "if_ingested"}
+        Whether ingested CSV/Parquet artifacts may be exported from DuckDB when
+        cold bytes are unavailable.
+    """
+    outputs: dict[str, HydratedRunOutput] = {}
     raw_outputs = _get_output_artifacts_for_run(tracker, run.id)
 
     key_counts: dict[str, int] = {}
@@ -353,6 +696,7 @@ def build_run_output_materialize_plan(
         )
 
     outputs_by_key = {artifact.key: artifact for artifact in raw_outputs}
+    key_order: tuple[str, ...]
     if keys is not None:
         requested_keys = list(keys)
         missing_keys = [key for key in requested_keys if key not in outputs_by_key]
@@ -362,8 +706,10 @@ def build_run_output_materialize_plan(
                 f"{run.id!r}: {', '.join(repr(key) for key in missing_keys)}"
             )
         selected_outputs = [outputs_by_key[key] for key in requested_keys]
+        key_order = tuple(requested_keys)
     else:
         selected_outputs = list(raw_outputs)
+        key_order = tuple(artifact.key for artifact in selected_outputs)
 
     planned_by_destination: dict[Path, PlannedMaterialization] = {}
     conflicted_destinations: set[Path] = set()
@@ -374,7 +720,12 @@ def build_run_output_materialize_plan(
         )
         remap = _derive_historical_remap(tracker, artifact=artifact, run=owning_run)
         if remap is None:
-            result.skipped_unmapped.append(artifact.key)
+            outputs[artifact.key] = _make_hydrated_output(
+                artifact,
+                status="skipped_unmapped",
+                path=None,
+                resolvable=False,
+            )
             continue
 
         historical_root, relative_path = remap
@@ -398,18 +749,26 @@ def build_run_output_materialize_plan(
             if db_fallback == "if_ingested" and artifact_meta.get("is_ingested", False):
                 driver = str(artifact.driver or "").lower()
                 if driver not in {"csv", "parquet"}:
-                    result.failed.append(
-                        (
-                            artifact.key,
+                    outputs[artifact.key] = _make_hydrated_output(
+                        artifact,
+                        status="failed",
+                        path=destination,
+                        message=(
                             "unsupported DB export for ingested driver "
-                            f"{artifact.driver!r}",
-                        )
+                            f"{artifact.driver!r}"
+                        ),
+                        resolvable=False,
                     )
                     continue
                 source_kind = "db_export"
                 source_path = None
             else:
-                result.skipped_missing_source.append(artifact.key)
+                outputs[artifact.key] = _make_hydrated_output(
+                    artifact,
+                    status="missing_source",
+                    path=destination,
+                    resolvable=False,
+                )
                 continue
 
         planned = PlannedMaterialization(
@@ -419,14 +778,16 @@ def build_run_output_materialize_plan(
             source_path=source_path,
             destination=destination,
             relative_path=relative_path,
+            artifacts_by_key={artifact.key: artifact},
         )
 
         if destination in conflicted_destinations:
-            result.failed.append(
-                (
-                    artifact.key,
-                    f"destination collision at {destination}",
-                )
+            outputs[artifact.key] = _make_hydrated_output(
+                artifact,
+                status="failed",
+                path=destination,
+                message=f"destination collision at {destination}",
+                resolvable=False,
             )
             continue
 
@@ -436,6 +797,8 @@ def build_run_output_materialize_plan(
             continue
 
         if _source_identity(existing) == _source_identity(planned):
+            combined_artifacts = dict(existing.artifacts_by_key or {})
+            combined_artifacts[artifact.key] = artifact
             planned_by_destination[destination] = PlannedMaterialization(
                 artifact=existing.artifact,
                 keys=existing.keys + (artifact.key,),
@@ -443,11 +806,26 @@ def build_run_output_materialize_plan(
                 source_path=existing.source_path,
                 destination=existing.destination,
                 relative_path=existing.relative_path,
+                artifacts_by_key=combined_artifacts,
             )
             continue
 
         for key in existing.keys + (artifact.key,):
-            result.failed.append((key, f"destination collision at {destination}"))
+            collision_artifact = (
+                (
+                    existing.artifacts_by_key
+                    or {existing.artifact.key: existing.artifact}
+                )[key]
+                if key in (existing.artifacts_by_key or {})
+                else artifact
+            )
+            outputs[key] = _make_hydrated_output(
+                collision_artifact,
+                status="failed",
+                path=destination,
+                message=f"destination collision at {destination}",
+                resolvable=False,
+            )
         conflicted_destinations.add(destination)
         del planned_by_destination[destination]
 
@@ -459,28 +837,85 @@ def build_run_output_materialize_plan(
         if preserve_existing and item.destination.exists():
             if item.destination.is_symlink():
                 for key in item.keys:
-                    result.failed.append(
-                        (
-                            key,
-                            f"Symlink detected in destination path: {item.destination}",
-                        )
+                    artifact = cast(Mapping[str, Artifact], item.artifacts_by_key)[key]
+                    outputs[key] = _make_hydrated_output(
+                        artifact,
+                        status="failed",
+                        path=item.destination,
+                        message=f"Symlink detected in destination path: {item.destination}",
+                        resolvable=False,
                     )
             else:
-                result.skipped_existing.extend(item.keys)
+                for key in item.keys:
+                    artifact = cast(Mapping[str, Artifact], item.artifacts_by_key)[key]
+                    outputs[key] = _make_hydrated_output(
+                        artifact,
+                        status="preserved_existing",
+                        path=item.destination,
+                        resolvable=True,
+                    )
             continue
         plan.append(item)
-    return plan, result
+    return PlannedRunOutputHydration(
+        key_order=key_order,
+        plan=plan,
+        preflight_results=_ordered_hydrated_results(key_order, outputs),
+    )
 
 
-def materialize_planned_outputs(
+def build_run_output_materialize_plan(
+    tracker: "Tracker",
+    run,
+    *,
+    target_root: Path,
+    source_root: Path | None,
+    keys: Sequence[str] | None,
+    preserve_existing: bool,
+    db_fallback: Literal["never", "if_ingested"],
+) -> tuple[list[PlannedMaterialization], MaterializationResult]:
+    """Build the legacy materialization plan and aggregate preflight result."""
+    planned = plan_run_output_hydration(
+        tracker,
+        run,
+        target_root=target_root,
+        source_root=source_root,
+        keys=keys,
+        preserve_existing=preserve_existing,
+        db_fallback=db_fallback,
+    )
+    return planned.plan, fold_hydrated_run_outputs_result(planned.preflight_results)
+
+
+def execute_planned_output_hydration(
     plan: Sequence[PlannedMaterialization],
     *,
     tracker: "Tracker",
     allowed_base: Path | Sequence[Path] | None,
     on_missing: Literal["warn", "raise"] = "warn",
     preserve_existing: bool = True,
-) -> MaterializationResult:
-    result = MaterializationResult()
+) -> HydratedRunOutputsResult:
+    """Execute a planned historical output hydration.
+
+    Parameters
+    ----------
+    plan : Sequence[PlannedMaterialization]
+        Planned filesystem copies or DuckDB exports to execute.
+    tracker : Tracker
+        Tracker used for DB exports and path policy.
+    allowed_base : Path | Sequence[Path] | None
+        Allowed destination roots. ``None`` disables destination-root checks.
+    on_missing : {"warn", "raise"}, default "warn"
+        Error policy for missing source bytes and execution failures.
+    preserve_existing : bool, default True
+        Whether existing destinations should be kept in place.
+
+    Returns
+    -------
+    HydratedRunOutputsResult
+        Per-key execution outcomes for the plan. Preflight-only results are not
+        included; callers merge them separately.
+    """
+    outputs: dict[str, HydratedRunOutput] = {}
 
     for item in plan:
         try:
@@ -495,12 +930,28 @@ def materialize_planned_outputs(
                     preserve_existing=preserve_existing,
                 )
                 if skipped_existing:
-                    result.skipped_existing.extend(item.keys)
+                    for key in item.keys:
+                        artifact = cast(Mapping[str, Artifact], item.artifacts_by_key)[
+                            key
+                        ]
+                        outputs[key] = _make_hydrated_output(
+                            artifact,
+                            status="preserved_existing",
+                            path=item.destination,
+                            resolvable=True,
+                        )
                     continue
                 if materialized:
-                    destination_str = str(item.destination.resolve())
                     for key in item.keys:
-                        result.materialized_from_filesystem[key] = destination_str
+                        artifact = cast(Mapping[str, Artifact], item.artifacts_by_key)[
+                            key
+                        ]
+                        outputs[key] = _make_hydrated_output(
+                            artifact,
+                            status="materialized_from_filesystem",
+                            path=item.destination,
+                            resolvable=True,
+                        )
                 continue
 
             destination_str = materialize_ingested_artifact_from_db(
@@ -510,7 +961,13 @@ def materialize_planned_outputs(
                 overwrite=not preserve_existing,
             )
             for key in item.keys:
-                result.materialized_from_db[key] = destination_str
+                artifact = cast(Mapping[str, Artifact], item.artifacts_by_key)[key]
+                outputs[key] = _make_hydrated_output(
+                    artifact,
+                    status="materialized_from_db",
+                    path=Path(destination_str),
+                    resolvable=True,
+                )
 
         except FileNotFoundError as exc:
             if on_missing == "raise":
@@ -520,7 +977,15 @@ def materialize_planned_outputs(
                 ",".join(repr(key) for key in item.keys),
                 exc,
             )
-            result.skipped_missing_source.extend(item.keys)
+            for key in item.keys:
+                artifact = cast(Mapping[str, Artifact], item.artifacts_by_key)[key]
+                outputs[key] = _make_hydrated_output(
+                    artifact,
+                    status="missing_source",
+                    path=item.destination,
+                    message=str(exc),
+                    resolvable=False,
+                )
         except (OSError, shutil.Error, RuntimeError, ValueError) as exc:
             if on_missing == "raise":
                 raise RuntimeError(
@@ -533,9 +998,83 @@ def materialize_planned_outputs(
                 exc,
             )
             for key in item.keys:
-                result.failed.append((key, str(exc)))
+                artifact = cast(Mapping[str, Artifact], item.artifacts_by_key)[key]
+                outputs[key] = _make_hydrated_output(
+                    artifact,
+                    status="failed",
+                    path=item.destination,
+                    message=str(exc),
+                    resolvable=False,
+                )
 
-    return result
+    key_order = tuple(key for item in plan for key in item.keys)
+    return _ordered_hydrated_results(key_order, outputs)
+
+
+def materialize_planned_outputs(
+    plan: Sequence[PlannedMaterialization],
+    *,
+    tracker: "Tracker",
+    allowed_base: Path | Sequence[Path] | None,
+    on_missing: Literal["warn", "raise"] = "warn",
+    preserve_existing: bool = True,
+) -> MaterializationResult:
+    """Execute a plan and fold results into ``MaterializationResult``."""
+    return fold_hydrated_run_outputs_result(
+        execute_planned_output_hydration(
+            plan,
+            tracker=tracker,
+            allowed_base=allowed_base,
+            on_missing=on_missing,
+            preserve_existing=preserve_existing,
+        )
+    )
+
+
+def hydrate_run_outputs(
+    tracker: "Tracker",
+    run,
+    *,
+    target_root: Path,
+    source_root: Path | None,
+    keys: Sequence[str] | None,
+    allowed_base: Path | Sequence[Path] | None,
+    preserve_existing: bool,
+    on_missing: Literal["warn", "raise"],
+    db_fallback: Literal["never", "if_ingested"],
+) -> HydratedRunOutputsResult:
+    """Hydrate selected historical outputs into a target workspace root.
+
+    This is the shared core behind ``Tracker.hydrate_run_outputs(...)`` and the
+    top-level ``consist.hydrate_run_outputs(...)`` helper. It performs planning
+    and execution, then returns a keyed result that combines preflight outcomes
+    with executed copy/export work.
+
+    Unlike ``materialize_run_outputs(...)``, this function returns detached
+    artifacts whose runtime ``abs_path`` points at the hydrated destination when
+    the outcome is resolvable. That makes the result suitable for restart and
+    cross-workspace recovery flows that want to use the returned artifact/path
+    directly instead of separately looking it up again.
+    """
+    planned = plan_run_output_hydration(
+        tracker,
+        run,
+        target_root=target_root,
+        source_root=source_root,
+        keys=keys,
+        preserve_existing=preserve_existing,
+        db_fallback=db_fallback,
+    )
+    executed = execute_planned_output_hydration(
+        planned.plan,
+        tracker=tracker,
+        allowed_base=allowed_base,
+        on_missing=on_missing,
+        preserve_existing=preserve_existing,
+    )
+    merged = dict(planned.preflight_results.items())
+    merged.update(executed.items())
+    return _ordered_hydrated_results(planned.key_order, merged)
 
 
 def materialize_artifacts(

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -74,6 +74,7 @@ class MaterializationResult:
     failed : list[tuple[str, str]]
         Keys that failed during recovery, paired with the failure message.
     """
+
     materialized_from_filesystem: dict[str, str] = field(default_factory=dict)
     materialized_from_db: dict[str, str] = field(default_factory=dict)
     skipped_existing: list[str] = field(default_factory=list)
@@ -146,6 +147,7 @@ class HydratedRunOutput:
         hydrated workspace. When ``True``, ``path`` exists or is treated as the
         preserved reusable destination.
     """
+
     key: str
     artifact: Artifact
     path: Path | None
@@ -179,6 +181,7 @@ class HydratedRunOutputsResult(MappingABC[str, HydratedRunOutput]):
     >>> hydrated.paths["persons"].name
     'persons.parquet'
     """
+
     outputs: dict[str, HydratedRunOutput] = field(default_factory=dict)
 
     def __getitem__(self, key: str) -> HydratedRunOutput:

--- a/src/consist/core/materialize_options.py
+++ b/src/consist/core/materialize_options.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+VALID_MATERIALIZE_ON_MISSING = frozenset({"warn", "raise"})
+VALID_MATERIALIZE_DB_FALLBACK = frozenset({"never", "if_ingested"})
+
+
+def normalize_materialize_output_keys(
+    keys: Sequence[str] | None,
+    *,
+    caller: str,
+) -> tuple[str, ...] | None:
+    """Normalize key selection for historical output recovery APIs.
+
+    Parameters
+    ----------
+    keys : Sequence[str] | None
+        Requested output keys. ``None`` means "all outputs for the run".
+    caller : str
+        Friendly caller name used in validation error messages.
+
+    Returns
+    -------
+    tuple[str, ...] | None
+        Tuple form of ``keys`` preserving caller order, or ``None`` when all
+        outputs should be selected.
+
+    Raises
+    ------
+    TypeError
+        If ``keys`` is a scalar string/bytes value or contains non-string
+        entries.
+    """
+    if keys is None:
+        return None
+    if isinstance(keys, (str, bytes)):
+        raise TypeError(
+            "keys must be a sequence of output-key strings, not a single str/bytes value."
+        )
+
+    normalized: list[str] = []
+    for key in keys:
+        if not isinstance(key, str):
+            raise TypeError(
+                "keys must contain only strings "
+                f"(got {type(key).__name__!s} in {caller})."
+            )
+        normalized.append(key)
+    return tuple(normalized)
+
+
+def validate_materialize_option(
+    *,
+    name: str,
+    value: str,
+    allowed: set[str] | frozenset[str],
+) -> None:
+    """Validate a runtime option shared by hydration/materialization helpers.
+
+    Parameters
+    ----------
+    name : str
+        Option name shown in any validation error.
+    value : str
+        User-provided option value.
+    allowed : set[str] | frozenset[str]
+        Accepted values for the option.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` is not present in ``allowed``.
+    """
+    if value not in allowed:
+        allowed_display = ", ".join(repr(item) for item in sorted(allowed))
+        raise ValueError(f"{name} must be one of: {allowed_display}")

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -76,7 +76,17 @@ from consist.core.persistence import (
 from consist.core.views import ViewFactory, ViewRegistry
 from consist.core.ingestion import ingest_artifact
 from consist.core.lineage import LineageService
-from consist.core.materialize import materialize_artifacts
+from consist.core.materialize import (
+    fold_hydrated_run_outputs_result,
+    hydrate_run_outputs as hydrate_run_outputs_core,
+    materialize_artifacts,
+)
+from consist.core.materialize_options import (
+    VALID_MATERIALIZE_DB_FALLBACK as _VALID_MATERIALIZE_DB_FALLBACK,
+    VALID_MATERIALIZE_ON_MISSING as _VALID_MATERIALIZE_ON_MISSING,
+    normalize_materialize_output_keys,
+    validate_materialize_option,
+)
 from consist.core.matrix import MatrixViewFactory
 from consist.core.netcdf_views import NetCdfMetadataView
 from consist.core.openmatrix_views import OpenMatrixMetadataView
@@ -108,14 +118,12 @@ from consist.types import (
 
 if TYPE_CHECKING:
     from consist.core.coupler import Coupler
-    from consist.core.materialize import MaterializationResult
+    from consist.core.materialize import HydratedRunOutputsResult, MaterializationResult
     from consist.core.step_context import StepContext
     from consist.runset import RunSet
 
 AccessMode = Literal["standard", "analysis", "read_only"]
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_VALID_MATERIALIZE_ON_MISSING = {"warn", "raise"}
-_VALID_MATERIALIZE_DB_FALLBACK = {"never", "if_ingested"}
 
 
 def _is_safe_identifier(identifier: str) -> bool:
@@ -131,38 +139,6 @@ def _env_bool(name: str, default: bool = False) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _normalize_materialize_output_keys(
-    keys: Sequence[str] | None,
-) -> tuple[str, ...] | None:
-    if keys is None:
-        return None
-    if isinstance(keys, (str, bytes)):
-        raise TypeError(
-            "keys must be a sequence of output-key strings, not a single str/bytes value."
-        )
-
-    normalized: list[str] = []
-    for key in keys:
-        if not isinstance(key, str):
-            raise TypeError(
-                "keys must contain only strings "
-                f"(got {type(key).__name__!s} in materialize_run_outputs)."
-            )
-        normalized.append(key)
-    return tuple(normalized)
-
-
-def _validate_materialize_option(
-    *,
-    name: str,
-    value: str,
-    allowed: set[str],
-) -> None:
-    if value not in allowed:
-        allowed_display = ", ".join(repr(item) for item in sorted(allowed))
-        raise ValueError(f"{name} must be one of: {allowed_display}")
 
 
 class Tracker:
@@ -4564,43 +4540,158 @@ class Tracker:
         db_fallback: Literal["never", "if_ingested"] = "if_ingested",
     ) -> "MaterializationResult":
         """
-        Materialize the output artifacts linked to a historical run.
+        Restore historical run outputs and return the legacy summary result.
 
-        This is a recovery/export helper for rematerializing run-linked outputs
-        into a new filesystem root while preserving historical relative layout
-        where the underlying planner can derive it.
+        This method performs the same copy/export work as
+        ``hydrate_run_outputs(...)`` but folds the keyed outcomes into the older
+        ``MaterializationResult`` buckets. Use it when you only need to know
+        which keys were restored, skipped, or failed.
+
+        For new restart or cross-workspace recovery flows, prefer
+        ``hydrate_run_outputs(...)`` because it returns detached artifacts and
+        directly usable per-key paths.
+
+        Parameters
+        ----------
+        run_id : str
+            Identifier of the historical run whose outputs should be restored.
+        target_root : str | Path
+            Destination root under which historical relative layout is recreated.
+        source_root : str | Path | None, optional
+            Optional alternate root to probe before the original historical
+            filesystem location. This is useful for archive mirrors.
+        keys : Sequence[str] | None, optional
+            Optional subset of output keys to restore. ``None`` means all
+            outputs linked to the run.
+        preserve_existing : bool, default True
+            If ``True``, existing destinations are treated as reusable and
+            reported in ``skipped_existing``.
+        on_missing : {"warn", "raise"}, default "warn"
+            Error handling policy for missing source bytes and copy/export
+            failures.
+        db_fallback : {"never", "if_ingested"}, default "if_ingested"
+            Whether ingested CSV/Parquet artifacts may be exported from DuckDB
+            when cold filesystem bytes are unavailable.
+
+        Returns
+        -------
+        MaterializationResult
+            Aggregate summary of the selected outputs.
+        """
+        return fold_hydrated_run_outputs_result(
+            self.hydrate_run_outputs(
+                run_id,
+                target_root=target_root,
+                source_root=source_root,
+                keys=keys,
+                preserve_existing=preserve_existing,
+                on_missing=on_missing,
+                db_fallback=db_fallback,
+            )
+        )
+
+    def hydrate_run_outputs(
+        self,
+        run_id: str,
+        *,
+        target_root: str | Path,
+        source_root: str | Path | None = None,
+        keys: Sequence[str] | None = None,
+        preserve_existing: bool = True,
+        on_missing: Literal["warn", "raise"] = "warn",
+        db_fallback: Literal["never", "if_ingested"] = "if_ingested",
+    ) -> "HydratedRunOutputsResult":
+        """
+        Hydrate the output artifacts linked to a historical run.
+
+        This is the first-class historical recovery API. It rematerializes
+        selected run outputs into ``target_root`` and returns one keyed result
+        per output, including:
+
+        - a detached artifact view for that key
+        - the resolved destination path under the new workspace root
+        - a status describing how recovery happened
+        - whether the detached artifact is immediately resolvable
+
+        Compared with ``materialize_run_outputs(...)``, this method removes the
+        need for separate output lookup and post-hoc "is this usable now?"
+        checks. The returned detached artifacts preserve provenance metadata but
+        are no longer attached to the original tracker state.
 
         Parameters
         ----------
         run_id : str
             Identifier of the run whose linked outputs should be restored.
         target_root : str | Path
-            Destination root for rematerialized outputs.
+            Destination root under which historical relative layout is recreated.
         source_root : str | Path | None, optional
-            Optional alternate root for filesystem-backed source recovery.
+            Optional alternate root to probe before the original historical
+            filesystem location. This is useful for archive mirrors or copied
+            cold-storage trees.
         keys : Sequence[str] | None, optional
-            Optional subset of output keys to restore.
+            Optional subset of output keys to restore. ``None`` means all
+            outputs linked to the run. Unknown keys raise ``KeyError`` before
+            any copy/export work starts.
         preserve_existing : bool, default True
-            If True, existing destinations are skipped rather than replaced.
+            If ``True``, existing destinations are treated as reusable and
+            returned with ``status="preserved_existing"``.
         on_missing : {"warn", "raise"}, default "warn"
-            Error handling policy for missing filesystem bytes or copy failures.
+            Error handling policy for missing filesystem bytes or copy/export
+            failures. ``"warn"`` returns per-key ``missing_source`` / ``failed``
+            statuses. ``"raise"`` aborts on execution-time failures.
         db_fallback : {"never", "if_ingested"}, default "if_ingested"
             Whether ingested csv/parquet artifacts may be exported from DuckDB
             when cold filesystem bytes are unavailable.
 
         Returns
         -------
-        MaterializationResult
-            Structured materialization outcome returned by the core planner and
-            executor.
+        HydratedRunOutputsResult
+            Keyed hydration outcomes for the selected historical outputs.
+
+        Notes
+        -----
+        Status values have the following meanings:
+
+        - ``materialized_from_filesystem``: copied from historical cold bytes
+        - ``materialized_from_db``: exported from DuckDB for an ingested output
+        - ``preserved_existing``: destination already existed and was reused
+        - ``skipped_unmapped``: no safe historical relative-path mapping exists
+        - ``missing_source``: historical bytes were unavailable and not
+          recoverable
+        - ``failed``: recovery was attempted but failed
+
+        Examples
+        --------
+        Restore two outputs into a new workspace root and inspect statuses:
+
+        >>> hydrated = tracker.hydrate_run_outputs(
+        ...     "prior_run_id",
+        ...     keys=["persons", "households"],
+        ...     target_root="restored",
+        ... )
+        >>> hydrated["persons"].status
+        'materialized_from_filesystem'
+        >>> hydrated.paths["persons"]
+        PosixPath('.../restored/.../persons.parquet')
+
+        Use the detached hydrated artifact directly:
+
+        >>> persons = hydrated["persons"]
+        >>> persons.resolvable
+        True
+        >>> persons.artifact.as_path()
+        PosixPath('.../restored/.../persons.parquet')
         """
-        normalized_keys = _normalize_materialize_output_keys(keys)
-        _validate_materialize_option(
+        normalized_keys = normalize_materialize_output_keys(
+            keys,
+            caller="hydrate_run_outputs",
+        )
+        validate_materialize_option(
             name="on_missing",
             value=on_missing,
             allowed=_VALID_MATERIALIZE_ON_MISSING,
         )
-        _validate_materialize_option(
+        validate_materialize_option(
             name="db_fallback",
             value=db_fallback,
             allowed=_VALID_MATERIALIZE_DB_FALLBACK,
@@ -4631,33 +4722,17 @@ class Tracker:
             Path(source_root).resolve() if source_root is not None else None
         )
 
-        plan, result = materialize_core.build_run_output_materialize_plan(
-            self,
-            run,
+        return hydrate_run_outputs_core(
+            tracker=self,
+            run=run,
             target_root=destination_root,
             source_root=source_root_override,
             keys=normalized_keys,
+            allowed_base=allowed_roots,
             preserve_existing=preserve_existing,
+            on_missing=on_missing,
             db_fallback=db_fallback,
         )
-
-        execution_result = materialize_core.materialize_planned_outputs(
-            plan,
-            tracker=self,
-            allowed_base=allowed_roots,
-            on_missing=on_missing,
-            preserve_existing=preserve_existing,
-        )
-
-        result.materialized_from_filesystem.update(
-            execution_result.materialized_from_filesystem
-        )
-        result.materialized_from_db.update(execution_result.materialized_from_db)
-        result.skipped_existing.extend(execution_result.skipped_existing)
-        result.skipped_unmapped.extend(execution_result.skipped_unmapped)
-        result.skipped_missing_source.extend(execution_result.skipped_missing_source)
-        result.failed.extend(execution_result.failed)
-        return result
 
     def get_config_bundle(
         self,

--- a/src/consist/models/run.py
+++ b/src/consist/models/run.py
@@ -16,50 +16,24 @@ from pydantic import BaseModel, ConfigDict, Field as PydanticField
 
 from sqlalchemy import Column, JSON, String
 from sqlmodel import Field, SQLModel
+from consist.core.materialize_options import (
+    VALID_MATERIALIZE_DB_FALLBACK as _VALID_MATERIALIZE_DB_FALLBACK,
+    VALID_MATERIALIZE_ON_MISSING as _VALID_MATERIALIZE_ON_MISSING,
+    normalize_materialize_output_keys,
+    validate_materialize_option,
+)
 from consist.models.artifact import Artifact, UUIDType
 
 UTC = timezone.utc
 
 if TYPE_CHECKING:
-    from consist.core.materialize import MaterializationResult
+    from consist.core.materialize import (
+        HydratedRunOutputsResult,
+        MaterializationResult,
+    )
     from consist.core.tracker import Tracker
 
-
-_VALID_MATERIALIZE_ON_MISSING = {"warn", "raise"}
-_VALID_MATERIALIZE_DB_FALLBACK = {"never", "if_ingested"}
 CanonicalRunMetaField = Literal["stage", "phase"]
-
-
-def _normalize_materialize_output_keys(
-    keys: Sequence[str] | None,
-) -> tuple[str, ...] | None:
-    if keys is None:
-        return None
-    if isinstance(keys, (str, bytes)):
-        raise TypeError(
-            "keys must be a sequence of output-key strings, not a single str/bytes value."
-        )
-
-    normalized: list[str] = []
-    for key in keys:
-        if not isinstance(key, str):
-            raise TypeError(
-                "keys must contain only strings "
-                f"(got {type(key).__name__!s} in materialize_outputs)."
-            )
-        normalized.append(key)
-    return tuple(normalized)
-
-
-def _validate_materialize_option(
-    *,
-    name: str,
-    value: str,
-    allowed: set[str],
-) -> None:
-    if value not in allowed:
-        allowed_display = ", ".join(repr(item) for item in sorted(allowed))
-        raise ValueError(f"{name} must be one of: {allowed_display}")
 
 
 def resolve_canonical_run_meta_field(
@@ -319,6 +293,14 @@ class Run(SQLModel, table=True):
         """
         Materialize this run's linked outputs through the supplied tracker.
 
+        This is the convenience ``Run`` wrapper for
+        ``Tracker.materialize_run_outputs(...)``. It restores historical bytes
+        into ``target_root`` and returns the legacy aggregate
+        ``MaterializationResult`` summary.
+
+        Prefer ``hydrate_outputs(...)`` when you want per-key statuses,
+        detached artifacts, or directly usable hydrated paths.
+
         Parameters
         ----------
         tracker : Tracker
@@ -335,20 +317,94 @@ class Run(SQLModel, table=True):
             Missing-source handling policy forwarded to the tracker.
         db_fallback : {"never", "if_ingested"}, default "if_ingested"
             DB fallback policy forwarded to the tracker.
+
+        Returns
+        -------
+        MaterializationResult
+            Aggregate summary of which outputs were restored, skipped, or failed.
         """
-        normalized_keys = _normalize_materialize_output_keys(keys)
-        _validate_materialize_option(
+        normalized_keys = normalize_materialize_output_keys(
+            keys,
+            caller="materialize_outputs",
+        )
+        validate_materialize_option(
             name="on_missing",
             value=on_missing,
             allowed=_VALID_MATERIALIZE_ON_MISSING,
         )
-        _validate_materialize_option(
+        validate_materialize_option(
             name="db_fallback",
             value=db_fallback,
             allowed=_VALID_MATERIALIZE_DB_FALLBACK,
         )
 
         return tracker.materialize_run_outputs(
+            self.id,
+            target_root=target_root,
+            source_root=source_root,
+            keys=normalized_keys,
+            preserve_existing=preserve_existing,
+            on_missing=on_missing,
+            db_fallback=db_fallback,
+        )
+
+    def hydrate_outputs(
+        self,
+        tracker: "Tracker",
+        *,
+        target_root: str | Path,
+        source_root: str | Path | None = None,
+        keys: Sequence[str] | None = None,
+        preserve_existing: bool = True,
+        on_missing: Literal["warn", "raise"] = "warn",
+        db_fallback: Literal["never", "if_ingested"] = "if_ingested",
+    ) -> "HydratedRunOutputsResult":
+        """
+        Hydrate this run's linked outputs through the supplied tracker.
+
+        This is the convenience ``Run`` wrapper for
+        ``Tracker.hydrate_run_outputs(...)``. It restores historical bytes into
+        ``target_root`` and returns a key-indexed result whose detached
+        artifacts and paths can be used immediately in the new workspace.
+
+        Parameters
+        ----------
+        tracker : Tracker
+            Tracker instance that owns the provenance database and path policy.
+        target_root : str | Path
+            Destination root for hydrated outputs.
+        source_root : str | Path | None, optional
+            Optional alternate source root for filesystem-backed recovery.
+        keys : Sequence[str] | None, optional
+            Optional subset of output keys to restore.
+        preserve_existing : bool, default True
+            If True, keep existing destination paths in place.
+        on_missing : {"warn", "raise"}, default "warn"
+            Missing-source handling policy forwarded to the tracker.
+        db_fallback : {"never", "if_ingested"}, default "if_ingested"
+            DB fallback policy forwarded to the tracker.
+
+        Returns
+        -------
+        HydratedRunOutputsResult
+            Per-key hydration outcomes keyed by output name.
+        """
+        normalized_keys = normalize_materialize_output_keys(
+            keys,
+            caller="hydrate_outputs",
+        )
+        validate_materialize_option(
+            name="on_missing",
+            value=on_missing,
+            allowed=_VALID_MATERIALIZE_ON_MISSING,
+        )
+        validate_materialize_option(
+            name="db_fallback",
+            value=db_fallback,
+            allowed=_VALID_MATERIALIZE_DB_FALLBACK,
+        )
+
+        return tracker.hydrate_run_outputs(
             self.id,
             target_root=target_root,
             source_root=source_root,

--- a/tests/integration/tracker/test_tracker_ergonomics.py
+++ b/tests/integration/tracker/test_tracker_ergonomics.py
@@ -97,6 +97,33 @@ def test_run_output_helpers(tracker: Tracker, run_dir):
     assert df.shape[0] == 1
 
 
+def test_hydrate_run_outputs_across_shared_db_workspaces(tmp_path):
+    db_path = str(tmp_path / "shared.duckdb")
+
+    tracker_a = Tracker(run_dir=tmp_path / "runs_a", db_path=db_path)
+    output_path = tracker_a.run_dir / "outputs" / "results.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    with tracker_a.start_run("historical_run", "model_outputs"):
+        tracker_a.log_artifact(output_path, key="results", direction="output")
+
+    tracker_b = Tracker(run_dir=tmp_path / "runs_b", db_path=db_path)
+    target_root = tracker_b.run_dir / "workspace_root"
+    hydrated = tracker_b.hydrate_run_outputs(
+        "historical_run",
+        target_root=target_root,
+        keys=["results"],
+    )
+
+    restored_path = (target_root / "outputs" / "results.csv").resolve()
+    result = hydrated["results"]
+    assert result.status == "materialized_from_filesystem"
+    assert result.path == restored_path
+    assert result.artifact.as_path() == restored_path
+    assert restored_path.exists()
+
+
 def test_artifact_accessor_helpers_support_attached_and_explicit_tracker(
     tracker: Tracker, run_dir
 ):

--- a/tests/unit/api/test_public_exports.py
+++ b/tests/unit/api/test_public_exports.py
@@ -1,6 +1,15 @@
-from consist import MaterializationResult
-from consist.core.materialize import MaterializationResult as CoreMaterializationResult
+from consist import HydratedRunOutput, HydratedRunOutputsResult, MaterializationResult
+from consist.core.materialize import (
+    HydratedRunOutput as CoreHydratedRunOutput,
+    HydratedRunOutputsResult as CoreHydratedRunOutputsResult,
+    MaterializationResult as CoreMaterializationResult,
+)
 
 
 def test_materialization_result_is_exported_from_top_level() -> None:
     assert MaterializationResult is CoreMaterializationResult
+
+
+def test_hydrated_run_output_types_are_exported_from_top_level() -> None:
+    assert HydratedRunOutput is CoreHydratedRunOutput
+    assert HydratedRunOutputsResult is CoreHydratedRunOutputsResult

--- a/tests/unit/api/test_run_materialize_outputs_api.py
+++ b/tests/unit/api/test_run_materialize_outputs_api.py
@@ -1,35 +1,39 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
+import uuid
 
 import pytest
 
 import consist
-import consist.core as consist_core
 import consist.core.materialize as consist_materialize
+from consist.api import hydrate_run_outputs as hydrate_run_outputs_api
 from consist.api import materialize_run_outputs as materialize_run_outputs_api
 from consist.core.tracker import Tracker
+from consist.models.artifact import Artifact
 from consist.models.run import Run
 
 
-def _result(
-    *,
-    fs: dict[str, str] | None = None,
-    db: dict[str, str] | None = None,
-    skipped_existing: list[str] | None = None,
-    skipped_unmapped: list[str] | None = None,
-    skipped_missing_source: list[str] | None = None,
-    failed: list[tuple[str, str]] | None = None,
-) -> SimpleNamespace:
-    return SimpleNamespace(
-        materialized_from_filesystem=fs or {},
-        materialized_from_db=db or {},
-        skipped_existing=skipped_existing or [],
-        skipped_unmapped=skipped_unmapped or [],
-        skipped_missing_source=skipped_missing_source or [],
-        failed=failed or [],
-    )
+def _hydrated_result(
+    outputs: dict[str, tuple[str | None, str, bool, str | None]],
+) -> consist_materialize.HydratedRunOutputsResult:
+    hydrated_outputs: dict[str, consist_materialize.HydratedRunOutput] = {}
+    for key, (path, status, resolvable, message) in outputs.items():
+        hydrated_outputs[key] = consist_materialize.HydratedRunOutput(
+            key=key,
+            artifact=Artifact(
+                id=uuid.uuid4(),
+                key=key,
+                container_uri=f"./{key}.csv",
+                driver="csv",
+                meta={},
+            ),
+            path=Path(path) if path is not None else None,
+            status=status,
+            message=message,
+            resolvable=resolvable,
+        )
+    return consist_materialize.HydratedRunOutputsResult(outputs=hydrated_outputs)
 
 
 def test_tracker_materialize_run_outputs_requires_db(tmp_path: Path) -> None:
@@ -63,115 +67,76 @@ def test_tracker_materialize_run_outputs_rejects_external_target_root_when_disal
         tracker.materialize_run_outputs("run_1", target_root=outside)
 
 
-def test_tracker_materialize_run_outputs_delegates_to_core_helpers(
+def test_tracker_materialize_run_outputs_folds_hydrated_results(
     tracker: Tracker,
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    run = Run(
-        id="run_1",
-        model_name="model",
-        config_hash=None,
-        git_hash=None,
-        meta={},
+    hydrated_result = _hydrated_result(
+        {
+            "from_fs": (
+                str((tracker.run_dir / "copied.csv").resolve()),
+                "materialized_from_filesystem",
+                True,
+                None,
+            ),
+            "from_db": (
+                str((tracker.run_dir / "exported.csv").resolve()),
+                "materialized_from_db",
+                True,
+                None,
+            ),
+            "keep-me": (
+                str((tracker.run_dir / "existing.csv").resolve()),
+                "preserved_existing",
+                True,
+                None,
+            ),
+            "already-unmapped": (None, "skipped_unmapped", False, None),
+            "missing-source": (
+                str((tracker.run_dir / "missing.csv").resolve()),
+                "missing_source",
+                False,
+                "source path missing",
+            ),
+            "bad": (
+                str((tracker.run_dir / "bad.csv").resolve()),
+                "failed",
+                False,
+                "copy failed",
+            ),
+        }
     )
-    plan = [object()]
-    planner_result = _result(
-        fs={"planned": "planner-only"},
-        skipped_unmapped=["already-unmapped"],
-    )
-    execution_result = _result(
-        fs={"from_fs": str((tracker.run_dir / "copied.csv").resolve())},
-        db={"from_db": str((tracker.run_dir / "exported.csv").resolve())},
-        skipped_existing=["keep-me"],
-        skipped_missing_source=["missing-source"],
-        failed=[("bad", "copy failed")],
-    )
-    planner_calls: dict[str, object] = {}
-    execution_calls: dict[str, object] = {}
+    calls: dict[str, object] = {}
 
-    monkeypatch.setattr(
-        tracker, "get_run", lambda run_id: run if run_id == "run_1" else None
-    )
+    def _fake_hydrate(self, run_id: str, **kwargs):
+        calls["run_id"] = run_id
+        calls["kwargs"] = kwargs
+        return hydrated_result
 
-    def _fake_plan(
-        tracker_arg,
-        run_arg,
-        *,
-        target_root,
-        source_root,
-        keys,
-        preserve_existing,
-        db_fallback,
-    ):
-        planner_calls.update(
-            tracker=tracker_arg,
-            run=run_arg,
-            target_root=target_root,
-            source_root=source_root,
-            keys=keys,
-            preserve_existing=preserve_existing,
-            db_fallback=db_fallback,
-        )
-        return plan, planner_result
-
-    def _fake_execute(
-        plan_arg,
-        *,
-        tracker,
-        allowed_base,
-        on_missing,
-        preserve_existing,
-    ):
-        execution_calls.update(
-            plan=plan_arg,
-            tracker=tracker,
-            allowed_base=allowed_base,
-            on_missing=on_missing,
-            preserve_existing=preserve_existing,
-        )
-        return execution_result
-
-    fake_materialize_module = SimpleNamespace(
-        build_run_output_materialize_plan=_fake_plan,
-        materialize_planned_outputs=_fake_execute,
-        build_allowed_materialization_roots=(
-            consist_materialize.build_allowed_materialization_roots
-        ),
-        validate_allowed_materialization_destination=(
-            consist_materialize.validate_allowed_materialization_destination
-        ),
-    )
-    monkeypatch.setattr(consist_core, "materialize", fake_materialize_module)
+    monkeypatch.setattr(Tracker, "hydrate_run_outputs", _fake_hydrate)
 
     result = tracker.materialize_run_outputs(
         "run_1",
         target_root=tracker.run_dir / "restored",
-        source_root=tmp_path / "archive",
+        source_root=tracker.run_dir / "archive",
         keys=("a", "b"),
         preserve_existing=False,
         on_missing="raise",
         db_fallback="never",
     )
 
-    assert planner_calls == {
-        "tracker": tracker,
-        "run": run,
-        "target_root": (tracker.run_dir / "restored").resolve(),
-        "source_root": (tmp_path / "archive").resolve(),
-        "keys": ("a", "b"),
-        "preserve_existing": False,
-        "db_fallback": "never",
-    }
-    assert execution_calls == {
-        "plan": plan,
-        "tracker": tracker,
-        "allowed_base": (tracker.run_dir.resolve(),),
-        "on_missing": "raise",
-        "preserve_existing": False,
+    assert calls == {
+        "run_id": "run_1",
+        "kwargs": {
+            "target_root": tracker.run_dir / "restored",
+            "source_root": tracker.run_dir / "archive",
+            "keys": ("a", "b"),
+            "preserve_existing": False,
+            "on_missing": "raise",
+            "db_fallback": "never",
+        },
     }
     assert result.materialized_from_filesystem == {
-        "planned": "planner-only",
         "from_fs": str((tracker.run_dir / "copied.csv").resolve()),
     }
     assert result.materialized_from_db == {
@@ -183,7 +148,78 @@ def test_tracker_materialize_run_outputs_delegates_to_core_helpers(
     assert result.failed == [("bad", "copy failed")]
 
 
-def test_tracker_materialize_run_outputs_allows_external_target_root_when_configured(
+def test_tracker_hydrate_run_outputs_delegates_to_core_helper(
+    tracker: Tracker,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = Run(
+        id="run_1",
+        model_name="model",
+        config_hash=None,
+        git_hash=None,
+        meta={},
+    )
+    calls: dict[str, object] = {}
+    hydrated_result = _hydrated_result({})
+
+    monkeypatch.setattr(tracker, "get_run", lambda _run_id: run)
+
+    def _fake_hydrate_core(
+        *,
+        tracker,
+        run,
+        target_root,
+        source_root,
+        keys,
+        allowed_base,
+        preserve_existing,
+        on_missing,
+        db_fallback,
+    ):
+        calls.update(
+            tracker=tracker,
+            run=run,
+            target_root=target_root,
+            source_root=source_root,
+            keys=keys,
+            allowed_base=allowed_base,
+            preserve_existing=preserve_existing,
+            on_missing=on_missing,
+            db_fallback=db_fallback,
+        )
+        return hydrated_result
+
+    monkeypatch.setattr(
+        "consist.core.tracker.hydrate_run_outputs_core",
+        _fake_hydrate_core,
+    )
+
+    result = tracker.hydrate_run_outputs(
+        "run_1",
+        target_root=tracker.run_dir / "restored",
+        source_root=tmp_path / "archive",
+        keys=("a", "b"),
+        preserve_existing=False,
+        on_missing="raise",
+        db_fallback="never",
+    )
+
+    assert result is hydrated_result
+    assert calls == {
+        "tracker": tracker,
+        "run": run,
+        "target_root": (tracker.run_dir / "restored").resolve(),
+        "source_root": (tmp_path / "archive").resolve(),
+        "keys": ("a", "b"),
+        "allowed_base": (tracker.run_dir.resolve(),),
+        "preserve_existing": False,
+        "on_missing": "raise",
+        "db_fallback": "never",
+    }
+
+
+def test_tracker_hydrate_run_outputs_allows_external_target_root_when_configured(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -199,42 +235,23 @@ def test_tracker_materialize_run_outputs_allows_external_target_root_when_config
         git_hash=None,
         meta={},
     )
-    planner_result = _result()
-    execution_result = _result()
-    execution_calls: dict[str, object] = {}
+    calls: dict[str, object] = {}
 
     monkeypatch.setattr(tracker, "get_run", lambda _run_id: run)
-    fake_materialize_module = SimpleNamespace(
-        build_run_output_materialize_plan=lambda *_args, **_kwargs: (
-            [],
-            planner_result,
-        ),
-        build_allowed_materialization_roots=(
-            consist_materialize.build_allowed_materialization_roots
-        ),
-        validate_allowed_materialization_destination=(
-            consist_materialize.validate_allowed_materialization_destination
-        ),
+
+    def _fake_hydrate_core(**kwargs):
+        calls["allowed_base"] = kwargs["allowed_base"]
+        return _hydrated_result({})
+
+    monkeypatch.setattr(
+        "consist.core.tracker.hydrate_run_outputs_core",
+        _fake_hydrate_core,
     )
 
-    def _fake_execute(
-        plan_arg,
-        *,
-        tracker,
-        allowed_base,
-        on_missing,
-        preserve_existing,
-    ):
-        execution_calls["allowed_base"] = allowed_base
-        return execution_result
-
-    fake_materialize_module.materialize_planned_outputs = _fake_execute
-    monkeypatch.setattr(consist_core, "materialize", fake_materialize_module)
-
     outside = tmp_path / "external"
-    tracker.materialize_run_outputs("run_1", target_root=outside)
+    tracker.hydrate_run_outputs("run_1", target_root=outside)
 
-    assert execution_calls["allowed_base"] is None
+    assert calls["allowed_base"] is None
 
     if tracker.engine:
         tracker.engine.dispose()
@@ -267,6 +284,46 @@ def test_run_materialize_outputs_delegates_to_tracker() -> None:
     )
 
     assert result == "result"
+    assert calls == {
+        "run_id": "run_1",
+        "kwargs": {
+            "target_root": "/tmp/restored",
+            "source_root": "/tmp/archive",
+            "keys": ("a",),
+            "preserve_existing": False,
+            "on_missing": "raise",
+            "db_fallback": "never",
+        },
+    }
+
+
+def test_run_hydrate_outputs_delegates_to_tracker() -> None:
+    run = Run(
+        id="run_1",
+        model_name="model",
+        config_hash=None,
+        git_hash=None,
+        meta={},
+    )
+    calls: dict[str, object] = {}
+
+    class _FakeTracker:
+        def hydrate_run_outputs(self, run_id: str, **kwargs):
+            calls["run_id"] = run_id
+            calls["kwargs"] = kwargs
+            return "hydrated"
+
+    result = run.hydrate_outputs(
+        _FakeTracker(),
+        target_root="/tmp/restored",
+        source_root="/tmp/archive",
+        keys=("a",),
+        preserve_existing=False,
+        on_missing="raise",
+        db_fallback="never",
+    )
+
+    assert result == "hydrated"
     assert calls == {
         "run_id": "run_1",
         "kwargs": {
@@ -322,7 +379,48 @@ def test_api_materialize_run_outputs_delegates_with_default_tracker(
     assert consist.MaterializationResult is consist_materialize.MaterializationResult
 
 
-def test_tracker_materialize_run_outputs_allows_configured_mount_roots(
+def test_api_hydrate_run_outputs_delegates_with_default_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    class _FakeTracker:
+        def hydrate_run_outputs(self, run_id: str, **kwargs):
+            calls["run_id"] = run_id
+            calls["kwargs"] = kwargs
+            return "hydrated-api-result"
+
+    fake_tracker = _FakeTracker()
+    monkeypatch.setattr(
+        "consist.api._resolve_tracker", lambda tracker=None: fake_tracker
+    )
+
+    result = hydrate_run_outputs_api(
+        "run_9",
+        target_root="/tmp/restored",
+        source_root="/tmp/archive",
+        keys=("x", "y"),
+        preserve_existing=False,
+        on_missing="raise",
+        db_fallback="never",
+    )
+
+    assert result == "hydrated-api-result"
+    assert calls == {
+        "run_id": "run_9",
+        "kwargs": {
+            "target_root": "/tmp/restored",
+            "source_root": "/tmp/archive",
+            "keys": ("x", "y"),
+            "preserve_existing": False,
+            "on_missing": "raise",
+            "db_fallback": "never",
+        },
+    }
+    assert consist.hydrate_run_outputs is hydrate_run_outputs_api
+
+
+def test_tracker_hydrate_run_outputs_allows_configured_mount_roots(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -339,44 +437,25 @@ def test_tracker_materialize_run_outputs_allows_configured_mount_roots(
         git_hash=None,
         meta={},
     )
-    planner_result = _result()
-    execution_result = _result()
-    execution_calls: dict[str, object] = {}
+    calls: dict[str, object] = {}
 
     monkeypatch.setattr(tracker, "get_run", lambda _run_id: run)
-    fake_materialize_module = SimpleNamespace(
-        build_run_output_materialize_plan=lambda *_args, **_kwargs: (
-            [],
-            planner_result,
-        ),
+
+    def _fake_hydrate_core(**kwargs):
+        calls["allowed_base"] = kwargs["allowed_base"]
+        return _hydrated_result({})
+
+    monkeypatch.setattr(
+        "consist.core.tracker.hydrate_run_outputs_core",
+        _fake_hydrate_core,
     )
 
-    def _fake_execute(
-        plan_arg,
-        *,
-        tracker,
-        allowed_base,
-        on_missing,
-        preserve_existing,
-    ):
-        execution_calls["allowed_base"] = allowed_base
-        return execution_result
-
-    fake_materialize_module.materialize_planned_outputs = _fake_execute
-    fake_materialize_module.build_allowed_materialization_roots = (
-        consist_materialize.build_allowed_materialization_roots
-    )
-    fake_materialize_module.validate_allowed_materialization_destination = (
-        consist_materialize.validate_allowed_materialization_destination
-    )
-    monkeypatch.setattr(consist_core, "materialize", fake_materialize_module)
-
-    tracker.materialize_run_outputs(
+    tracker.hydrate_run_outputs(
         "run_1",
         target_root=workspace_root / "restored",
     )
 
-    assert execution_calls["allowed_base"] == (
+    assert calls["allowed_base"] == (
         tracker.run_dir.resolve(),
         workspace_root.resolve(),
     )
@@ -454,6 +533,30 @@ def test_run_materialize_outputs_rejects_scalar_string_keys_before_delegation(
         )
 
 
+@pytest.mark.parametrize("bad_keys", ["out", b"out"])
+def test_run_hydrate_outputs_rejects_scalar_string_keys_before_delegation(
+    bad_keys: str | bytes,
+) -> None:
+    run = Run(
+        id="run_1",
+        model_name="model",
+        config_hash=None,
+        git_hash=None,
+        meta={},
+    )
+
+    class _FakeTracker:
+        def hydrate_run_outputs(self, run_id: str, **kwargs):
+            raise AssertionError("delegation should not happen for invalid keys")
+
+    with pytest.raises(TypeError, match="keys must be a sequence"):
+        run.hydrate_outputs(
+            _FakeTracker(),
+            target_root="/tmp/restored",
+            keys=bad_keys,
+        )
+
+
 @pytest.mark.parametrize(
     ("field_name", "field_value"),
     [
@@ -483,6 +586,35 @@ def test_run_materialize_outputs_rejects_invalid_runtime_options_before_delegati
         run.materialize_outputs(_FakeTracker(), **kwargs)
 
 
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("on_missing", "ignore"),
+        ("db_fallback", "always"),
+    ],
+)
+def test_run_hydrate_outputs_rejects_invalid_runtime_options_before_delegation(
+    field_name: str,
+    field_value: str,
+) -> None:
+    run = Run(
+        id="run_1",
+        model_name="model",
+        config_hash=None,
+        git_hash=None,
+        meta={},
+    )
+
+    class _FakeTracker:
+        def hydrate_run_outputs(self, run_id: str, **kwargs):
+            raise AssertionError("delegation should not happen for invalid options")
+
+    kwargs = {"target_root": "/tmp/restored", field_name: field_value}
+
+    with pytest.raises(ValueError, match=field_name):
+        run.hydrate_outputs(_FakeTracker(), **kwargs)
+
+
 @pytest.mark.parametrize("bad_keys", ["out", b"out"])
 def test_api_materialize_run_outputs_rejects_scalar_string_keys_before_delegation(
     monkeypatch: pytest.MonkeyPatch,
@@ -498,6 +630,23 @@ def test_api_materialize_run_outputs_rejects_scalar_string_keys_before_delegatio
 
     with pytest.raises(TypeError, match="keys must be a sequence"):
         materialize_run_outputs_api("run_1", target_root="/tmp/restored", keys=bad_keys)
+
+
+@pytest.mark.parametrize("bad_keys", ["out", b"out"])
+def test_api_hydrate_run_outputs_rejects_scalar_string_keys_before_delegation(
+    monkeypatch: pytest.MonkeyPatch,
+    bad_keys: str | bytes,
+) -> None:
+    class _FakeTracker:
+        def hydrate_run_outputs(self, run_id: str, **kwargs):
+            raise AssertionError("delegation should not happen for invalid keys")
+
+    monkeypatch.setattr(
+        "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
+    )
+
+    with pytest.raises(TypeError, match="keys must be a sequence"):
+        hydrate_run_outputs_api("run_1", target_root="/tmp/restored", keys=bad_keys)
 
 
 @pytest.mark.parametrize(
@@ -523,3 +672,28 @@ def test_api_materialize_run_outputs_rejects_invalid_runtime_options_before_dele
 
     with pytest.raises(ValueError, match=field_name):
         materialize_run_outputs_api("run_1", **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("on_missing", "ignore"),
+        ("db_fallback", "always"),
+    ],
+)
+def test_api_hydrate_run_outputs_rejects_invalid_runtime_options_before_delegation(
+    monkeypatch: pytest.MonkeyPatch,
+    field_name: str,
+    field_value: str,
+) -> None:
+    class _FakeTracker:
+        def hydrate_run_outputs(self, run_id: str, **kwargs):
+            raise AssertionError("delegation should not happen for invalid options")
+
+    monkeypatch.setattr(
+        "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
+    )
+    kwargs = {"target_root": "/tmp/restored", field_name: field_value}
+
+    with pytest.raises(ValueError, match=field_name):
+        hydrate_run_outputs_api("run_1", **kwargs)

--- a/tests/unit/core/test_run_materialize_outputs_core.py
+++ b/tests/unit/core/test_run_materialize_outputs_core.py
@@ -11,6 +11,7 @@ from consist.core.fs import FileSystemManager
 from consist.core.materialize import (
     PlannedMaterialization,
     build_run_output_materialize_plan,
+    hydrate_run_outputs,
     materialize_planned_outputs,
 )
 from consist.models.artifact import Artifact
@@ -669,3 +670,83 @@ def test_build_plan_reports_unsupported_ingested_driver_clearly(
             "unsupported DB export for ingested driver 'json'",
         )
     ]
+
+
+def test_hydrate_run_outputs_returns_detached_artifact_views(
+    tracker, run_dir: Path
+) -> None:
+    output_path = run_dir / "outputs" / "table.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("value\n1\n", encoding="utf-8")
+
+    with tracker.start_run(
+        "producer_hydrate", model="producer", cache_mode="overwrite"
+    ):
+        tracker.log_artifact(output_path, key="table", direction="output")
+
+    historical_artifact = tracker.get_run_outputs("producer_hydrate")["table"]
+
+    hydrated = tracker.hydrate_run_outputs(
+        "producer_hydrate",
+        target_root=run_dir / "restored_hydrate",
+        keys=["table"],
+    )
+
+    restored_path = (run_dir / "restored_hydrate" / "outputs" / "table.csv").resolve()
+    result = hydrated["table"]
+    assert result.status == "materialized_from_filesystem"
+    assert result.resolvable is True
+    assert result.path == restored_path
+    assert result.artifact is not historical_artifact
+    assert result.artifact.container_uri == historical_artifact.container_uri
+    assert result.artifact.as_path() == restored_path
+    assert hydrated.paths == {"table": restored_path}
+    assert list(hydrated.resolvable) == ["table"]
+    assert hydrated.complete is True
+    assert historical_artifact.as_path() == output_path
+
+
+def test_hydrate_run_outputs_warn_mode_returns_mixed_keyed_statuses(
+    tmp_path: Path,
+) -> None:
+    producer_dir = tmp_path / "producer"
+    existing_source = producer_dir / "outputs" / "good.csv"
+    existing_source.parent.mkdir(parents=True, exist_ok=True)
+    existing_source.write_text("value\n1\n", encoding="utf-8")
+
+    selected_run = _run("consumer", run_dir=tmp_path / "consumer")
+    producing_run = _run("producer", run_dir=producer_dir)
+    outputs = [
+        _artifact("good", "./outputs/good.csv", run_id="producer"),
+        _artifact("missing", "./outputs/missing.csv", run_id="producer"),
+        _artifact("absolute", "/tmp/data.csv", run_id="producer"),
+    ]
+    tracker = _stub_tracker(
+        run_dir=tmp_path / "workspace",
+        outputs_by_run={"consumer": outputs},
+        runs={"consumer": selected_run, "producer": producing_run},
+    )
+
+    result = hydrate_run_outputs(
+        tracker,
+        selected_run,
+        target_root=tmp_path / "restored",
+        source_root=None,
+        keys=None,
+        allowed_base=tmp_path,
+        preserve_existing=True,
+        on_missing="warn",
+        db_fallback="never",
+    )
+
+    assert result["good"].status == "materialized_from_filesystem"
+    assert result["good"].resolvable is True
+    assert result["missing"].status == "missing_source"
+    assert result["missing"].resolvable is False
+    assert result["absolute"].status == "skipped_unmapped"
+    assert result["absolute"].path is None
+    assert result.paths == {
+        "good": (tmp_path / "restored" / "outputs" / "good.csv").resolve()
+    }
+    assert list(result.failed_keys) == []
+    assert result.complete is False


### PR DESCRIPTION
**Summary**

This PR adds a new first-class API for restoring selected outputs from a historical run into a workspace root and getting a keyed result back.

The new `hydrate_run_outputs(...)` flow is designed for restart, archive-mirror recovery, and cross-workspace reuse. Instead of forcing callers to separately find the run, look up output artifacts by key, materialize bytes, and then independently prove the result is usable, the new API does that as one logical operation and returns a per-key outcome with the detached artifact, destination path, status, and resolvability.

The existing `materialize_run_outputs(...)` API remains supported as a compatibility wrapper over the same underlying planner/executor flow.

Addresses #100 

**What changed**

- Added `Tracker.hydrate_run_outputs(...)`
- Added `Run.hydrate_outputs(...)`
- Added top-level `consist.hydrate_run_outputs(...)`
- Added keyed result types:
  - `HydratedRunOutput`
  - `HydratedRunOutputsResult`
- Refactored the historical output planner/executor to produce keyed per-output outcomes once
- Reimplemented `materialize_run_outputs(...)` as a compatibility fold back into `MaterializationResult`
- Centralized shared materialization option validation in `src/consist/core/materialize_options.py`
- Expanded docs and docstrings to make the new recovery flow the recommended path

**New API behavior**

`hydrate_run_outputs(...)` returns a mapping-like result keyed by output key, where each entry includes:

- `artifact`: detached copy of the historical artifact record
- `path`: intended or hydrated destination path
- `status`: one of:
  - `materialized_from_filesystem`
  - `materialized_from_db`
  - `preserved_existing`
  - `skipped_unmapped`
  - `missing_source`
  - `failed`
- `message`: optional detail for failures/missing-source outcomes
- `resolvable`: whether the detached artifact is immediately usable in the hydrated workspace

Unknown requested keys raise before hydration work starts.

**Why**

Before this change, consumers like PILATES had to glue together multiple separate operations for one conceptual workflow:

1. identify the producing run
2. query outputs for that run
3. find the artifact for a specific key
4. materialize bytes
5. independently verify the result is usable in the workspace

This PR makes that a single, explicit, library-level operation.

**Compatibility**

- `materialize_run_outputs(...)` is still available
- Existing materialization behavior is preserved, but now comes from the shared keyed hydration core
- Narrative docs now recommend `hydrate_run_outputs(...)` for new workflows and position `materialize_run_outputs(...)` as the aggregate compatibility surface

**Files of interest**

Core/API:
- `src/consist/core/materialize_options.py`
- `src/consist/core/materialize.py`
- `src/consist/core/tracker.py`
- `src/consist/models/run.py`
- `src/consist/api.py`
- `src/consist/__init__.py`

Tests:
- `tests/unit/api/test_run_materialize_outputs_api.py`
- `tests/unit/api/test_public_exports.py`
- `tests/unit/core/test_run_materialize_outputs_core.py`
- `tests/integration/tracker/test_tracker_ergonomics.py`

Docs:
- `docs/api/materialize.md`
- `docs/api/public_api.md`
- `docs/concepts/caching-and-hydration.md`
- `docs/mounts-and-portability.md`
- `docs/troubleshooting.md`
- `docs/usage-guide.md`


**Notes / follow-ups**

- Narrative docs now prefer `hydrate_run_outputs(...)` as the default historical recovery API
- Duplicate `keys=` behavior is currently not explicitly documented as a special contract; the keyed result naturally collapses duplicate keys to one entry
- I did not run the full repository test suite or a docs-site build