### PR TITLE
Clone rather than modify artifacts from db

### DIFF
--- a/src/consist/core/artifacts.py
+++ b/src/consist/core/artifacts.py
@@ -226,6 +226,38 @@ class ArtifactManager:
                     "content_id equality governs deduplication instead."
                 )
 
+        def _clone_artifact(
+            artifact: Artifact,
+            *,
+            driver_override: Optional[str],
+            table_path_override: Optional[str],
+            array_path_override: Optional[str],
+        ) -> Artifact:
+            cloned = Artifact(
+                id=artifact.id,
+                key=artifact.key,
+                container_uri=artifact.container_uri,
+                table_path=(
+                    table_path_override
+                    if table_path_override is not None
+                    else artifact.table_path
+                ),
+                array_path=(
+                    array_path_override
+                    if array_path_override is not None
+                    else artifact.array_path
+                ),
+                driver=driver_override or artifact.driver,
+                hash=artifact.hash,
+                content_id=artifact.content_id,
+                run_id=artifact.run_id,
+                meta=dict(artifact.meta or {}),
+                created_at=artifact.created_at,
+            )
+            if artifact.abs_path:
+                cloned.abs_path = artifact.abs_path
+            return cloned
+
         def _attach_content_id(artifact: Artifact) -> None:
             hash_value = hash_state.effective_hash or artifact.hash
             effective_driver = driver or artifact.driver
@@ -315,20 +347,20 @@ class ArtifactManager:
         _warn_output_reuse_deprecated()
 
         if isinstance(path, Artifact):
-            artifact_obj = path
-            resolved_abs_path = artifact_obj.abs_path or self.tracker.resolve_uri(
-                artifact_obj.container_uri
+            source_artifact = path
+            resolved_abs_path = source_artifact.abs_path or self.tracker.resolve_uri(
+                source_artifact.container_uri
             )
             if key is None:
-                key = artifact_obj.key
+                key = source_artifact.key
             if key is not None:
                 validate_artifact_key(key)
-            if driver:
-                artifact_obj.driver = driver
-            if table_path is not None:
-                artifact_obj.table_path = table_path
-            if array_path is not None:
-                artifact_obj.array_path = array_path
+            artifact_obj = _clone_artifact(
+                source_artifact,
+                driver_override=driver,
+                table_path_override=table_path,
+                array_path_override=array_path,
+            )
             _apply_content_hash_override(artifact_obj)
             if meta:
                 artifact_obj.meta.update(meta)
@@ -372,9 +404,12 @@ class ArtifactManager:
                         )
 
                     if should_reuse:
-                        artifact_obj = parent
-                        if driver:
-                            artifact_obj.driver = driver
+                        artifact_obj = _clone_artifact(
+                            parent,
+                            driver_override=driver,
+                            table_path_override=table_path,
+                            array_path_override=array_path,
+                        )
                         _apply_content_hash_override(artifact_obj)
                         if meta:
                             artifact_obj.meta.update(meta)

--- a/tests/unit/core/test_artifacts.py
+++ b/tests/unit/core/test_artifacts.py
@@ -1,9 +1,12 @@
+import logging
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from consist.core.artifacts import ArtifactManager
+from consist.core.persistence import DatabaseManager
 from consist.models.artifact import Artifact
 from consist.models.artifact import ArtifactContent
 
@@ -168,3 +171,139 @@ def test_attach_content_id_uses_artifact_driver_when_arg_missing():
     tracker.db.get_or_create_artifact_content.assert_called_with(
         content_hash="hash_from_obj", driver="parquet"
     )
+
+
+def test_attach_content_id_handles_deepcopied_detached_artifact(tmp_path, caplog):
+    db = DatabaseManager(str(tmp_path / "artifact_replay.db"))
+
+    with db.session_scope() as session:
+        original = Artifact(
+            key="geoid_to_zone",
+            container_uri="outputs://zones.parquet",
+            driver="parquet",
+            hash="shared_hash",
+            run_id="run_a",
+        )
+        session.add(original)
+        session.commit()
+        artifact_id = original.id
+
+    detached = db.get_artifact(artifact_id)
+    assert detached is not None
+    replayed = deepcopy(detached)
+
+    tracker = MagicMock()
+    tracker.resolve_uri = lambda uri: f"/abs/{uri}"
+    tracker.fs.virtualize_path = lambda path: f"inputs://{Path(path).name}"
+    tracker.identity.compute_file_checksum.return_value = "shared_hash"
+    tracker.db = db
+
+    manager = ArtifactManager(tracker)
+    with caplog.at_level(logging.WARNING):
+        out = manager.create_artifact(path=replayed, run_id="run_b")
+
+    content = db.find_artifact_content(content_hash="shared_hash", driver="parquet")
+
+    assert out is not replayed
+    assert out.id == replayed.id
+    assert content is not None
+    assert out.content_id == content.id
+    assert "Failed to record artifact content identity" not in caplog.text
+
+
+def test_create_artifact_handles_driver_override_on_deepcopied_detached_artifact(
+    tmp_path, caplog
+):
+    db = DatabaseManager(str(tmp_path / "artifact_driver_override.db"))
+
+    with db.session_scope() as session:
+        original = Artifact(
+            key="geoid_to_zone",
+            container_uri="outputs://zones.parquet",
+            driver="parquet",
+            hash="shared_hash",
+            run_id="run_a",
+        )
+        session.add(original)
+        session.commit()
+        artifact_id = original.id
+
+    detached = db.get_artifact(artifact_id)
+    assert detached is not None
+    replayed = deepcopy(detached)
+
+    tracker = MagicMock()
+    tracker.resolve_uri = lambda uri: f"/abs/{uri}"
+    tracker.fs.virtualize_path = lambda path: f"inputs://{Path(path).name}"
+    tracker.identity.compute_file_checksum.return_value = "shared_hash"
+    tracker.db = db
+
+    manager = ArtifactManager(tracker)
+    with caplog.at_level(logging.WARNING):
+        out = manager.create_artifact(
+            path=replayed,
+            run_id="run_b",
+            driver="csv",
+        )
+
+    db.sync_artifact(out, run_id="run_b", direction="output")
+    persisted = db.get_artifact(out.id)
+    content = db.find_artifact_content(content_hash="shared_hash", driver="csv")
+
+    assert out is not replayed
+    assert out.id == replayed.id
+    assert replayed.driver == "parquet"
+    assert persisted is not None
+    assert persisted.driver == "csv"
+    assert content is not None
+    assert persisted.content_id == content.id
+    assert replayed.content_id != content.id
+    assert "Failed to record artifact content identity" not in caplog.text
+
+
+def test_create_artifact_clones_reused_input_artifact_before_mutation(tmp_path, caplog):
+    db = DatabaseManager(str(tmp_path / "artifact_input_reuse.db"))
+
+    with db.session_scope() as session:
+        original = Artifact(
+            key="geoid_to_zone",
+            container_uri="inputs://zones.parquet",
+            driver="parquet",
+            hash="shared_hash",
+            run_id="run_a",
+        )
+        session.add(original)
+        session.commit()
+        artifact_id = original.id
+
+    detached = db.get_artifact(artifact_id)
+    assert detached is not None
+    reused_parent = deepcopy(detached)
+
+    tracker = MagicMock()
+    tracker.resolve_uri = lambda uri: str(tmp_path / uri.split("://", 1)[1])
+    tracker.fs.virtualize_path = lambda path: f"inputs://{Path(path).name}"
+    tracker.identity.compute_file_checksum.return_value = "shared_hash"
+    tracker.mounts = {}
+    tracker.db = MagicMock(wraps=db)
+    tracker.db.find_latest_artifact_at_uri.return_value = reused_parent
+
+    manager = ArtifactManager(tracker)
+    input_path = tmp_path / "zones.parquet"
+    input_path.write_text("zone,data\n1,a\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        out = manager.create_artifact(
+            path=input_path,
+            key="geoid_to_zone",
+            direction="input",
+        )
+
+    content = db.find_artifact_content(content_hash="shared_hash", driver="parquet")
+
+    assert out is not reused_parent
+    assert out.id == reused_parent.id
+    assert reused_parent.content_id is None
+    assert content is not None
+    assert out.content_id == content.id
+    assert "Failed to record artifact content identity" not in caplog.text


### PR DESCRIPTION
## Summary

Fix detached `Artifact` mutation during replay / reuse by cloning reused artifacts before applying overrides or attaching `content_id`.

This addresses a cache-hit recovery / recovered-output replay issue (Issue #104)  where assigning `Artifact.content_id` could fail with:

> Can't emit change event for attribute 'Artifact.content_id' - parent object of type <Artifact> has been garbage collected.

## Problem

`ArtifactManager.create_artifact(...)` could receive an `Artifact` instance that originated from a detached or deep-copied ORM object during replay/cache hydration. Mutating mapped fields on that object could trigger SQLAlchemy change-event failures.

This was most visible in `_attach_content_id(...)`, but the same class of issue also applied to other reuse paths that mutated previously-loaded `Artifact` instances.

## Solution

Instead of mutating reused `Artifact` instances in place, `create_artifact(...)` now clones them into a fresh `Artifact` object before applying any changes.

Behavioral details:
- preserves the same conceptual artifact identity by keeping the same `id`
- copies persisted fields forward (`driver`, `hash`, `content_id`, `run_id`, `meta`, `created_at`, etc.)
- carries over runtime `abs_path`
- applies overrides and `content_id` attachment only to the cloned object

This is now applied in both reuse paths:
- when `path` itself is an `Artifact`
- when input reuse resolves a prior artifact via `find_latest_artifact_at_uri(...)`

## Why this approach

This avoids fragile ORM lifecycle interactions entirely rather than catching assignment failures after the fact. It keeps provenance identity stable while making replay/reuse behavior safer and easier to reason about.

## Tests

Added targeted regressions for:
- attaching `content_id` on a deep-copied detached artifact
- overriding `driver` on a deep-copied detached artifact while preserving the same `id`
- cloning reused input artifacts returned from `find_latest_artifact_at_uri(...)` before mutation


Closes #104 
