### PR TITLE
Input staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ cleaned_df = consist.load_df(artifact)
 the local `Path` values named in `inputs`, while those same inputs still define
 cache identity and lineage.
 
+When a path-bound step needs inputs at specific local destinations, request
+staging through `ExecutionOptions` instead of manually copying files:
+
+```python
+result = tracker.run(
+    fn=clean_data,
+    inputs={"raw": Path("raw.parquet")},
+    outputs=["cleaned"],
+    execution_options=ExecutionOptions(
+        input_binding="paths",
+        input_materialization="requested",
+        input_paths={"raw": Path("./workspace/raw.parquet")},
+    ),
+)
+```
+
+That keeps artifact identity canonical while ensuring the callable sees a real
+local file at the requested path, including on cache hits.
+
 **Summary**: Consist computes a deterministic fingerprint from your code version, config, and input files. If you change
 anything upstream, only affected downstream steps will re-execute.
 
@@ -137,6 +156,8 @@ Use `output_paths` when a function returns `None` but writes files, or when you 
   affected downstream steps re-execute when any upstream piece changes.
 - **Plain Python**: Tasks are ordinary Python functions—callable and testable without the tracker. The tracker is
   additive and does not restructure your code.
+- **Explicit File Workflows**: Path-bound steps can request staged local inputs without giving up canonical artifact
+  identity, which is useful for subprocesses, external tools, and workspace-local contracts.
 - **Complete Lineage**: Every result is tagged with the exact code and config that created it. Trace lineage from any
   output back to its sources.
 - **SQL-Native Analysis**: All metadata is indexed in DuckDB. Query across runs, join tables, and compare variants using

--- a/docs/api/materialize.md
+++ b/docs/api/materialize.md
@@ -1,5 +1,12 @@
 # Materialization
 
+Consist has two related filesystem-recovery stories:
+
+- historical output recovery, which starts with `hydrate_run_outputs(...)`
+- canonical input staging, which starts with
+  `ExecutionOptions(input_materialization="requested", input_paths={...})` on
+  `run(...)` and `ScenarioContext.run(...)`
+
 For historical output recovery, start with `hydrate_run_outputs(...)`.
 
 It is the clearest API for restart, archive-mirror recovery, and
@@ -14,6 +21,12 @@ but returns the older aggregate
 [`MaterializationResult`](#consist.core.materialize.MaterializationResult).
 Keep it for compatibility or summary-style reporting; use
 `hydrate_run_outputs(...)` for new workflows.
+
+For input-side workflows, prefer requested input materialization on the run
+surface. It uses the same canonical artifact recovery rules, but keeps the
+operation attached to normal execution and cache-hit behavior. Reach for
+`stage_artifact(...)` and `stage_inputs(...)` only when you need the same
+staging behavior outside a run lifecycle.
 
 ## Recovery Ordering
 
@@ -103,6 +116,51 @@ In this flow:
   `resolvable` is `True`, `artifact.as_path()` points at the hydrated
   destination in the new workspace.
 
+## Requested Input Staging
+
+For new workflow code, input-side staging usually belongs on the run surface:
+
+```python
+from pathlib import Path
+from consist import ExecutionOptions
+
+result = tracker.run(
+    fn=run_tool,
+    inputs={"config_path": Path("./configs/baseline.yaml")},
+    outputs=["report"],
+    execution_options=ExecutionOptions(
+        input_binding="paths",
+        input_materialization="requested",
+        input_paths={"config_path": Path("./workspace/config.yaml")},
+    ),
+)
+```
+
+This keeps the canonical input artifact unchanged for identity and lineage
+while ensuring the callable sees a real local file at the requested path.
+
+Use the low-level helpers when you already have resolved artifacts and need to
+stage them manually:
+
+```python
+from pathlib import Path
+import consist
+
+staged = consist.stage_inputs(
+    {"config_path": artifact},
+    destinations_by_key={"config_path": Path("./workspace/config.yaml")},
+)
+```
+
+## Staging Status Meanings
+
+| Status | Meaning |
+|---|---|
+| `staged` | Copied bytes to the requested destination |
+| `preserved_existing` | Destination already existed with matching content and was reused |
+| `missing_source` | No readable source bytes were found for the canonical artifact |
+| `failed` | Staging was attempted but failed due to a collision, policy check, or copy error |
+
 ## Status Meanings
 
 | Status | Meaning |
@@ -140,6 +198,10 @@ signatures and attribute details, use the generated reference below.
       show_root_heading: false
       show_root_toc_entry: false
       members:
+        - stage_artifact
+        - stage_inputs
+        - StagedInput
+        - StagedInputsResult
         - HydratedRunOutput
         - HydratedRunOutputsResult
         - MaterializationResult

--- a/docs/api/public_api.md
+++ b/docs/api/public_api.md
@@ -84,6 +84,8 @@ with tracker.scenario("baseline") as sc:
 - [`consist.HydratedRunOutput`](materialize.md#consist.core.materialize.HydratedRunOutput)
 - [`consist.HydratedRunOutputsResult`](materialize.md#consist.core.materialize.HydratedRunOutputsResult)
 - [`consist.MaterializationResult`](materialize.md#consist.core.materialize.MaterializationResult)
+- [`consist.StagedInput`](materialize.md#consist.core.materialize.StagedInput)
+- [`consist.StagedInputsResult`](materialize.md#consist.core.materialize.StagedInputsResult)
 - [`consist.RunSet`](runset.md#consist.runset.RunSet)
 - [`consist.AlignedPair`](runset.md#consist.runset.AlignedPair)
 - `consist.CacheOptions`, `consist.OutputPolicyOptions`, `consist.ExecutionOptions`
@@ -123,6 +125,8 @@ Scenario defaults like `name_template` and `cache_epoch` are configured via `con
 - [`consist.get_artifact`](api_helpers.md#consist.api.get_artifact)
 - [`consist.hydrate_run_outputs`](api_helpers.md#consist.api.hydrate_run_outputs) (recommended historical output recovery API)
 - [`consist.materialize_run_outputs`](api_helpers.md#consist.api.materialize_run_outputs) (aggregate compatibility wrapper)
+- [`consist.stage_artifact`](api_helpers.md#consist.api.stage_artifact) (low-level canonical input staging)
+- [`consist.stage_inputs`](api_helpers.md#consist.api.stage_inputs) (low-level canonical input staging)
 - [`consist.set_artifact_recovery_roots`](api_helpers.md#consist.api.set_artifact_recovery_roots)
 - [`consist.archive_artifact`](api_helpers.md#consist.api.archive_artifact)
 - [`consist.archive_run_outputs`](api_helpers.md#consist.api.archive_run_outputs)
@@ -187,6 +191,7 @@ as needed.
 - `find_artifacts_by_params`, `get_artifact_kv`, `register_artifact_facet_parser`
 - `get_run`, `get_run_config`, `get_run_inputs`, `get_run_outputs`
 - `hydrate_run_outputs`, `materialize_run_outputs`
+- `stage_artifact`, `stage_inputs`
 - `set_artifact_recovery_roots`, `archive_artifact`, `archive_run_outputs`
 - `get_artifact_lineage`, `print_lineage`, `history`
 - `diff_runs`, `get_config_facet`, `get_config_facets`, `get_run_config_kv`

--- a/docs/api/run.md
+++ b/docs/api/run.md
@@ -11,6 +11,31 @@ Use options objects instead:
 - `output_policy=OutputPolicyOptions(...)`
 - `execution_options=ExecutionOptions(...)`
 
+For path-bound steps, `ExecutionOptions` is also the public surface for
+requested input staging:
+
+```python
+from pathlib import Path
+import consist
+from consist import ExecutionOptions
+
+result = consist.run(
+    fn=run_tool,
+    inputs={"config_path": Path("./configs/baseline.yaml")},
+    outputs=["report"],
+    execution_options=ExecutionOptions(
+        input_binding="paths",
+        input_materialization="requested",
+        input_paths={"config_path": Path("./workspace/config.yaml")},
+    ),
+)
+```
+
+That pattern applies equally to `Tracker.run(...)` and
+`ScenarioContext.run(...)`. It keeps canonical artifact identity in
+`inputs={...}` while ensuring the callable sees a real local file at the
+requested destination, including on cache hits.
+
 For migration details, see
 [Options Objects Migration Guide](../migrations/options-objects-migration-guide.md).
 
@@ -29,6 +54,17 @@ Passing them raises `TypeError` (`unexpected keyword argument ...`).
 Run/trace parity is implemented through a shared invocation-resolution path
 (`resolve_run_invocation`), so identity and cache-option validation rules are
 consistent across both execution styles.
+
+## Execution controls to reach for first
+
+Use `ExecutionOptions(...)` for three common runtime choices:
+
+- `input_binding="paths"` when the callable should own file I/O
+- `input_binding="loaded"` when Consist should hydrate data objects first
+- `input_materialization="requested"` plus `input_paths={...}` when a
+  path-bound step needs exact local input destinations
+
+For the lower-level staging helpers, see [Materialization](materialize.md).
 
 ::: consist.api.run
     options:

--- a/docs/concepts/caching-and-hydration.md
+++ b/docs/concepts/caching-and-hydration.md
@@ -43,9 +43,11 @@ Materialize cached outputs (copy bytes to your current run) in three cases:
 
 1. **Extending a scenario in a new workspace**: Cached results in `/workspace/2024`, continuing in `/workspace/2025`. Use `cache_hydration="inputs-missing"` to copy input files.
 
-2. **Preparing outputs for external tools**: Tools expect local files. Use `cache_hydration="outputs-requested"` with `materialize_cached_output_paths`. With `consist.run(...)` or `sc.run(...)`, use `output_paths={...}`.
+2. **Preparing declared inputs for path-bound steps**: A callable or wrapped tool expects one or more inputs at fixed local destinations. Use `ExecutionOptions(input_binding="paths", input_materialization="requested", input_paths={...})`.
 
-3. **Ensuring local reproducibility**: All results accessible without remote mounts. Use `cache_hydration="outputs-all"` to copy all cached outputs.
+3. **Preparing outputs for external tools**: Tools expect local files. Use `cache_hydration="outputs-requested"` with `materialize_cached_output_paths`. With `consist.run(...)` or `sc.run(...)`, use `output_paths={...}`.
+
+4. **Ensuring local reproducibility**: All results accessible without remote mounts. Use `cache_hydration="outputs-all"` to copy all cached outputs.
 
 ### Example: Electric Grid Modeling Workflow
 
@@ -144,6 +146,42 @@ That is why path-oriented workflows often pair naturally with
 `cache_hydration="inputs-missing"` when work moves across run directories.
 Loaded workflows can often keep using `cache_hydration="metadata"` and let
 Consist load the bytes on demand.
+
+### Requested Input Materialization for Path Binding
+
+`cache_hydration` is about reusing prior outputs. Requested input
+materialization is the complementary input-side mechanism for path-bound runs.
+
+Use it when a declared input artifact is canonical in provenance terms, but the
+callable needs a staged local copy at a specific destination:
+
+```python
+from pathlib import Path
+import consist
+from consist import ExecutionOptions
+
+result = tracker.run(
+    fn=run_tool,
+    inputs={"config_path": consist.ref(prepare, key="config")},
+    outputs=["report"],
+    execution_options=ExecutionOptions(
+        input_binding="paths",
+        input_materialization="requested",
+        input_paths={"config_path": Path("./workspace/tool-config.yaml")},
+    ),
+)
+```
+
+This gives you a clear split of responsibilities:
+
+- `inputs={...}` declares identity and lineage.
+- `input_binding="paths"` says the callable wants filesystem paths.
+- `input_paths={...}` names the exact local destinations that must exist.
+- `input_materialization="requested"` tells Consist to create those paths on
+  cache misses and cache hits.
+
+Use this when a tool expects exact workspace-local filenames or when you need a
+fresh local copy instead of reading from the artifact's canonical path.
 
 ### Signatures and Cache Behavior
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -123,6 +123,25 @@ returns a cache hit and skips execution.
 the function. Use `"loaded"` when you want hydrated tables or objects; use
 `"paths"` when you want the callable to own its own I/O boundary.
 
+If a path-bound step needs an input at a specific local filename, request that
+staging directly in `ExecutionOptions`:
+
+``` python
+first = tracker.run(
+    fn=summarize_values,
+    inputs={"data_path": Path("input.csv")},
+    outputs=["summary"],
+    execution_options=ExecutionOptions(
+        input_binding="paths",
+        input_materialization="requested",
+        input_paths={"data_path": Path("./workspace/input.csv")},
+    ),
+)
+```
+
+That is the recommended pattern for subprocesses or legacy tools that expect
+fixed workspace-local input paths, and it still works on cache hits.
+
 The main Consist-specific onboarding cost in these examples is small but real:
 return `dict[str, Path]` instead of a bare `Path`, and declare
 `outputs=[...]` so the tracker knows which artifact key to log.

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,9 @@ deeper work.
 === "By Topic"
 
     - **Caching and reuse**: [Caching & Hydration](concepts/caching-and-hydration.md)
+    - **Path-bound external tools**:
+      [Usage Guide](usage-guide.md),
+      [Materialization](api/materialize.md)
     - **Configuration and identity**: [Config Management](concepts/config-management.md)
     - **SQL analytics and ingestion**:
       [Data Materialization](concepts/data-materialization.md),
@@ -86,6 +89,7 @@ deeper work.
 | I want to...                           | Go to                                                                                   |
 |----------------------------------------|-----------------------------------------------------------------------------------------|
 | Speed up my pipeline                   | [Caching & Hydration](concepts/caching-and-hydration.md)                                |
+| Run a tool that needs fixed local input files | [Usage Guide](usage-guide.md) or [Materialization](api/materialize.md)           |
 | Debug a cache miss                     | [Troubleshooting](troubleshooting.md)                                                   |
 | Operate or repair the provenance DB    | [DB Maintenance Guide](db-maintenance.md)                                               |
 | Find which config produced a result    | [`consist lineage`](cli-reference.md#consist-lineage)                                   |

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -24,6 +24,7 @@ for the recommended wrapper architecture.
 
 - [Choosing Your Pattern](#choosing-your-pattern)
 - [Pattern 1: Single-Step Runs (`run()`)](#pattern-1-single-step-runs-run)
+- [Requested Input Staging for Path-Bound Steps](#requested-input-staging-for-path-bound-steps)
 - [Pattern 2: Multi-Step Workflows (`scenario()`)](#pattern-2-multi-step-workflows-scenario)
 - [Pattern 3: Container Integration](#pattern-3-container-integration)
 - [Advanced Patterns](#advanced-patterns)
@@ -45,7 +46,7 @@ workflow state, or per-step caching across a larger pipeline.
 |-------------------------------------------------------------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Single data processing step (clean, transform, aggregate)   | **`run`**                       | Simple: caches the entire function call with low overhead. Use for self-contained operations.                               |
 | Multi-step workflow (preprocessing → simulation → analysis) | **`scenario`**                  | Groups related steps, shares state via coupler, per-step caching. Use when steps have dependencies or shared configuration. |
-| Existing tool/model (subprocess, legacy code, container)    | **[`container` or `depends_on`](containers-guide.md)** | Wraps external executables, tracks container digest as cache key. Use for black-box tools.                                  |
+| Existing tool/model (subprocess, legacy code, container)    | **[`container` or `depends_on`](containers-guide.md)** | Wraps external executables, tracks container digest as cache key. Pair path-bound steps with requested input staging when a tool expects fixed local input paths. |
 | Parameter sweep / sensitivity analysis                      | **`scenario`&nbsp;+&nbsp;loop** | Run the same step with different configs, compare results.                                                                  |
 | Multi-year simulation                                       | **`scenario`&nbsp;+&nbsp;loop** | Runs in years, each year caches independently, all years share scenario context.                                            |
 
@@ -73,6 +74,24 @@ identity-only and you do not want automatic binding.
 `runtime_kwargs` still exists, but it should usually mean "runtime-only values
 that are not the declared named inputs." It is no longer the recommended way to
 pass paths into a path-based step.
+
+If a path-bound step needs those inputs at exact local destinations, request
+staging as part of the run instead of copying files yourself:
+
+``` python
+execution_options = ExecutionOptions(
+    input_binding="paths",
+    input_materialization="requested",
+    input_paths={
+        "raw_path": Path("./workspace/raw.parquet"),
+    },
+)
+```
+
+That pattern is especially useful for subprocess wrappers, legacy tools, and
+steps that need stable workspace-local filenames. The requested paths are
+created before execution on cache misses and before the cached result is
+returned on cache hits.
 
 **When to use:**
 
@@ -216,6 +235,53 @@ This reduces cache misses when unrelated files elsewhere in the repository chang
 
 Legacy run-policy kwargs are no longer supported on `run(...)` APIs. Use
 `cache_options=...`, `output_policy=...`, and `execution_options=...`.
+
+### Requested Input Staging for Path-Bound Steps
+
+Use requested input staging when the callable or wrapped tool expects one or
+more declared inputs at specific local destinations. This keeps the canonical
+artifact identity unchanged while creating a run-local working copy where the
+tool expects it.
+
+``` python
+from pathlib import Path
+import subprocess
+from consist import ExecutionOptions, Tracker
+
+tracker = Tracker(run_dir="./runs", db_path="./provenance.duckdb")
+
+
+def run_legacy_tool(config_path: Path) -> dict[str, Path]:
+    output = Path("./report.txt")
+    subprocess.run(
+        ["legacy-tool", "--config", str(config_path), "--out", str(output)],
+        check=True,
+    )
+    return {"report": output}
+
+
+result = tracker.run(
+    fn=run_legacy_tool,
+    inputs={"config_path": Path("./configs/baseline.yaml")},
+    outputs=["report"],
+    execution_options=ExecutionOptions(
+        input_binding="paths",
+        input_materialization="requested",
+        input_paths={
+            "config_path": Path("./workspace/config.yaml"),
+        },
+    ),
+)
+```
+
+Use this pattern when:
+
+- the step expects a fixed on-disk input location
+- the same expectation must hold on cache hits
+- you want `inputs={...}` to remain the source of identity and lineage
+
+Use low-level `consist.stage_artifact(...)` or `consist.stage_inputs(...)` only
+for custom orchestration or setup work outside a normal run lifecycle.
 
 For file outputs, prefer returning `dict[str, Path]` and declaring
 `outputs=[...]` when you control the function body. Use managed helpers like

--- a/src/consist/__init__.py
+++ b/src/consist/__init__.py
@@ -56,6 +56,8 @@ from consist.api import (
     get_run_result,
     hydrate_run_outputs,
     materialize_run_outputs,
+    stage_artifact,
+    stage_inputs,
     set_artifact_recovery_roots,
     archive_artifact,
     archive_run_outputs,
@@ -103,6 +105,8 @@ from consist.core.materialize import (
     HydratedRunOutput,
     HydratedRunOutputsResult,
     MaterializationResult,
+    StagedInput,
+    StagedInputsResult,
 )
 from consist.runtime import create_tracker
 from consist.protocols import (
@@ -136,6 +140,8 @@ __all__ = [
     "HydratedRunOutput",
     "HydratedRunOutputsResult",
     "MaterializationResult",
+    "StagedInput",
+    "StagedInputsResult",
     "create_tracker",
     "ArtifactLike",
     "RunIdentifiedResultLike",
@@ -182,6 +188,8 @@ __all__ = [
     "get_run_result",
     "hydrate_run_outputs",
     "materialize_run_outputs",
+    "stage_artifact",
+    "stage_inputs",
     "set_artifact_recovery_roots",
     "archive_artifact",
     "archive_run_outputs",

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -55,6 +55,10 @@ from consist.core.materialize_options import (
     validate_materialize_option,
 )
 from consist.core.run_options import raise_legacy_policy_kwargs_error
+from consist.core.materialize import (
+    stage_artifact as stage_artifact_core,
+    stage_inputs as stage_inputs_core,
+)
 from consist.core.stores import get_hot_data_db_path
 from consist.core.views import _quote_ident, create_view_model
 from consist.core.workflow import OutputCapture, RunContext
@@ -77,6 +81,8 @@ if TYPE_CHECKING:
     from consist.core.materialize import (
         HydratedRunOutputsResult,
         MaterializationResult,
+        StagedInput,
+        StagedInputsResult,
     )
     from consist.core.step_context import StepContext
     from consist.runset import RunSet
@@ -1202,6 +1208,67 @@ def hydrate_run_outputs(
         preserve_existing=preserve_existing,
         on_missing=on_missing,
         db_fallback=db_fallback,
+    )
+
+
+def stage_artifact(
+    artifact: Artifact,
+    *,
+    destination: str | Path,
+    overwrite: bool = False,
+    mode: Literal["copy", "hardlink", "symlink"] = "copy",
+    validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+    allow_external_paths: Optional[bool] = None,
+    tracker: Optional["Tracker"] = None,
+) -> "StagedInput":
+    """
+    Stage a single artifact to a requested filesystem destination.
+
+    This is the low-level convenience wrapper for canonical input staging. It
+    copies the artifact bytes into the requested destination, preserving
+    existing identical content when possible and returning a detached staged
+    artifact view for immediate reuse.
+    """
+    tr = _resolve_tracker(tracker)
+    return stage_artifact_core(
+        tr,
+        artifact,
+        Path(destination),
+        mode=mode,
+        overwrite=overwrite,
+        validate_content_hash=validate_content_hash,
+        allow_external_paths=allow_external_paths,
+    )
+
+
+def stage_inputs(
+    inputs_by_key: Mapping[str, Artifact],
+    *,
+    destinations_by_key: Mapping[str, str | Path],
+    overwrite: bool = False,
+    mode: Literal["copy", "hardlink", "symlink"] = "copy",
+    validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+    allow_external_paths: Optional[bool] = None,
+    tracker: Optional["Tracker"] = None,
+) -> "StagedInputsResult":
+    """
+    Stage multiple keyed artifacts to explicitly requested filesystem paths.
+
+    Keys must match the input artifact mapping keys. The returned result is
+    keyed in the same order as ``destinations_by_key``.
+    """
+    tr = _resolve_tracker(tracker)
+    normalized_destinations = {
+        key: Path(destination) for key, destination in destinations_by_key.items()
+    }
+    return stage_inputs_core(
+        tr,
+        inputs_by_key,
+        normalized_destinations,
+        mode=mode,
+        overwrite=overwrite,
+        validate_content_hash=validate_content_hash,
+        allow_external_paths=allow_external_paths,
     )
 
 

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -580,7 +580,10 @@ def run(
     output_policy : Optional[OutputPolicyOptions]
         Grouped output mismatch/missing policy controls.
     execution_options : Optional[ExecutionOptions]
-        Grouped runtime execution controls.
+        Grouped runtime execution controls. For path-bound workflows, this is
+        also where you request local input staging via
+        ``ExecutionOptions(input_binding="paths", input_materialization="requested",
+        input_paths={...})``.
     **kwargs : Any
         Arguments forwarded to `Tracker.run`, including `inputs`, `config`,
         `tags`, and other core run metadata.
@@ -1228,6 +1231,11 @@ def stage_artifact(
     copies the artifact bytes into the requested destination, preserving
     existing identical content when possible and returning a detached staged
     artifact view for immediate reuse.
+
+    Prefer ``ExecutionOptions(input_materialization="requested",
+    input_paths={...})`` on ``run(...)`` or ``ScenarioContext.run(...)`` when
+    the goal is to prepare declared inputs for one execution. Use this helper
+    when you need the same staging behavior outside a run lifecycle.
     """
     tr = _resolve_tracker(tracker)
     return stage_artifact_core(
@@ -1256,6 +1264,10 @@ def stage_inputs(
 
     Keys must match the input artifact mapping keys. The returned result is
     keyed in the same order as ``destinations_by_key``.
+
+    Prefer run-level requested input materialization for standard workflow
+    code. Use this helper when you already have resolved artifacts and need to
+    stage them before or outside normal run execution.
     """
     tr = _resolve_tracker(tracker)
     normalized_destinations = {

--- a/src/consist/core/cache.py
+++ b/src/consist/core/cache.py
@@ -1,5 +1,7 @@
+import hashlib
 import os
 import logging
+import shutil
 import tempfile
 import weakref
 from copy import deepcopy
@@ -19,6 +21,7 @@ from typing import (
 
 from consist.models.artifact import Artifact
 from consist.models.run import Run, RunArtifacts, ConsistRecord
+from consist.core.error_messages import format_problem_cause_fix
 
 if TYPE_CHECKING:
     from consist.core.tracker import Tracker
@@ -130,6 +133,10 @@ class ActiveRunCacheOptions:
     materialize_cached_outputs_dir: Optional[Path] = None
     materialize_cached_outputs_source_root: Optional[Path] = None
     validate_cached_outputs: str = "lazy"  # "eager" | "lazy"
+    requested_input_paths: Optional[Dict[str, Path]] = None
+    requested_input_materialization: Optional[str] = None
+    requested_input_materialization_mode: Optional[str] = None
+    requested_input_validate_content_hash: str = "if-present"
 
 
 def _can_delegate_run_output_materialization(tracker: CacheHydrationContext) -> bool:
@@ -703,7 +710,6 @@ def materialize_missing_inputs(
 
     items: list[tuple[Artifact, Path, Path]] = []
     db_items: list[tuple[Artifact, Path]] = []
-    run_dir_cache: dict[str, Optional[str]] = {}
 
     for artifact in tracker.current_consist.inputs:
         if not artifact.run_id:
@@ -714,20 +720,15 @@ def materialize_missing_inputs(
             continue
 
         run_id = str(artifact.run_id)
-        if run_id not in run_dir_cache:
-            run = db.get_run(run_id)
-            run_dir_cache[run_id] = (
-                run.meta.get("_physical_run_dir") if run and run.meta else None
-            )
-
-        original_run_dir = run_dir_cache.get(run_id)
+        run = db.get_run(run_id)
+        original_run_dir = run.meta.get("_physical_run_dir") if run and run.meta else None
         if not original_run_dir:
             continue
 
         source = Path(
             tracker.fs.resolve_historical_path(artifact.container_uri, original_run_dir)
         )
-        if source.exists():
+        if source is not None and source.exists():
             items.append((artifact, source, destination))
             continue
 
@@ -765,3 +766,264 @@ def materialize_missing_inputs(
 
     if materialized:
         tracker.current_consist.run.meta["materialized_inputs"] = materialized
+
+
+def materialize_requested_inputs(
+    *,
+    tracker: CacheMaterializationContext,
+    options: Optional[ActiveRunCacheOptions],
+) -> dict[str, str]:
+    """
+    Stage explicitly requested input paths for the active run.
+
+    This helper is used after cache-hit hydration and after cache-miss input
+    materialization so Python execution sees concrete local paths when
+    ``ExecutionOptions.input_materialization='requested'`` is enabled.
+    """
+    active_options = options or ActiveRunCacheOptions()
+    if active_options.requested_input_materialization != "requested":
+        return {}
+    if not tracker.current_consist:
+        return {}
+
+    requested_mode = active_options.requested_input_materialization_mode or "copy"
+    requested_paths = active_options.requested_input_paths or {}
+    if not requested_paths:
+        return {}
+
+    run = tracker.current_consist.run
+    inputs_by_key: dict[str, list[Artifact]] = {}
+    for artifact in tracker.current_consist.inputs:
+        inputs_by_key.setdefault(artifact.key, []).append(artifact)
+
+    allowed_base = _allowed_materialization_roots(tracker, target_run=run)
+    staged: dict[str, str] = {}
+    run_dir_cache: dict[str, Optional[str]] = {}
+
+    def _file_hash(path: Path) -> str:
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _dir_hash(path: Path) -> str:
+        digest = hashlib.sha256()
+        base = Path(path).resolve()
+        for root, dirnames, filenames in os.walk(base):
+            dirnames.sort()
+            filenames.sort()
+            rel_root = Path(root).resolve().relative_to(base).as_posix()
+            digest.update(f"dir:{rel_root}".encode())
+            for dirname in dirnames:
+                digest.update(
+                    f"subdir:{Path(root, dirname).resolve().relative_to(base).as_posix()}".encode()
+                )
+            for filename in filenames:
+                file_path = Path(root, filename)
+                rel_file = file_path.resolve().relative_to(base).as_posix()
+                digest.update(f"file:{rel_file}:{file_path.stat().st_size}".encode())
+                digest.update(_file_hash(file_path).encode())
+        return digest.hexdigest()
+
+    def _content_signature(path: Path) -> tuple[str, str] | None:
+        if path.is_dir():
+            return ("dir", _dir_hash(path))
+        if path.is_file():
+            return ("file", _file_hash(path))
+        return None
+
+    def _paths_match(source: Path, destination: Path) -> bool:
+        if source.resolve() == destination.resolve():
+            return True
+        source_sig = _content_signature(source)
+        destination_sig = _content_signature(destination)
+        return source_sig is not None and source_sig == destination_sig
+
+    def _remove_existing(path: Path) -> None:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    def _resolve_source(artifact: Artifact) -> Optional[Path]:
+        resolved_path = Path(tracker.resolve_uri(artifact.container_uri))
+        if resolved_path.exists():
+            return resolved_path
+
+        if artifact.abs_path:
+            abs_path = Path(artifact.abs_path)
+            if abs_path.exists():
+                return abs_path
+
+        if tracker.db is not None and artifact.run_id:
+            run_id = str(artifact.run_id)
+            if run_id not in run_dir_cache:
+                prior_run = tracker.db.get_run(run_id)
+                run_dir_cache[run_id] = (
+                    prior_run.meta.get("_physical_run_dir")
+                    if prior_run and prior_run.meta
+                    else None
+                )
+            original_run_dir = run_dir_cache.get(run_id)
+            if original_run_dir:
+                historical = Path(
+                    tracker.fs.resolve_historical_path(
+                        artifact.container_uri,
+                        original_run_dir,
+                    )
+                )
+                if historical.exists():
+                    return historical
+
+        return None
+
+    for key, destination in requested_paths.items():
+        matches = inputs_by_key.get(key, [])
+        if not matches:
+            raise ValueError(
+                format_problem_cause_fix(
+                    problem=(
+                        f"Requested input materialization key {key!r} was not "
+                        "present in the resolved run inputs."
+                    ),
+                    cause=(
+                        "Requested staging destinations must correspond to a "
+                        "resolved input artifact key."
+                    ),
+                    fix=(
+                        "Choose keys from the resolved inputs mapping, or remove "
+                        "the entry from execution_options.input_paths."
+                    ),
+                )
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                format_problem_cause_fix(
+                    problem=(
+                        f"Requested input materialization key {key!r} is ambiguous."
+                    ),
+                    cause="Multiple resolved input artifacts share the same key.",
+                    fix=(
+                        "Use unique input keys for the run, or stage a different key."
+                    ),
+                )
+            )
+
+        artifact = matches[0]
+        destination_path = Path(destination).resolve()
+
+        from consist.core.materialize import (
+            _ensure_destination_not_symlink,
+            materialize_artifacts_from_sources,
+            materialize_ingested_artifact_from_db,
+            validate_allowed_materialization_destination,
+        )
+
+        validate_allowed_materialization_destination(destination_path, allowed_base)
+        _ensure_destination_not_symlink(destination_path)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+
+        source_path = _resolve_source(artifact)
+        if destination_path.exists():
+            if destination_path.is_symlink():
+                raise ValueError(
+                    f"Symlink detected in destination path: {destination_path}"
+                )
+            if (
+                source_path is None
+                and artifact.hash
+                and destination_path.is_file()
+                and _file_hash(destination_path) == artifact.hash
+            ):
+                artifact.abs_path = str(destination_path)
+                staged[key] = str(destination_path)
+                continue
+            if source_path is not None and _paths_match(source_path, destination_path):
+                artifact.abs_path = str(destination_path)
+                staged[key] = str(destination_path)
+                continue
+            if requested_mode != "copy":
+                raise ValueError(
+                    format_problem_cause_fix(
+                        problem=(
+                            "requested_input_materialization_mode must be 'copy'."
+                        ),
+                        cause="Only copy-based requested input staging is supported.",
+                        fix=(
+                            "Use execution_options=ExecutionOptions("
+                            "input_materialization_mode='copy')."
+                        ),
+                    )
+                )
+            _remove_existing(destination_path)
+
+        if source_path is None:
+            if artifact.meta.get("is_ingested", False):
+                staged_path = Path(
+                    materialize_ingested_artifact_from_db(
+                        artifact=artifact,
+                        tracker=cast("Tracker", tracker),
+                        destination=destination_path,
+                        overwrite=False,
+                    )
+                ).resolve()
+                if (
+                    active_options.requested_input_validate_content_hash == "if-present"
+                    and artifact.hash
+                    and staged_path.is_file()
+                    and _file_hash(staged_path) != artifact.hash
+                ):
+                    raise ValueError(
+                        format_problem_cause_fix(
+                            problem=(
+                                f"Hash mismatch after staging ingested input {key!r}."
+                            ),
+                            cause=(
+                                "The reconstructed bytes do not match the artifact hash."
+                            ),
+                            fix=(
+                                "Verify the source data in DuckDB or disable hash "
+                                "validation for this staging request."
+                            ),
+                        )
+                    )
+                artifact.abs_path = str(staged_path)
+                staged[key] = str(staged_path)
+                continue
+            raise FileNotFoundError(
+                f"[Consist] Cannot stage input {artifact.key!r}: source path missing."
+            )
+
+        if source_path.resolve() == destination_path:
+            artifact.abs_path = str(destination_path)
+            staged[key] = str(destination_path)
+            continue
+
+        materialize_artifacts_from_sources(
+            items=[(artifact, source_path, destination_path)],
+            allowed_base=allowed_base,
+            on_missing="raise",
+        )
+
+        if (
+            active_options.requested_input_validate_content_hash == "if-present"
+            and artifact.hash
+            and destination_path.is_file()
+            and _file_hash(destination_path) != artifact.hash
+        ):
+            raise ValueError(
+                format_problem_cause_fix(
+                    problem=f"Hash mismatch after staging input {key!r}.",
+                    cause="The staged file bytes do not match the artifact hash.",
+                    fix=(
+                        "Verify the source artifact or disable hash validation for "
+                        "this staging request."
+                    ),
+                )
+            )
+
+        artifact.abs_path = str(destination_path)
+        staged[key] = str(destination_path)
+
+    return staged

--- a/src/consist/core/cache.py
+++ b/src/consist/core/cache.py
@@ -721,7 +721,9 @@ def materialize_missing_inputs(
 
         run_id = str(artifact.run_id)
         run = db.get_run(run_id)
-        original_run_dir = run.meta.get("_physical_run_dir") if run and run.meta else None
+        original_run_dir = (
+            run.meta.get("_physical_run_dir") if run and run.meta else None
+        )
         if not original_run_dir:
             continue
 

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -346,7 +346,9 @@ class StagedInputsResult(MappingABC[str, StagedInput]):
 
     @property
     def failed_keys(self) -> list[str]:
-        return [key for key, output in self.outputs.items() if output.status == "failed"]
+        return [
+            key for key, output in self.outputs.items() if output.status == "failed"
+        ]
 
     @property
     def complete(self) -> bool:
@@ -1015,9 +1017,7 @@ def _stage_artifact_path(
 
         source_path = _resolve_staging_source_path(tracker, artifact=artifact)
         if source_path is None or not source_path.exists():
-            msg = (
-                f"[Consist] Cannot stage artifact {artifact.key!r}: source path missing."
-            )
+            msg = f"[Consist] Cannot stage artifact {artifact.key!r}: source path missing."
             logging.warning(msg)
             return _make_staged_output(
                 artifact,
@@ -1033,9 +1033,7 @@ def _stage_artifact_path(
             )
 
         if validate_content_hash == "always" and not artifact.hash:
-            msg = (
-                f"[Consist] Cannot validate artifact {artifact.key!r}: artifact.hash is missing."
-            )
+            msg = f"[Consist] Cannot validate artifact {artifact.key!r}: artifact.hash is missing."
             logging.warning(msg)
             return _make_staged_output(
                 artifact,
@@ -1082,9 +1080,7 @@ def _stage_artifact_path(
                     resolvable=False,
                 )
             if source_path.is_dir() != destination_path.is_dir():
-                msg = (
-                    f"Destination type mismatch for {destination_path}; refusing to overwrite."
-                )
+                msg = f"Destination type mismatch for {destination_path}; refusing to overwrite."
                 logging.warning("[Consist] %s", msg)
                 return _make_staged_output(
                     artifact,
@@ -1147,9 +1143,7 @@ def _stage_artifact_path(
             resolvable=False,
         )
     except (OSError, shutil.Error, RuntimeError, ValueError) as exc:
-        msg = (
-            f"[Consist] Failed to stage artifact {artifact.key!r} to {destination_path}: {exc}"
-        )
+        msg = f"[Consist] Failed to stage artifact {artifact.key!r} to {destination_path}: {exc}"
         logging.warning(msg)
         return _make_staged_output(
             artifact,
@@ -1175,7 +1169,9 @@ def stage_artifacts_to_destinations(
     staging helpers and run-time requested input materialization.
     """
     if mode != "copy":
-        raise ValueError(f"Unsupported staging mode {mode!r}; only 'copy' is supported.")
+        raise ValueError(
+            f"Unsupported staging mode {mode!r}; only 'copy' is supported."
+        )
 
     outputs: dict[str, StagedInput] = {}
     key_order: list[str] = []
@@ -1953,7 +1949,9 @@ def stage_inputs(
     for key, destination in destinations_by_key.items():
         artifact = inputs_by_key.get(key)
         if artifact is None:
-            raise KeyError(f"Input key {key!r} was not found in the resolved artifact set.")
+            raise KeyError(
+                f"Input key {key!r} was not found in the resolved artifact set."
+            )
         items.append((key, artifact, Path(destination)))
     return stage_artifacts_to_destinations(
         tracker,

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -261,7 +261,36 @@ class HydratedRunOutputsResult(MappingABC[str, HydratedRunOutput]):
 
 @dataclass(frozen=True, slots=True)
 class StagedInput:
-    """Per-key outcome for canonical input staging."""
+    """Per-key outcome for canonical input staging.
+
+    Attributes
+    ----------
+    key : str
+        Input key requested by the caller.
+    artifact : Artifact
+        Detached copy of the input artifact. When ``resolvable`` is ``True``,
+        the detached artifact's runtime ``abs_path`` points at the staged
+        destination so helpers like ``artifact.as_path()`` can be used
+        directly.
+    path : Path | None
+        Explicit staging destination, when one was known.
+    status : StagingStatus
+        One of:
+
+        - ``"staged"``: bytes were copied to the requested destination.
+        - ``"preserved_existing"``: destination already existed with matching
+          content and was reused.
+        - ``"missing_source"``: no readable source bytes were found for the
+          canonical artifact.
+        - ``"failed"``: staging was attempted but failed due to a collision,
+          policy check, or copy error.
+    message : str | None
+        Optional warning or error detail for ``"missing_source"`` and
+        ``"failed"`` outcomes.
+    resolvable : bool
+        Whether the returned detached artifact is immediately usable from the
+        staged destination.
+    """
 
     key: str
     artifact: Artifact
@@ -273,7 +302,13 @@ class StagedInput:
 
 @dataclass(slots=True)
 class StagedInputsResult(MappingABC[str, StagedInput]):
-    """Key-indexed result for canonical input staging."""
+    """Key-indexed result for canonical input staging.
+
+    This mapping preserves the caller's requested key order and answers the
+    practical questions for each requested input: what destination was used,
+    whether the staged artifact is immediately usable, and whether staging
+    copied bytes or reused an existing local path.
+    """
 
     outputs: dict[str, StagedInput] = field(default_factory=dict)
 
@@ -1134,7 +1169,11 @@ def stage_artifacts_to_destinations(
     validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
     allow_external_paths: bool | None = None,
 ) -> StagedInputsResult:
-    """Stage explicit artifact/destination pairs into a keyed result."""
+    """Stage explicit artifact/destination pairs into a keyed result.
+
+    This is the shared implementation used by both the public low-level
+    staging helpers and run-time requested input materialization.
+    """
     if mode != "copy":
         raise ValueError(f"Unsupported staging mode {mode!r}; only 'copy' is supported.")
 
@@ -1833,7 +1872,32 @@ def stage_artifact(
     validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
     allow_external_paths: bool | None = None,
 ) -> StagedInput:
-    """Stage one artifact to a requested filesystem destination."""
+    """Stage one artifact to a requested filesystem destination.
+
+    Parameters
+    ----------
+    tracker : Tracker
+        Tracker used to resolve canonical paths, allowed roots, and recovery
+        fallbacks.
+    artifact : Artifact
+        Canonical input artifact to stage.
+    destination : Path
+        Explicit local destination where the staged copy should exist.
+    mode : {"copy", "hardlink", "symlink"}, default "copy"
+        Staging mode. In v1, only ``"copy"`` is supported.
+    overwrite : bool, default False
+        Whether to replace an existing non-identical destination.
+    validate_content_hash : {"never", "if-present", "always"}, default "if-present"
+        Whether to validate staged file bytes against ``artifact.hash`` when a
+        file hash is available.
+    allow_external_paths : bool | None, default None
+        Override for the tracker's external-path policy.
+
+    Returns
+    -------
+    StagedInput
+        Detached artifact view plus the per-key staging outcome.
+    """
     return stage_artifacts_to_destinations(
         tracker,
         [(artifact.key, artifact, Path(destination))],
@@ -1854,7 +1918,33 @@ def stage_inputs(
     validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
     allow_external_paths: bool | None = None,
 ) -> StagedInputsResult:
-    """Stage multiple keyed artifacts to their requested destinations."""
+    """Stage multiple keyed artifacts to their requested destinations.
+
+    Parameters
+    ----------
+    tracker : Tracker
+        Tracker used to resolve canonical paths, allowed roots, and recovery
+        fallbacks.
+    inputs_by_key : Mapping[str, Artifact]
+        Resolved input artifact mapping, typically the same key space later
+        used for ``inputs={...}`` on ``run(...)`` or ``ScenarioContext.run(...)``.
+    destinations_by_key : Mapping[str, Path]
+        Explicit staging destinations keyed by input name.
+    mode : {"copy", "hardlink", "symlink"}, default "copy"
+        Staging mode. In v1, only ``"copy"`` is supported.
+    overwrite : bool, default False
+        Whether to replace an existing non-identical destination.
+    validate_content_hash : {"never", "if-present", "always"}, default "if-present"
+        Whether to validate staged file bytes against ``artifact.hash`` when a
+        file hash is available.
+    allow_external_paths : bool | None, default None
+        Override for the tracker's external-path policy.
+
+    Returns
+    -------
+    StagedInputsResult
+        Key-indexed staging outcomes in the caller's requested key order.
+    """
     if mode != "copy":
         raise ValueError(
             f"Unsupported staging mode {mode!r}; only 'copy' is supported."

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping as MappingABC
 from dataclasses import dataclass, field
+import hashlib
 import logging
 import os
 import shutil
@@ -40,6 +41,13 @@ HydrationStatus = Literal[
     "materialized_from_db",
     "preserved_existing",
     "skipped_unmapped",
+    "missing_source",
+    "failed",
+]
+
+StagingStatus = Literal[
+    "staged",
+    "preserved_existing",
     "missing_source",
     "failed",
 ]
@@ -252,6 +260,85 @@ class HydratedRunOutputsResult(MappingABC[str, HydratedRunOutput]):
 
 
 @dataclass(frozen=True, slots=True)
+class StagedInput:
+    """Per-key outcome for canonical input staging."""
+
+    key: str
+    artifact: Artifact
+    path: Path | None
+    status: StagingStatus
+    message: str | None = None
+    resolvable: bool = False
+
+
+@dataclass(slots=True)
+class StagedInputsResult(MappingABC[str, StagedInput]):
+    """Key-indexed result for canonical input staging."""
+
+    outputs: dict[str, StagedInput] = field(default_factory=dict)
+
+    def __getitem__(self, key: str) -> StagedInput:
+        return self.outputs[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.outputs)
+
+    def __len__(self) -> int:
+        return len(self.outputs)
+
+    def items(self):
+        return self.outputs.items()
+
+    def keys(self):
+        return self.outputs.keys()
+
+    def values(self):
+        return self.outputs.values()
+
+    @property
+    def paths(self) -> dict[str, Path]:
+        return {
+            key: output.path
+            for key, output in self.outputs.items()
+            if output.path is not None and output.resolvable
+        }
+
+    @property
+    def resolvable(self) -> dict[str, StagedInput]:
+        return {
+            key: output for key, output in self.outputs.items() if output.resolvable
+        }
+
+    @property
+    def failed_keys(self) -> list[str]:
+        return [key for key, output in self.outputs.items() if output.status == "failed"]
+
+    @property
+    def complete(self) -> bool:
+        incomplete_statuses = {"missing_source", "failed"}
+        return all(
+            output.status not in incomplete_statuses for output in self.outputs.values()
+        )
+
+    @property
+    def summary(self) -> str:
+        counts: dict[str, int] = {
+            "staged": 0,
+            "preserved_existing": 0,
+            "missing_source": 0,
+            "failed": 0,
+        }
+        for output in self.outputs.values():
+            counts[output.status] += 1
+        return (
+            f"staged={counts['staged']} "
+            f"preserved_existing={counts['preserved_existing']} "
+            f"missing_source={counts['missing_source']} "
+            f"failed={counts['failed']}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class PlannedMaterialization:
     artifact: Artifact
     keys: tuple[str, ...]
@@ -333,6 +420,29 @@ def _make_hydrated_output(
     )
 
 
+def _make_staged_output(
+    artifact: Artifact,
+    *,
+    status: StagingStatus,
+    path: Path | None,
+    message: str | None = None,
+    resolvable: bool,
+) -> StagedInput:
+    normalized_path = path.resolve() if path is not None else None
+    detached = _detach_artifact_for_hydration(
+        artifact,
+        hydrated_path=normalized_path if resolvable else None,
+    )
+    return StagedInput(
+        key=artifact.key,
+        artifact=detached,
+        path=normalized_path,
+        status=status,
+        message=message,
+        resolvable=resolvable,
+    )
+
+
 def _ordered_hydrated_results(
     key_order: Sequence[str],
     outputs: Mapping[str, HydratedRunOutput],
@@ -346,6 +456,21 @@ def _ordered_hydrated_results(
         if key not in ordered:
             ordered[key] = output
     return HydratedRunOutputsResult(outputs=ordered)
+
+
+def _ordered_staged_results(
+    key_order: Sequence[str],
+    outputs: Mapping[str, StagedInput],
+) -> StagedInputsResult:
+    ordered: dict[str, StagedInput] = {}
+    for key in key_order:
+        output = outputs.get(key)
+        if output is not None:
+            ordered[key] = output
+    for key, output in outputs.items():
+        if key not in ordered:
+            ordered[key] = output
+    return StagedInputsResult(outputs=ordered)
 
 
 def fold_hydrated_run_outputs_result(
@@ -383,6 +508,35 @@ def fold_hydrated_run_outputs_result(
 def _ensure_destination_not_symlink(path: Path) -> None:
     if path.exists() and path.is_symlink():
         raise ValueError(f"Symlink detected in destination path: {path}")
+
+
+def _compute_file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _compute_path_checksum(path: Path) -> str:
+    if path.is_dir():
+        digest = hashlib.sha256()
+        base = path.resolve()
+        for root, dirnames, filenames in os.walk(base):
+            dirnames.sort()
+            filenames.sort()
+            rel_root = Path(root).resolve().relative_to(base).as_posix()
+            digest.update(f"dir:{rel_root}".encode("utf-8"))
+            for dirname in dirnames:
+                rel_dir = Path(root, dirname).resolve().relative_to(base).as_posix()
+                digest.update(f"subdir:{rel_dir}".encode("utf-8"))
+            for filename in filenames:
+                file_path = Path(root, filename).resolve()
+                rel_file = file_path.relative_to(base).as_posix()
+                digest.update(f"file:{rel_file}".encode("utf-8"))
+                digest.update(_compute_file_sha256(file_path).encode("utf-8"))
+        return digest.hexdigest()
+    return _compute_file_sha256(path)
 
 
 def _copy_file_atomic(source: Path, destination: Path) -> bool:
@@ -749,6 +903,267 @@ def _source_identity(item: PlannedMaterialization) -> tuple[str, str]:
         assert item.source_path is not None
         return ("filesystem", str(item.source_path.resolve()))
     return ("db_export", str(item.artifact.id))
+
+
+def _resolve_staging_source_path(
+    tracker: "Tracker",
+    *,
+    artifact: Artifact,
+) -> Path | None:
+    try:
+        canonical_path = Path(tracker.resolve_uri(artifact.container_uri)).resolve()
+        if canonical_path.exists():
+            return canonical_path
+    except (OSError, ValueError, AttributeError):
+        pass
+
+    runtime_abs_path = artifact.abs_path
+    if runtime_abs_path:
+        candidate = Path(runtime_abs_path).resolve()
+        if candidate.exists():
+            return candidate
+
+    fs = getattr(tracker, "fs", None)
+    helper = getattr(fs, "get_remappable_relative_path", None)
+    if not callable(helper):
+        return None
+
+    relative_path = helper(artifact.container_uri)
+    if relative_path is None:
+        return None
+
+    if artifact.run_id:
+        owning_run = tracker.get_run(str(artifact.run_id))
+        if owning_run is not None:
+            _, source, _ = find_existing_recovery_source_path(
+                tracker,
+                artifact=artifact,
+                run=owning_run,
+                source_root=None,
+            )
+            if source is not None:
+                return source
+
+    for root in _artifact_recovery_roots(tracker, artifact=artifact):
+        candidate = (root / relative_path).resolve()
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _stage_artifact_path(
+    tracker: "Tracker",
+    *,
+    artifact: Artifact,
+    destination: Path,
+    overwrite: bool,
+    validate_content_hash: Literal["never", "if-present", "always"],
+    allow_external_paths: bool | None,
+) -> StagedInput:
+    allow_external = (
+        getattr(tracker, "allow_external_paths", False)
+        if allow_external_paths is None
+        else allow_external_paths
+    )
+    allowed_base = build_allowed_materialization_roots(
+        run_dir=Path(getattr(tracker, "run_dir")),
+        mounts=getattr(getattr(tracker, "fs", None), "mounts", None),
+        allow_external_paths=allow_external,
+    )
+
+    destination_path = Path(destination)
+
+    try:
+        _ensure_destination_not_symlink(destination_path)
+        destination_path = destination_path.resolve()
+        validate_allowed_materialization_destination(destination_path, allowed_base)
+
+        source_path = _resolve_staging_source_path(tracker, artifact=artifact)
+        if source_path is None or not source_path.exists():
+            msg = (
+                f"[Consist] Cannot stage artifact {artifact.key!r}: source path missing."
+            )
+            logging.warning(msg)
+            return _make_staged_output(
+                artifact,
+                status="missing_source",
+                path=destination_path,
+                message=msg,
+                resolvable=False,
+            )
+
+        if validate_content_hash not in {"never", "if-present", "always"}:
+            raise ValueError(
+                "validate_content_hash must be one of 'never', 'if-present', or 'always'."
+            )
+
+        if validate_content_hash == "always" and not artifact.hash:
+            msg = (
+                f"[Consist] Cannot validate artifact {artifact.key!r}: artifact.hash is missing."
+            )
+            logging.warning(msg)
+            return _make_staged_output(
+                artifact,
+                status="failed",
+                path=destination_path,
+                message=msg,
+                resolvable=False,
+            )
+
+        source_hash: str | None = None
+        if artifact.hash and validate_content_hash != "never":
+            source_hash = _compute_path_checksum(source_path)
+            if source_hash != artifact.hash:
+                msg = (
+                    f"[Consist] Content hash mismatch while staging {artifact.key!r}: "
+                    f"expected {artifact.hash}, found {source_hash}."
+                )
+                logging.warning(msg)
+                return _make_staged_output(
+                    artifact,
+                    status="failed",
+                    path=destination_path,
+                    message=msg,
+                    resolvable=False,
+                )
+
+        if source_path == destination_path:
+            return _make_staged_output(
+                artifact,
+                status="preserved_existing",
+                path=destination_path,
+                resolvable=True,
+            )
+
+        if destination_path.exists():
+            if destination_path.is_symlink():
+                msg = f"Symlink detected in destination path: {destination_path}"
+                logging.warning("[Consist] %s", msg)
+                return _make_staged_output(
+                    artifact,
+                    status="failed",
+                    path=destination_path,
+                    message=msg,
+                    resolvable=False,
+                )
+            if source_path.is_dir() != destination_path.is_dir():
+                msg = (
+                    f"Destination type mismatch for {destination_path}; refusing to overwrite."
+                )
+                logging.warning("[Consist] %s", msg)
+                return _make_staged_output(
+                    artifact,
+                    status="failed",
+                    path=destination_path,
+                    message=msg,
+                    resolvable=False,
+                )
+
+            if not overwrite:
+                if source_hash is None:
+                    source_hash = _compute_path_checksum(source_path)
+                destination_hash = _compute_path_checksum(destination_path)
+                if source_hash == destination_hash:
+                    return _make_staged_output(
+                        artifact,
+                        status="preserved_existing",
+                        path=destination_path,
+                        resolvable=True,
+                    )
+
+                msg = f"Destination already exists and differs for {destination_path}; "
+                msg += "refusing to overwrite."
+                logging.warning("[Consist] %s", msg)
+                return _make_staged_output(
+                    artifact,
+                    status="failed",
+                    path=destination_path,
+                    message=msg,
+                    resolvable=False,
+                )
+
+        materialized, skipped_existing = _materialize_path(
+            source=source_path,
+            destination=destination_path,
+            preserve_existing=False,
+        )
+        if skipped_existing:
+            return _make_staged_output(
+                artifact,
+                status="preserved_existing",
+                path=destination_path,
+                resolvable=True,
+            )
+        if materialized:
+            return _make_staged_output(
+                artifact,
+                status="staged",
+                path=destination_path,
+                resolvable=True,
+            )
+
+        msg = f"Failed to stage artifact {artifact.key!r} to {destination_path}."
+        logging.warning("[Consist] %s", msg)
+        return _make_staged_output(
+            artifact,
+            status="failed",
+            path=destination_path,
+            message=msg,
+            resolvable=False,
+        )
+    except (OSError, shutil.Error, RuntimeError, ValueError) as exc:
+        msg = (
+            f"[Consist] Failed to stage artifact {artifact.key!r} to {destination_path}: {exc}"
+        )
+        logging.warning(msg)
+        return _make_staged_output(
+            artifact,
+            status="failed",
+            path=destination_path,
+            message=str(exc),
+            resolvable=False,
+        )
+
+
+def stage_artifacts_to_destinations(
+    tracker: "Tracker",
+    items: Sequence[tuple[str, Artifact, Path]],
+    *,
+    mode: Literal["copy", "hardlink", "symlink"] = "copy",
+    overwrite: bool = False,
+    validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+    allow_external_paths: bool | None = None,
+) -> StagedInputsResult:
+    """Stage explicit artifact/destination pairs into a keyed result."""
+    if mode != "copy":
+        raise ValueError(f"Unsupported staging mode {mode!r}; only 'copy' is supported.")
+
+    outputs: dict[str, StagedInput] = {}
+    key_order: list[str] = []
+    for key, artifact, destination in items:
+        key_order.append(key)
+        if artifact.key != key:
+            msg = (
+                f"Resolved artifact key {artifact.key!r} does not match requested "
+                f"staging key {key!r}."
+            )
+            outputs[key] = _make_staged_output(
+                artifact,
+                status="failed",
+                path=Path(destination),
+                message=msg,
+                resolvable=False,
+            )
+            continue
+        outputs[key] = _stage_artifact_path(
+            tracker,
+            artifact=artifact,
+            destination=Path(destination),
+            overwrite=overwrite,
+            validate_content_hash=validate_content_hash,
+            allow_external_paths=allow_external_paths,
+        )
+    return _ordered_staged_results(tuple(key_order), outputs)
 
 
 def plan_run_output_hydration(
@@ -1406,6 +1821,58 @@ def build_materialize_items_for_keys(
         if artifact is not None:
             items.append((artifact, Path(dest)))
     return items
+
+
+def stage_artifact(
+    tracker: "Tracker",
+    artifact: Artifact,
+    destination: Path,
+    *,
+    mode: Literal["copy", "hardlink", "symlink"] = "copy",
+    overwrite: bool = False,
+    validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+    allow_external_paths: bool | None = None,
+) -> StagedInput:
+    """Stage one artifact to a requested filesystem destination."""
+    return stage_artifacts_to_destinations(
+        tracker,
+        [(artifact.key, artifact, Path(destination))],
+        mode=mode,
+        overwrite=overwrite,
+        validate_content_hash=validate_content_hash,
+        allow_external_paths=allow_external_paths,
+    )[artifact.key]
+
+
+def stage_inputs(
+    tracker: "Tracker",
+    inputs_by_key: Mapping[str, Artifact],
+    destinations_by_key: Mapping[str, Path],
+    *,
+    mode: Literal["copy", "hardlink", "symlink"] = "copy",
+    overwrite: bool = False,
+    validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+    allow_external_paths: bool | None = None,
+) -> StagedInputsResult:
+    """Stage multiple keyed artifacts to their requested destinations."""
+    if mode != "copy":
+        raise ValueError(
+            f"Unsupported staging mode {mode!r}; only 'copy' is supported."
+        )
+    items: list[tuple[str, Artifact, Path]] = []
+    for key, destination in destinations_by_key.items():
+        artifact = inputs_by_key.get(key)
+        if artifact is None:
+            raise KeyError(f"Input key {key!r} was not found in the resolved artifact set.")
+        items.append((key, artifact, Path(destination)))
+    return stage_artifacts_to_destinations(
+        tracker,
+        items,
+        mode=mode,
+        overwrite=overwrite,
+        validate_content_hash=validate_content_hash,
+        allow_external_paths=allow_external_paths,
+    )
 
 
 def materialize_ingested_artifact_from_db(

--- a/src/consist/core/run_invocation.py
+++ b/src/consist/core/run_invocation.py
@@ -142,8 +142,8 @@ class ResolvedRunInvocation:
     input_binding: InputBindingMode
     load_inputs: Optional[bool]
     input_paths: Optional[Mapping[str, PathLike]]
-    input_materialization: Optional[str]
-    input_materialization_mode: Optional[str]
+    input_materialization: Optional[Literal["requested"]]
+    input_materialization_mode: Optional[Literal["copy"]]
     executor: Literal["python", "container"]
     container: Optional[Mapping[str, Any]]
     runtime_kwargs: Optional[Dict[str, Any]]

--- a/src/consist/core/run_invocation.py
+++ b/src/consist/core/run_invocation.py
@@ -97,6 +97,12 @@ class ResolvedRunInvocation:
         Effective input binding mode for callable execution.
     load_inputs : Optional[bool]
         Effective legacy input auto-loading preference retained for compatibility.
+    input_paths : Optional[Mapping[str, PathLike]]
+        Requested destination paths for explicit input staging.
+    input_materialization : Optional[Literal["requested"]]
+        Requested input-staging policy.
+    input_materialization_mode : Optional[Literal["copy"]]
+        Requested staging transport mode.
     executor : Literal["python", "container"]
         Effective execution backend.
     container : Optional[Mapping[str, Any]]
@@ -135,6 +141,9 @@ class ResolvedRunInvocation:
     output_missing: Literal["warn", "error", "ignore"]
     input_binding: InputBindingMode
     load_inputs: Optional[bool]
+    input_paths: Optional[Mapping[str, PathLike]]
+    input_materialization: Optional[str]
+    input_materialization_mode: Optional[str]
     executor: Literal["python", "container"]
     container: Optional[Mapping[str, Any]]
     runtime_kwargs: Optional[Dict[str, Any]]
@@ -355,6 +364,9 @@ def resolve_run_invocation(
     output_missing = merged_options.output_missing
     input_binding = merged_options.input_binding
     load_inputs = merged_options.load_inputs
+    requested_input_paths = merged_options.input_paths
+    requested_input_materialization = merged_options.input_materialization
+    requested_input_materialization_mode = merged_options.input_materialization_mode
     executor = merged_options.executor
     container = merged_options.container
     runtime_kwargs = merged_options.runtime_kwargs
@@ -556,6 +568,58 @@ def resolve_run_invocation(
     if resolved_validate_cached_outputs is None:
         resolved_validate_cached_outputs = "lazy"
 
+    if requested_input_materialization is not None:
+        if requested_input_materialization != "requested":
+            raise ValueError(
+                format_problem_cause_fix(
+                    problem=(
+                        "execution_options.input_materialization must be 'requested'. "
+                        f"Received {requested_input_materialization!r}."
+                    ),
+                    cause="An unsupported input materialization policy was configured.",
+                    fix=(
+                        "Use execution_options=ExecutionOptions("
+                        "input_materialization='requested', input_paths={...})."
+                    ),
+                )
+            )
+        if requested_input_paths is None:
+            raise ValueError(
+                format_problem_cause_fix(
+                    problem=(
+                        "execution_options.input_materialization='requested' "
+                        "requires input_paths."
+                    ),
+                    cause=(
+                        "Requested input staging needs explicit destination paths."
+                    ),
+                    fix=(
+                        "Provide execution_options=ExecutionOptions("
+                        "input_materialization='requested', input_paths={...})."
+                    ),
+                )
+            )
+    else:
+        requested_input_paths = None
+
+    if (
+        requested_input_materialization_mode is not None
+        and requested_input_materialization_mode != "copy"
+    ):
+        raise ValueError(
+            format_problem_cause_fix(
+                problem=(
+                    "execution_options.input_materialization_mode must be 'copy'. "
+                    f"Received {requested_input_materialization_mode!r}."
+                ),
+                cause="Only copy-based requested input staging is supported.",
+                fix=(
+                    "Use execution_options=ExecutionOptions("
+                    "input_materialization_mode='copy')."
+                ),
+            )
+        )
+
     if output_mismatch not in {"warn", "error", "ignore"}:
         raise ValueError(
             format_problem_cause_fix(
@@ -591,6 +655,33 @@ def resolve_run_invocation(
         inputs=resolved.inputs,
     )
 
+    if (
+        requested_input_materialization == "requested"
+        and requested_input_paths is not None
+        and isinstance(resolved.inputs, Mapping)
+    ):
+        requested_keys = set(requested_input_paths.keys())
+        resolved_keys = {str(key) for key in resolved.inputs.keys()}
+        missing_keys = sorted(requested_keys - resolved_keys)
+        if missing_keys:
+            raise ValueError(
+                format_problem_cause_fix(
+                    problem=(
+                        "execution_options.input_paths contains keys that are not "
+                        "present in the resolved inputs: "
+                        f"{missing_keys}."
+                    ),
+                    cause=(
+                        "Requested input staging can only target resolved input "
+                        "artifact keys."
+                    ),
+                    fix=(
+                        "Use keys from the run inputs mapping, or remove the "
+                        "missing entries from execution_options.input_paths."
+                    ),
+                )
+            )
+
     return ResolvedRunInvocation(
         name=resolved.name,
         model=resolved.model,
@@ -624,6 +715,11 @@ def resolve_run_invocation(
         output_missing=cast(Literal["warn", "error", "ignore"], output_missing),
         input_binding=resolved_input_binding,
         load_inputs=resolved.load_inputs,
+        input_paths=(
+            dict(requested_input_paths) if requested_input_paths is not None else None
+        ),
+        input_materialization=requested_input_materialization,
+        input_materialization_mode=requested_input_materialization_mode,
         executor=cast(Literal["python", "container"], executor),
         container=container,
         runtime_kwargs=runtime_kwargs_dict,

--- a/src/consist/core/run_invocation.py
+++ b/src/consist/core/run_invocation.py
@@ -590,9 +590,7 @@ def resolve_run_invocation(
                         "execution_options.input_materialization='requested' "
                         "requires input_paths."
                     ),
-                    cause=(
-                        "Requested input staging needs explicit destination paths."
-                    ),
+                    cause=("Requested input staging needs explicit destination paths."),
                     fix=(
                         "Provide execution_options=ExecutionOptions("
                         "input_materialization='requested', input_paths={...})."

--- a/src/consist/core/run_options.py
+++ b/src/consist/core/run_options.py
@@ -27,6 +27,14 @@ LEGACY_POLICY_KWARG_REPLACEMENTS: Final[dict[str, str]] = {
     "load_inputs": "execution_options=ExecutionOptions(load_inputs=...)",
     "executor": "execution_options=ExecutionOptions(executor=...)",
     "container": "execution_options=ExecutionOptions(container=...)",
+    "input_binding": "execution_options=ExecutionOptions(input_binding=...)",
+    "input_paths": "execution_options=ExecutionOptions(input_paths=...)",
+    "input_materialization": (
+        "execution_options=ExecutionOptions(input_materialization=...)"
+    ),
+    "input_materialization_mode": (
+        "execution_options=ExecutionOptions(input_materialization_mode=...)"
+    ),
     "runtime_kwargs": "execution_options=ExecutionOptions(runtime_kwargs=...)",
     "inject_context": "execution_options=ExecutionOptions(inject_context=...)",
 }
@@ -54,6 +62,9 @@ class ResolvedRunOptions:
     output_missing: Optional[str]
     input_binding: Optional[InputBindingMode]
     load_inputs: Optional[bool]
+    input_paths: Optional[Mapping[str, Any]]
+    input_materialization: Optional[str]
+    input_materialization_mode: Optional[str]
     executor: Optional[str]
     container: Optional[Mapping[str, Any]]
     runtime_kwargs: Optional[Mapping[str, Any]]
@@ -118,6 +129,9 @@ def resolve_runtime_kwargs_alias(
     return ExecutionOptions(
         input_binding=execution_options.input_binding,
         load_inputs=execution_options.load_inputs,
+        input_paths=execution_options.input_paths,
+        input_materialization=execution_options.input_materialization,
+        input_materialization_mode=execution_options.input_materialization_mode,
         executor=execution_options.executor,
         container=execution_options.container,
         runtime_kwargs=runtime_kwargs,
@@ -154,6 +168,9 @@ def merge_run_options(
         output_missing=output_obj.output_missing,
         input_binding=exec_obj.input_binding,
         load_inputs=exec_obj.load_inputs,
+        input_paths=exec_obj.input_paths,
+        input_materialization=exec_obj.input_materialization,
+        input_materialization_mode=exec_obj.input_materialization_mode,
         executor=exec_obj.executor,
         container=exec_obj.container,
         runtime_kwargs=exec_obj.runtime_kwargs,

--- a/src/consist/core/run_options.py
+++ b/src/consist/core/run_options.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Final, Mapping, Optional, Union
+from typing import Any, Final, Literal, Mapping, Optional, Union
 
 from consist.core.error_messages import format_problem_cause_fix
 from consist.types import (
@@ -63,8 +63,8 @@ class ResolvedRunOptions:
     input_binding: Optional[InputBindingMode]
     load_inputs: Optional[bool]
     input_paths: Optional[Mapping[str, Any]]
-    input_materialization: Optional[str]
-    input_materialization_mode: Optional[str]
+    input_materialization: Optional[Literal["requested"]]
+    input_materialization_mode: Optional[Literal["copy"]]
     executor: Optional[str]
     container: Optional[Mapping[str, Any]]
     runtime_kwargs: Optional[Mapping[str, Any]]

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -1501,7 +1501,12 @@ class Tracker:
             Grouped output policies (`output_mismatch`, `output_missing`).
         execution_options : Optional[ExecutionOptions], optional
             Grouped execution controls (`input_binding`, legacy `load_inputs`,
-            `executor`, `container`, `runtime_kwargs`, `inject_context`).
+            `input_materialization`, `input_paths`,
+            `input_materialization_mode`, `executor`, `container`,
+            `runtime_kwargs`, `inject_context`). Use requested input
+            materialization with path-bound runs when a callable or external
+            tool expects inputs at specific local paths on both cache misses
+            and cache hits.
         runtime_kwargs : Optional[Mapping[str, Any]], optional
             Top-level alias for `execution_options.runtime_kwargs`. This is
             mutually exclusive with
@@ -4083,6 +4088,11 @@ class Tracker:
         does not create a new tracked artifact identity; it returns a detached
         staged artifact view whose runtime path points at the staged location
         when successful.
+
+        Prefer ``execution_options=ExecutionOptions(
+        input_materialization="requested", input_paths={...})`` on
+        ``Tracker.run(...)`` when you want the staging side effect to happen as
+        part of a normal run lifecycle.
         """
         return stage_artifact_core(
             self,
@@ -4106,6 +4116,11 @@ class Tracker:
     ) -> "StagedInputsResult":
         """
         Stage multiple canonical input artifacts to explicit local destinations.
+
+        This low-level helper is most useful for custom orchestration or
+        preflight setup. Standard workflow code should usually request the same
+        behavior through ``ExecutionOptions`` on ``run(...)`` or
+        ``ScenarioContext.run(...)``.
         """
         normalized_destinations = {
             str(key): Path(destination)

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -81,6 +81,8 @@ from consist.core.materialize import (
     fold_hydrated_run_outputs_result,
     hydrate_run_outputs as hydrate_run_outputs_core,
     materialize_artifacts,
+    stage_artifact as stage_artifact_core,
+    stage_inputs as stage_inputs_core,
 )
 from consist.core.materialize_options import (
     VALID_MATERIALIZE_DB_FALLBACK as _VALID_MATERIALIZE_DB_FALLBACK,
@@ -119,7 +121,12 @@ from consist.types import (
 
 if TYPE_CHECKING:
     from consist.core.coupler import Coupler
-    from consist.core.materialize import HydratedRunOutputsResult, MaterializationResult
+    from consist.core.materialize import (
+        HydratedRunOutputsResult,
+        MaterializationResult,
+        StagedInput,
+        StagedInputsResult,
+    )
     from consist.core.step_context import StepContext
     from consist.runset import RunSet
 
@@ -4058,6 +4065,61 @@ class Tracker:
             on_missing=on_missing,
         )
         return result.get(artifact.key)
+
+    def stage_artifact(
+        self,
+        artifact: Artifact,
+        *,
+        destination: str | Path,
+        mode: Literal["copy", "hardlink", "symlink"] = "copy",
+        overwrite: bool = False,
+        validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+        allow_external_paths: Optional[bool] = None,
+    ) -> "StagedInput":
+        """
+        Stage one canonical input artifact to an explicit local destination.
+
+        This is the low-level input-side equivalent of output hydration. It
+        does not create a new tracked artifact identity; it returns a detached
+        staged artifact view whose runtime path points at the staged location
+        when successful.
+        """
+        return stage_artifact_core(
+            self,
+            artifact,
+            Path(destination),
+            mode=mode,
+            overwrite=overwrite,
+            validate_content_hash=validate_content_hash,
+            allow_external_paths=allow_external_paths,
+        )
+
+    def stage_inputs(
+        self,
+        inputs_by_key: Mapping[str, Artifact],
+        *,
+        destinations_by_key: Mapping[str, str | Path],
+        mode: Literal["copy", "hardlink", "symlink"] = "copy",
+        overwrite: bool = False,
+        validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+        allow_external_paths: Optional[bool] = None,
+    ) -> "StagedInputsResult":
+        """
+        Stage multiple canonical input artifacts to explicit local destinations.
+        """
+        normalized_destinations = {
+            str(key): Path(destination)
+            for key, destination in destinations_by_key.items()
+        }
+        return stage_inputs_core(
+            self,
+            inputs_by_key,
+            normalized_destinations,
+            mode=mode,
+            overwrite=overwrite,
+            validate_content_hash=validate_content_hash,
+            allow_external_paths=allow_external_paths,
+        )
 
     # --- Retrieval Helpers ---
 

--- a/src/consist/core/tracker_lifecycle.py
+++ b/src/consist/core/tracker_lifecycle.py
@@ -26,6 +26,7 @@ from consist.core.cache import (
     CacheValidationContext,
     hydrate_cache_hit_outputs,
     materialize_missing_inputs,
+    materialize_requested_inputs,
     parse_materialize_cached_outputs_kwargs,
     validate_cached_run_outputs,
 )
@@ -247,6 +248,37 @@ class RunLifecycleCoordinator:
             materialize_cached_outputs_source_root,
             validate_cached_outputs,
         ) = parse_materialize_cached_outputs_kwargs(kwargs)
+        requested_input_paths_raw = kwargs.pop("requested_input_paths", None)
+        requested_input_materialization = kwargs.pop(
+            "requested_input_materialization", None
+        )
+        requested_input_materialization_mode = kwargs.pop(
+            "requested_input_materialization_mode", None
+        )
+
+        requested_input_paths: Optional[Dict[str, Path]] = None
+        if requested_input_paths_raw is not None:
+            requested_input_paths = {
+                str(key): Path(value)
+                for key, value in dict(requested_input_paths_raw).items()
+            }
+        if (
+            requested_input_materialization_mode is not None
+            and requested_input_materialization_mode != "copy"
+        ):
+            raise ValueError(
+                format_problem_cause_fix(
+                    problem=(
+                        "requested_input_materialization_mode must be 'copy'. "
+                        f"Received {requested_input_materialization_mode!r}."
+                    ),
+                    cause="Only copy-based requested input staging is supported.",
+                    fix=(
+                        "Use execution_options=ExecutionOptions("
+                        "input_materialization_mode='copy')."
+                    ),
+                )
+            )
 
         raw_config_model: Optional[BaseModel] = (
             config if isinstance(config, BaseModel) else None
@@ -390,6 +422,15 @@ class RunLifecycleCoordinator:
         if run.meta is None:
             run.meta = {}
         run.meta.setdefault("mounts", dict(tracker.mounts))
+        if requested_input_materialization == "requested" and requested_input_paths:
+            run.meta["requested_input_staging"] = {
+                "materialization": requested_input_materialization,
+                "mode": requested_input_materialization_mode or "copy",
+                "input_paths": {
+                    key: str(Path(value).resolve())
+                    for key, value in requested_input_paths.items()
+                },
+            }
 
         push_tracker(tracker)
         tracker.current_consist = ConsistRecord(run=run, config=config_dict)
@@ -402,6 +443,16 @@ class RunLifecycleCoordinator:
                 materialize_cached_outputs_source_root
             ),
             validate_cached_outputs=validate_cached_outputs,
+            requested_input_paths=requested_input_paths,
+            requested_input_materialization=requested_input_materialization,
+            requested_input_materialization_mode=(
+                requested_input_materialization_mode
+                or (
+                    "copy"
+                    if requested_input_materialization == "requested"
+                    else None
+                )
+            ),
         )
 
         facet_dict = tracker.config_facets.resolve_facet_dict(
@@ -563,6 +614,14 @@ class RunLifecycleCoordinator:
                 tracker=cast(CacheMaterializationContext, tracker),
                 options=tracker._active_run_cache_options,
             )
+
+        if requested_input_materialization == "requested" and requested_input_paths:
+            staged_inputs = materialize_requested_inputs(
+                tracker=cast(CacheMaterializationContext, tracker),
+                options=tracker._active_run_cache_options,
+            )
+            if staged_inputs:
+                run.meta["staged_inputs"] = staged_inputs
 
         tracker._flush_json()
         if cached_output_ids and tracker.db:

--- a/src/consist/core/tracker_lifecycle.py
+++ b/src/consist/core/tracker_lifecycle.py
@@ -447,11 +447,7 @@ class RunLifecycleCoordinator:
             requested_input_materialization=requested_input_materialization,
             requested_input_materialization_mode=(
                 requested_input_materialization_mode
-                or (
-                    "copy"
-                    if requested_input_materialization == "requested"
-                    else None
-                )
+                or ("copy" if requested_input_materialization == "requested" else None)
             ),
         )
 

--- a/src/consist/core/tracker_orchestration.py
+++ b/src/consist/core/tracker_orchestration.py
@@ -1147,12 +1147,9 @@ class RunTraceCoordinator:
                     if get_tracker_ref(artifact) is None:
                         set_tracker_ref(artifact, tracker)
                     if input_binding == "paths":
-                        artifact_path = None
                         if requested_input_paths and param_name in requested_input_paths:
                             artifact_path = Path(requested_input_paths[param_name])
-                        elif artifact.abs_path is not None:
-                            artifact_path = Path(artifact.abs_path)
-                        if artifact_path is None:
+                        else:
                             artifact_path = artifact.path
                         if not artifact_path.exists():
                             raise ValueError(

--- a/src/consist/core/tracker_orchestration.py
+++ b/src/consist/core/tracker_orchestration.py
@@ -138,6 +138,9 @@ class RunInvocationContext:
     input_binding: InputBindingMode
     resolved_inputs: List[ArtifactRef]
     input_artifacts_by_key: Dict[str, Artifact]
+    requested_input_paths: Optional[Dict[str, Path]]
+    requested_input_materialization: Optional[str]
+    requested_input_materialization_mode: Optional[str]
     run_id: str
     start_kwargs: Dict[str, Any]
 
@@ -270,6 +273,9 @@ class RunTraceCoordinator:
         materialize_cached_output_paths: Optional[Dict[str, Path]] = None,
         materialize_cached_outputs_dir: Optional[Path] = None,
         materialize_cached_outputs_source_root: Optional[Path] = None,
+        requested_input_paths: Optional[Mapping[str, Any]] = None,
+        requested_input_materialization: Optional[str] = None,
+        requested_input_materialization_mode: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Build the kwargs payload passed into ``tracker.start_run``."""
         start_kwargs: Dict[str, Any] = {
@@ -297,6 +303,21 @@ class RunTraceCoordinator:
             )
         if code_identity_callable is not None:
             start_kwargs["_consist_code_identity_callable"] = code_identity_callable
+        if requested_input_materialization is not None:
+            start_kwargs["requested_input_materialization"] = (
+                requested_input_materialization
+            )
+        if requested_input_paths is not None:
+            start_kwargs["requested_input_paths"] = {
+                str(key): str(Path(value)) for key, value in requested_input_paths.items()
+            }
+        requested_mode = requested_input_materialization_mode or (
+            "copy" if requested_input_materialization == "requested" else None
+        )
+        if requested_mode is not None:
+            start_kwargs["requested_input_materialization_mode"] = (
+                requested_mode
+            )
         optional_values: Dict[str, Any] = {
             "cache_version": invocation.cache_version,
             "phase": phase,
@@ -460,6 +481,9 @@ class RunTraceCoordinator:
             adapter=invocation.adapter,
         )
         input_binding = invocation.input_binding
+        requested_input_paths = invocation.input_paths
+        requested_input_materialization = invocation.input_materialization
+        requested_input_materialization_mode = invocation.input_materialization_mode
         if (
             input_binding != "none"
             and invocation.inputs is not None
@@ -506,8 +530,35 @@ class RunTraceCoordinator:
             tracker,
             invocation.inputs,
             depends_on,
-            include_keyed_artifacts=invocation.executor == "python",
+            include_keyed_artifacts=(
+                invocation.executor == "python"
+                or requested_input_materialization == "requested"
+            ),
         )
+        if (
+            requested_input_materialization == "requested"
+            and requested_input_paths is not None
+        ):
+            missing_requested_keys = sorted(
+                set(requested_input_paths) - set(input_artifacts_by_key)
+            )
+            if missing_requested_keys:
+                raise ValueError(
+                    format_problem_cause_fix(
+                        problem=(
+                            "execution_options.input_paths contains keys that are "
+                            "not present in the resolved input artifact set."
+                        ),
+                        cause=(
+                            "Requested input staging only works for explicitly keyed "
+                            "input artifacts."
+                        ),
+                        fix=(
+                            "Use input_paths keys drawn from the resolved inputs "
+                            f"mapping. Unknown keys: {missing_requested_keys}."
+                        ),
+                    )
+                )
 
         if run_id is None:
             run_id = f"{resolved_name}_{uuid.uuid4().hex[:8]}"
@@ -568,6 +619,11 @@ class RunTraceCoordinator:
                 if invocation.materialize_cached_outputs_source_root is not None
                 else None
             ),
+            requested_input_paths=requested_input_paths,
+            requested_input_materialization=requested_input_materialization,
+            requested_input_materialization_mode=(
+                requested_input_materialization_mode
+            ),
         )
 
         return RunInvocationContext(
@@ -586,6 +642,15 @@ class RunTraceCoordinator:
             input_binding=input_binding,
             resolved_inputs=resolved_inputs,
             input_artifacts_by_key=input_artifacts_by_key,
+            requested_input_paths=(
+                {str(key): Path(value) for key, value in requested_input_paths.items()}
+                if requested_input_paths is not None
+                else None
+            ),
+            requested_input_materialization=requested_input_materialization,
+            requested_input_materialization_mode=(
+                requested_input_materialization_mode
+            ),
             run_id=run_id,
             start_kwargs=start_kwargs,
         )
@@ -995,6 +1060,7 @@ class RunTraceCoordinator:
         inject_context: Optional[Union[bool, str]],
         input_binding: InputBindingMode,
         input_artifacts_by_key: Dict[str, Artifact],
+        requested_input_paths: Optional[Mapping[str, Path]],
         capture_dir: Optional[Path],
         capture_pattern: str,
     ) -> tuple[Any, Dict[str, Artifact]]:
@@ -1081,7 +1147,13 @@ class RunTraceCoordinator:
                     if get_tracker_ref(artifact) is None:
                         set_tracker_ref(artifact, tracker)
                     if input_binding == "paths":
-                        artifact_path = artifact.as_path(tracker=tracker)
+                        artifact_path = None
+                        if requested_input_paths and param_name in requested_input_paths:
+                            artifact_path = Path(requested_input_paths[param_name])
+                        elif artifact.abs_path is not None:
+                            artifact_path = Path(artifact.abs_path)
+                        if artifact_path is None:
+                            artifact_path = artifact.path
                         if not artifact_path.exists():
                             raise ValueError(
                                 format_problem_cause_fix(
@@ -1333,6 +1405,7 @@ class RunTraceCoordinator:
         input_binding = context.input_binding
         resolved_inputs = context.resolved_inputs
         input_artifacts_by_key = context.input_artifacts_by_key
+        requested_input_paths = context.requested_input_paths
         run_id = context.run_id
         start_kwargs = context.start_kwargs
 
@@ -1407,6 +1480,7 @@ class RunTraceCoordinator:
                 inject_context=inject_context,
                 input_binding=input_binding,
                 input_artifacts_by_key=input_artifacts_by_key,
+                requested_input_paths=requested_input_paths,
                 capture_dir=capture_dir,
                 capture_pattern=capture_pattern,
             )

--- a/src/consist/core/tracker_orchestration.py
+++ b/src/consist/core/tracker_orchestration.py
@@ -309,15 +309,14 @@ class RunTraceCoordinator:
             )
         if requested_input_paths is not None:
             start_kwargs["requested_input_paths"] = {
-                str(key): str(Path(value)) for key, value in requested_input_paths.items()
+                str(key): str(Path(value))
+                for key, value in requested_input_paths.items()
             }
         requested_mode = requested_input_materialization_mode or (
             "copy" if requested_input_materialization == "requested" else None
         )
         if requested_mode is not None:
-            start_kwargs["requested_input_materialization_mode"] = (
-                requested_mode
-            )
+            start_kwargs["requested_input_materialization_mode"] = requested_mode
         optional_values: Dict[str, Any] = {
             "cache_version": invocation.cache_version,
             "phase": phase,
@@ -621,9 +620,7 @@ class RunTraceCoordinator:
             ),
             requested_input_paths=requested_input_paths,
             requested_input_materialization=requested_input_materialization,
-            requested_input_materialization_mode=(
-                requested_input_materialization_mode
-            ),
+            requested_input_materialization_mode=(requested_input_materialization_mode),
         )
 
         return RunInvocationContext(
@@ -648,9 +645,7 @@ class RunTraceCoordinator:
                 else None
             ),
             requested_input_materialization=requested_input_materialization,
-            requested_input_materialization_mode=(
-                requested_input_materialization_mode
-            ),
+            requested_input_materialization_mode=(requested_input_materialization_mode),
             run_id=run_id,
             start_kwargs=start_kwargs,
         )
@@ -1147,7 +1142,10 @@ class RunTraceCoordinator:
                     if get_tracker_ref(artifact) is None:
                         set_tracker_ref(artifact, tracker)
                     if input_binding == "paths":
-                        if requested_input_paths and param_name in requested_input_paths:
+                        if (
+                            requested_input_paths
+                            and param_name in requested_input_paths
+                        ):
                             artifact_path = Path(requested_input_paths[param_name])
                         else:
                             artifact_path = artifact.path

--- a/src/consist/core/workflow.py
+++ b/src/consist/core/workflow.py
@@ -1036,6 +1036,11 @@ class ScenarioContext:
             ),
             execution_options=ExecutionOptions(
                 input_binding=resolved_input_binding,
+                input_paths=resolved_invocation.input_paths,
+                input_materialization=resolved_invocation.input_materialization,
+                input_materialization_mode=(
+                    resolved_invocation.input_materialization_mode
+                ),
                 executor=resolved_executor,
                 container=resolved_container,
                 runtime_kwargs=runtime_kwargs_dict,

--- a/src/consist/types.py
+++ b/src/consist/types.py
@@ -106,6 +106,9 @@ class ExecutionOptions:
 
     load_inputs: Optional[bool] = None
     input_binding: Optional[InputBindingMode] = None
+    input_paths: Optional[Mapping[str, PathLike]] = None
+    input_materialization: Optional[Literal["requested"]] = None
+    input_materialization_mode: Optional[Literal["copy"]] = None
     executor: Optional[Literal["python", "container"]] = None
     container: Optional[Mapping[str, Any]] = None
     runtime_kwargs: Optional[Mapping[str, Any]] = None

--- a/src/consist/types.py
+++ b/src/consist/types.py
@@ -102,6 +102,34 @@ class ExecutionOptions:
 
     These are runtime controls and do not affect cache identity unless the
     corresponding primitive kwargs already do.
+
+    Attributes
+    ----------
+    load_inputs : Optional[bool]
+        Legacy compatibility switch for automatic input loading. Prefer
+        ``input_binding=...`` for new code.
+    input_binding : Optional[InputBindingMode]
+        Controls what the callable receives for declared named inputs:
+        ``"paths"``, ``"loaded"``, or ``"none"``.
+    input_paths : Optional[Mapping[str, PathLike]]
+        Explicit per-input local destinations used when requested input
+        materialization is enabled. Keys must refer to resolved named inputs.
+    input_materialization : Optional[Literal["requested"]]
+        Enables run-time input staging for the keys listed in ``input_paths``.
+        Use this with path-bound runs when a tool expects inputs at specific
+        local paths, including on cache hits.
+    input_materialization_mode : Optional[Literal["copy"]]
+        Strategy for requested input materialization. In v1, only ``"copy"``
+        is supported.
+    executor : Optional[Literal["python", "container"]]
+        Selects the execution backend.
+    container : Optional[Mapping[str, Any]]
+        Backend-specific container configuration when ``executor="container"``.
+    runtime_kwargs : Optional[Mapping[str, Any]]
+        Runtime-only keyword arguments forwarded to the callable without
+        affecting cache identity.
+    inject_context : Optional[Union[bool, str]]
+        Whether to inject a ``RunContext`` into the callable.
     """
 
     load_inputs: Optional[bool] = None

--- a/tests/unit/api/test_public_exports.py
+++ b/tests/unit/api/test_public_exports.py
@@ -1,8 +1,20 @@
-from consist import HydratedRunOutput, HydratedRunOutputsResult, MaterializationResult
+from consist import (
+    HydratedRunOutput,
+    HydratedRunOutputsResult,
+    MaterializationResult,
+    StagedInput,
+    StagedInputsResult,
+    stage_artifact,
+    stage_inputs,
+)
+from consist.api import stage_artifact as stage_artifact_api
+from consist.api import stage_inputs as stage_inputs_api
 from consist.core.materialize import (
     HydratedRunOutput as CoreHydratedRunOutput,
     HydratedRunOutputsResult as CoreHydratedRunOutputsResult,
     MaterializationResult as CoreMaterializationResult,
+    StagedInput as CoreStagedInput,
+    StagedInputsResult as CoreStagedInputsResult,
 )
 
 
@@ -13,3 +25,10 @@ def test_materialization_result_is_exported_from_top_level() -> None:
 def test_hydrated_run_output_types_are_exported_from_top_level() -> None:
     assert HydratedRunOutput is CoreHydratedRunOutput
     assert HydratedRunOutputsResult is CoreHydratedRunOutputsResult
+
+
+def test_staged_input_types_and_helpers_are_exported_from_top_level() -> None:
+    assert StagedInput is CoreStagedInput
+    assert StagedInputsResult is CoreStagedInputsResult
+    assert stage_artifact is stage_artifact_api
+    assert stage_inputs is stage_inputs_api

--- a/tests/unit/core/test_error_message_diagnostics.py
+++ b/tests/unit/core/test_error_message_diagnostics.py
@@ -119,6 +119,38 @@ def test_run_rejects_path_binding_with_non_mapping_inputs(tracker) -> None:
     assert "input_binding='paths' requires inputs to be a dict" in message
 
 
+def test_run_rejects_requested_input_materialization_without_paths(tracker) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        tracker.run(
+            fn=lambda data: None,
+            name="missing_requested_input_paths",
+            inputs={"data": Path("any.csv")},
+            execution_options=ExecutionOptions(input_materialization="requested"),
+        )
+
+    message = str(excinfo.value)
+    _assert_problem_cause_fix(message)
+    assert "input_materialization='requested' requires input_paths" in message
+
+
+def test_run_rejects_invalid_requested_input_materialization_mode(tracker) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        tracker.run(
+            fn=lambda data: None,
+            name="bad_requested_input_materialization_mode",
+            inputs={"data": Path("any.csv")},
+            execution_options=ExecutionOptions(
+                input_materialization="requested",
+                input_paths={"data": Path("stage.csv")},
+                input_materialization_mode=cast(Any, "symlink"),
+            ),
+        )
+
+    message = str(excinfo.value)
+    _assert_problem_cause_fix(message)
+    assert "input_materialization_mode must be 'copy'" in message
+
+
 def test_run_rejects_invalid_executor_message_shape(tracker) -> None:
     with pytest.raises(ValueError) as excinfo:
         tracker.run(

--- a/tests/unit/core/test_input_staging.py
+++ b/tests/unit/core/test_input_staging.py
@@ -84,7 +84,9 @@ def test_stage_artifact_copies_file_and_detaches_artifact(tmp_path: Path) -> Non
     assert destination.read_text(encoding="utf-8") == "value\n1\n"
 
 
-def test_stage_artifact_preserves_existing_identical_destination(tmp_path: Path) -> None:
+def test_stage_artifact_preserves_existing_identical_destination(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "inputs" / "source.csv"
     destination = tmp_path / "runs" / "staged" / "source.csv"
     source.parent.mkdir(parents=True, exist_ok=True)
@@ -117,7 +119,9 @@ def test_stage_artifact_stages_directories(tmp_path: Path) -> None:
     result = stage_artifact(tracker, artifact, destination)
 
     assert result.status == "staged"
-    assert (destination / "nested" / "data.txt").read_text(encoding="utf-8") == "payload"
+    assert (destination / "nested" / "data.txt").read_text(
+        encoding="utf-8"
+    ) == "payload"
 
 
 def test_stage_artifact_uses_runtime_abs_path_when_canonical_resolution_missing(

--- a/tests/unit/core/test_input_staging.py
+++ b/tests/unit/core/test_input_staging.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import consist.api as consist_api
+from consist.core.fs import FileSystemManager
+from consist.core.materialize import (
+    StagedInput,
+    StagedInputsResult,
+    stage_artifact,
+    stage_inputs,
+)
+from consist.models.artifact import Artifact
+
+
+def _checksum(path: Path) -> str:
+    if path.is_dir():
+        digest = hashlib.sha256()
+        for child in sorted(path.rglob("*")):
+            if child.is_file():
+                digest.update(child.relative_to(path).as_posix().encode("utf-8"))
+                digest.update(b"\0")
+                digest.update(child.read_bytes())
+        return digest.hexdigest()
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _tracker(
+    run_dir: Path,
+    *,
+    resolve_uri,
+    allow_external_paths: bool = True,
+    mounts: dict[str, str] | None = None,
+):
+    return SimpleNamespace(
+        run_dir=run_dir,
+        fs=FileSystemManager(run_dir, mounts),
+        allow_external_paths=allow_external_paths,
+        resolve_uri=resolve_uri,
+        identity=SimpleNamespace(compute_file_checksum=_checksum),
+    )
+
+
+def _artifact(
+    key: str,
+    container_uri: str,
+    *,
+    driver: str = "csv",
+    hash_value: str | None = None,
+    meta: dict | None = None,
+    abs_path: Path | None = None,
+) -> Artifact:
+    artifact = Artifact(
+        key=key,
+        container_uri=container_uri,
+        driver=driver,
+        hash=hash_value,
+        meta=dict(meta or {}),
+    )
+    if abs_path is not None:
+        artifact.abs_path = str(abs_path)
+    return artifact
+
+
+def test_stage_artifact_copies_file_and_detaches_artifact(tmp_path: Path) -> None:
+    source = tmp_path / "inputs" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    destination = tmp_path / "runs" / "staged" / "source.csv"
+    tracker = _tracker(tmp_path / "runs", resolve_uri=lambda _uri: str(source))
+    artifact = _artifact("source", "./inputs/source.csv", hash_value=_checksum(source))
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert isinstance(result, StagedInput)
+    assert result.status == "staged"
+    assert result.resolvable is True
+    assert result.path == destination.resolve()
+    assert result.artifact.as_path() == destination.resolve()
+    assert destination.read_text(encoding="utf-8") == "value\n1\n"
+
+
+def test_stage_artifact_preserves_existing_identical_destination(tmp_path: Path) -> None:
+    source = tmp_path / "inputs" / "source.csv"
+    destination = tmp_path / "runs" / "staged" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    destination.write_text("value\n1\n", encoding="utf-8")
+    tracker = _tracker(tmp_path / "runs", resolve_uri=lambda _uri: str(source))
+    artifact = _artifact("source", "./inputs/source.csv", hash_value=_checksum(source))
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "preserved_existing"
+    assert result.resolvable is True
+    assert result.path == destination.resolve()
+    assert result.artifact.as_path() == destination.resolve()
+
+
+def test_stage_artifact_stages_directories(tmp_path: Path) -> None:
+    source = tmp_path / "inputs" / "bundle"
+    (source / "nested").mkdir(parents=True, exist_ok=True)
+    (source / "nested" / "data.txt").write_text("payload", encoding="utf-8")
+    destination = tmp_path / "runs" / "staged" / "bundle"
+    tracker = _tracker(tmp_path / "runs", resolve_uri=lambda _uri: str(source))
+    artifact = _artifact(
+        "bundle",
+        "./inputs/bundle",
+        driver="zarr",
+    )
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "staged"
+    assert (destination / "nested" / "data.txt").read_text(encoding="utf-8") == "payload"
+
+
+def test_stage_artifact_uses_runtime_abs_path_when_canonical_resolution_missing(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "fallback" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    destination = tmp_path / "runs" / "staged" / "source.csv"
+    tracker = _tracker(
+        tmp_path / "runs",
+        resolve_uri=lambda _uri: str(tmp_path / "missing" / "source.csv"),
+    )
+    artifact = _artifact(
+        "source",
+        "./inputs/source.csv",
+        abs_path=source,
+        hash_value=_checksum(source),
+    )
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "staged"
+    assert destination.read_text(encoding="utf-8") == "value\n1\n"
+
+
+def test_stage_artifact_uses_recovery_roots_when_source_is_not_resolved(
+    tmp_path: Path,
+) -> None:
+    archive_root = tmp_path / "archive"
+    source = archive_root / "inputs" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    destination = tmp_path / "runs" / "staged" / "source.csv"
+    tracker = _tracker(
+        tmp_path / "runs",
+        resolve_uri=lambda _uri: str(tmp_path / "missing" / "source.csv"),
+    )
+    artifact = _artifact(
+        "source",
+        "./inputs/source.csv",
+        meta={"recovery_roots": [archive_root]},
+        hash_value=_checksum(source),
+    )
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "staged"
+    assert destination.read_text(encoding="utf-8") == "value\n1\n"
+
+
+def test_stage_artifact_reports_missing_source(tmp_path: Path) -> None:
+    source = tmp_path / "missing.csv"
+    destination = tmp_path / "runs" / "staged" / "missing.csv"
+    tracker = _tracker(tmp_path / "runs", resolve_uri=lambda _uri: str(source))
+    artifact = _artifact("missing", "./missing.csv")
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "missing_source"
+    assert result.resolvable is False
+    assert "source path missing" in (result.message or "")
+
+
+def test_stage_artifact_reports_hash_mismatch_when_validation_applies(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "inputs" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    destination = tmp_path / "runs" / "staged" / "source.csv"
+    tracker = _tracker(tmp_path / "runs", resolve_uri=lambda _uri: str(source))
+    artifact = _artifact("source", "./inputs/source.csv", hash_value="deadbeef")
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "failed"
+    assert "Content hash mismatch" in (result.message or "")
+    assert not destination.exists()
+
+
+def test_stage_artifact_rejects_symlink_destination(tmp_path: Path) -> None:
+    source = tmp_path / "inputs" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    real_destination = tmp_path / "runs" / "real.csv"
+    real_destination.parent.mkdir(parents=True, exist_ok=True)
+    real_destination.write_text("value\n2\n", encoding="utf-8")
+    destination = tmp_path / "runs" / "linked.csv"
+    destination.symlink_to(real_destination)
+    tracker = _tracker(tmp_path / "runs", resolve_uri=lambda _uri: str(source))
+    artifact = _artifact("source", "./inputs/source.csv", hash_value=_checksum(source))
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "failed"
+    assert "Symlink detected in destination path" in (result.message or "")
+
+
+def test_stage_artifact_rejects_external_destination_when_disallowed(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "inputs" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    tracker = _tracker(
+        tmp_path / "runs",
+        resolve_uri=lambda _uri: str(source),
+        allow_external_paths=False,
+    )
+    artifact = _artifact("source", "./inputs/source.csv", hash_value=_checksum(source))
+    destination = tmp_path / "outside.csv"
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "failed"
+    assert "outside allowed" in (result.message or "")
+
+
+def test_stage_inputs_returns_ordered_keyed_results(tmp_path: Path) -> None:
+    source_a = tmp_path / "inputs" / "a.csv"
+    source_b = tmp_path / "inputs" / "b.csv"
+    source_a.parent.mkdir(parents=True, exist_ok=True)
+    source_a.write_text("value\n1\n", encoding="utf-8")
+    source_b.write_text("value\n2\n", encoding="utf-8")
+    dest_a = tmp_path / "runs" / "staged" / "a.csv"
+    dest_b = tmp_path / "runs" / "staged" / "b.csv"
+    dest_b.parent.mkdir(parents=True, exist_ok=True)
+    dest_b.write_text("value\n2\n", encoding="utf-8")
+    tracker = _tracker(
+        tmp_path / "runs",
+        resolve_uri=lambda uri: str(source_a if uri.endswith("a.csv") else source_b),
+    )
+    inputs = {
+        "b": _artifact("b", "./inputs/b.csv", hash_value=_checksum(source_b)),
+        "a": _artifact("a", "./inputs/a.csv", hash_value=_checksum(source_a)),
+    }
+    destinations = {"b": dest_b, "a": dest_a}
+
+    result = stage_inputs(tracker, inputs, destinations)
+
+    assert isinstance(result, StagedInputsResult)
+    assert list(result.keys()) == ["b", "a"]
+    assert result["b"].status == "preserved_existing"
+    assert result["a"].status == "staged"
+    assert result.paths["a"] == dest_a.resolve()
+    assert result.paths["b"] == dest_b.resolve()
+
+
+def test_api_stage_artifact_delegates_to_core(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel = object()
+    calls: dict[str, object] = {}
+    tracker = SimpleNamespace()
+    artifact = _artifact("source", "./inputs/source.csv")
+
+    def _fake_stage(tr, art, destination, **kwargs):
+        calls.update(tr=tr, art=art, destination=destination, kwargs=kwargs)
+        return sentinel
+
+    monkeypatch.setattr(consist_api, "stage_artifact_core", _fake_stage)
+
+    result = consist_api.stage_artifact(
+        artifact,
+        destination="/tmp/staged.csv",
+        tracker=tracker,
+        overwrite=True,
+        mode="copy",
+    )
+
+    assert result is sentinel
+    assert calls["tr"] is tracker
+    assert calls["art"] is artifact
+    assert calls["destination"] == Path("/tmp/staged.csv")
+    assert calls["kwargs"]["overwrite"] is True
+
+
+def test_api_stage_inputs_delegates_to_core(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel = object()
+    calls: dict[str, object] = {}
+    tracker = SimpleNamespace()
+    artifact = _artifact("source", "./inputs/source.csv")
+
+    def _fake_stage(tr, inputs_by_key, destinations_by_key, **kwargs):
+        calls.update(
+            tr=tr,
+            inputs_by_key=inputs_by_key,
+            destinations_by_key=destinations_by_key,
+            kwargs=kwargs,
+        )
+        return sentinel
+
+    monkeypatch.setattr(consist_api, "stage_inputs_core", _fake_stage)
+
+    result = consist_api.stage_inputs(
+        {"source": artifact},
+        destinations_by_key={"source": "/tmp/staged.csv"},
+        tracker=tracker,
+        overwrite=True,
+        mode="copy",
+    )
+
+    assert result is sentinel
+    assert calls["tr"] is tracker
+    assert calls["inputs_by_key"] == {"source": artifact}
+    assert calls["destinations_by_key"] == {"source": Path("/tmp/staged.csv")}
+    assert calls["kwargs"]["overwrite"] is True

--- a/tests/unit/core/test_input_staging_runtime.py
+++ b/tests/unit/core/test_input_staging_runtime.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from consist.types import ExecutionOptions
+
+
+def test_tracker_stage_artifact_method_stages_to_requested_destination(
+    tracker, sample_csv
+) -> None:
+    source = sample_csv("stage_source.csv", rows=2)
+    artifact = tracker.artifacts.create_artifact(
+        source,
+        run_id=None,
+        key="data",
+        direction="input",
+    )
+    destination = tracker.run_dir / "staged" / "data.csv"
+
+    result = tracker.stage_artifact(artifact, destination=destination)
+
+    assert result.status == "staged"
+    assert result.path == destination.resolve()
+    assert destination.exists()
+    assert pd.read_csv(destination)["value"].tolist() == [0, 1]
+
+
+def test_tracker_run_requested_input_materialization_stages_before_execution(
+    tracker, sample_csv
+) -> None:
+    source = sample_csv("runtime_stage.csv", rows=3)
+    staged_path = tracker.run_dir / "workspace" / "runtime_stage.csv"
+    seen: dict[str, Path] = {}
+
+    def step(data: Path) -> None:
+        seen["data"] = data
+        assert data == staged_path
+        assert pd.read_csv(data)["value"].tolist() == [0, 1, 2]
+
+    result = tracker.run(
+        fn=step,
+        name="requested_input_stage_runtime",
+        inputs={"data": source},
+        execution_options=ExecutionOptions(
+            input_binding="paths",
+            input_materialization="requested",
+            input_paths={"data": staged_path},
+        ),
+    )
+
+    assert result.cache_hit is False
+    assert seen["data"] == staged_path
+    assert staged_path.exists()
+    assert result.run.meta["staged_inputs"]["data"] == str(staged_path.resolve())
+
+
+def test_tracker_run_requested_input_materialization_runs_on_cache_hit(
+    tracker, sample_csv
+) -> None:
+    source = sample_csv("cache_hit_stage.csv", rows=2)
+    staged_path = tracker.run_dir / "workspace" / "cache_hit_stage.csv"
+    calls: list[Path] = []
+
+    def step(data: Path, ctx) -> None:
+        calls.append(data)
+        assert data == staged_path
+        ctx.run_dir.mkdir(parents=True, exist_ok=True)
+        (ctx.run_dir / "out.txt").write_text("ok\n", encoding="utf-8")
+
+    first = tracker.run(
+        fn=step,
+        name="requested_input_stage_cache_hit",
+        inputs={"data": source},
+        output_paths={"out": "out.txt"},
+        execution_options=ExecutionOptions(
+            inject_context="ctx",
+            input_binding="paths",
+            input_materialization="requested",
+            input_paths={"data": staged_path},
+        ),
+    )
+    assert first.cache_hit is False
+    assert staged_path.exists()
+
+    staged_path.unlink()
+
+    second = tracker.run(
+        fn=step,
+        name="requested_input_stage_cache_hit",
+        inputs={"data": source},
+        output_paths={"out": "out.txt"},
+        execution_options=ExecutionOptions(
+            inject_context="ctx",
+            input_binding="paths",
+            input_materialization="requested",
+            input_paths={"data": staged_path},
+        ),
+    )
+
+    assert second.cache_hit is True
+    assert calls == [staged_path]
+    assert staged_path.exists()
+    assert second.run.meta["staged_inputs"]["data"] == str(staged_path.resolve())
+
+
+def test_scenario_run_requested_input_materialization_stages_coupler_input(
+    tracker,
+) -> None:
+    staged_path = tracker.run_dir / "workspace" / "scenario_data.csv"
+    seen: dict[str, Path] = {}
+
+    def produce(ctx) -> None:
+        ctx.run_dir.mkdir(parents=True, exist_ok=True)
+        output = ctx.run_dir / "data.csv"
+        pd.DataFrame({"value": [4, 5]}).to_csv(output, index=False)
+
+    def consume(data: Path) -> None:
+        seen["data"] = data
+        assert data == staged_path
+        assert pd.read_csv(data)["value"].tolist() == [4, 5]
+
+    with tracker.scenario("scenario_requested_input_stage") as sc:
+        sc.run(
+            fn=produce,
+            output_paths={"data": "data.csv"},
+            execution_options=ExecutionOptions(inject_context="ctx"),
+        )
+        result = sc.run(
+            fn=consume,
+            inputs=["data"],
+            execution_options=ExecutionOptions(
+                input_binding="paths",
+                input_materialization="requested",
+                input_paths={"data": staged_path},
+            ),
+        )
+
+    assert result.cache_hit is False
+    assert seen["data"] == staged_path
+    assert staged_path.exists()
+
+
+def test_tracker_run_rejects_requested_input_materialization_for_unknown_key(
+    tracker, sample_csv
+) -> None:
+    source = sample_csv("unknown_key_stage.csv", rows=1)
+
+    with pytest.raises(
+        ValueError, match="input_paths contains keys that are not present"
+    ):
+        tracker.run(
+            fn=lambda data: None,
+            name="requested_input_stage_unknown_key",
+            inputs={"data": source},
+            execution_options=ExecutionOptions(
+                input_binding="paths",
+                input_materialization="requested",
+                input_paths={"other": tracker.run_dir / "workspace" / "other.csv"},
+            ),
+        )

--- a/tests/unit/core/test_requested_input_staging.py
+++ b/tests/unit/core/test_requested_input_staging.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+from consist.core.cache import ActiveRunCacheOptions, materialize_requested_inputs
+from consist.core.tracker_orchestration import RunTraceCoordinator, RunTraceHelpers
+from consist.models.artifact import Artifact
+from consist.models.run import ConsistRecord, Run
+from consist.types import ExecutionOptions
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _make_run(run_id: str = "run_001") -> Run:
+    now = datetime.now(timezone.utc)
+    return Run(
+        id=run_id,
+        model_name="model",
+        status="running",
+        config_hash="config",
+        git_hash="git",
+        started_at=now,
+        created_at=now,
+        updated_at=now,
+        meta={},
+    )
+
+
+class _FakeTracker:
+    def __init__(self, *, run_dir: Path, current_consist: ConsistRecord | None = None):
+        self.current_consist = current_consist
+        self.db = None
+        self.fs = SimpleNamespace(
+            resolve_historical_path=lambda uri, original_run_dir: uri,
+            normalize_recovery_roots=lambda roots: [],
+            get_remappable_relative_path=lambda uri: None,
+            get_historical_root=lambda **kwargs: None,
+        )
+        self.run_dir = run_dir
+        self.mounts = {}
+
+    def resolve_uri(self, uri: str) -> str:
+        return uri
+
+    def run_artifact_dir(self) -> Path:
+        return self.run_dir
+
+
+def test_materialize_requested_inputs_stages_requested_key(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    source.write_text("value\n1\n", encoding="utf-8")
+    destination = tmp_path / "staged" / "raw.csv"
+
+    artifact = Artifact(
+        key="raw",
+        container_uri=str(source),
+        driver="csv",
+        hash=_sha256(source),
+        meta={},
+    )
+    run = _make_run()
+
+    tracker = _FakeTracker(
+        run_dir=tmp_path,
+        current_consist=ConsistRecord(run=run, inputs=[artifact]),
+    )
+
+    staged = materialize_requested_inputs(
+        tracker=tracker,
+        options=ActiveRunCacheOptions(
+            requested_input_paths={"raw": destination},
+            requested_input_materialization="requested",
+        ),
+    )
+
+    assert staged == {"raw": str(destination.resolve())}
+    assert destination.read_text(encoding="utf-8") == "value\n1\n"
+    assert artifact.abs_path == str(destination.resolve())
+
+
+def test_execute_python_run_uses_staged_input_path(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    source.write_text("source\n", encoding="utf-8")
+    staged = tmp_path / "staged" / "raw.csv"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.write_text("staged\n", encoding="utf-8")
+
+    artifact = Artifact(
+        key="raw",
+        container_uri=str(source),
+        driver="csv",
+        hash=_sha256(staged),
+        meta={},
+    )
+    artifact.abs_path = str(staged)
+
+    tracker = _FakeTracker(run_dir=tmp_path)
+
+    coordinator = RunTraceCoordinator(
+        tracker=tracker,
+        helpers=RunTraceHelpers(
+            resolve_input_refs=lambda *args, **kwargs: ([], {}),
+            preview_run_artifact_dir=lambda *args, **kwargs: tmp_path,
+            resolve_output_path=lambda *args, **kwargs: tmp_path / "out",
+            is_xarray_dataset=lambda value: False,
+            write_xarray_dataset=lambda *args, **kwargs: None,
+        ),
+    )
+
+    def fn(raw: Path) -> None:
+        assert raw == staged
+        assert raw.read_text(encoding="utf-8") == "staged\n"
+
+    result, captured = coordinator._execute_python_run(
+        tracker=tracker,
+        active_tracker=tracker,
+        fn=fn,
+        resolved_name="step",
+        config=None,
+        inputs={"raw": artifact},
+        runtime_kwargs_dict=None,
+        inject_context=None,
+        input_binding="paths",
+        input_artifacts_by_key={"raw": artifact},
+        requested_input_paths={"raw": staged},
+        capture_dir=None,
+        capture_pattern="*",
+    )
+
+    assert result is None
+    assert captured == {}
+
+
+def test_tracker_run_stages_requested_input_paths(tracker, tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    source.write_text("value\n42\n", encoding="utf-8")
+    destination = tracker.run_dir / "staged" / "raw.csv"
+
+    def fn(raw: Path) -> None:
+        assert raw == destination.resolve()
+        assert raw.read_text(encoding="utf-8") == "value\n42\n"
+
+    result = tracker.run(
+        fn=fn,
+        name="requested_input_staging",
+        inputs={"raw": source},
+        execution_options=ExecutionOptions(
+            input_binding="paths",
+            input_materialization="requested",
+            input_paths={"raw": destination},
+        ),
+    )
+
+    assert result.cache_hit is False
+    assert result.run.meta["staged_inputs"] == {"raw": str(destination.resolve())}
+    assert destination.read_text(encoding="utf-8") == "value\n42\n"

--- a/tests/unit/core/test_run_options.py
+++ b/tests/unit/core/test_run_options.py
@@ -20,7 +20,13 @@ def test_merge_run_options_merges_options_objects() -> None:
             code_identity_extra_deps=["helpers.py"],
         ),
         output_policy=OutputPolicyOptions(output_missing="error"),
-        execution_options=ExecutionOptions(inject_context="ctx"),
+        execution_options=ExecutionOptions(
+            inject_context="ctx",
+            input_binding="paths",
+            input_paths={"raw": "/tmp/raw.csv"},
+            input_materialization="requested",
+            input_materialization_mode="copy",
+        ),
     )
 
     assert merged.cache_mode == "reuse"
@@ -29,7 +35,10 @@ def test_merge_run_options_merges_options_objects() -> None:
     assert merged.code_identity == "callable_module"
     assert merged.code_identity_extra_deps == ["helpers.py"]
     assert merged.output_missing == "error"
-    assert merged.input_binding is None
+    assert merged.input_binding == "paths"
+    assert merged.input_paths == {"raw": "/tmp/raw.csv"}
+    assert merged.input_materialization == "requested"
+    assert merged.input_materialization_mode == "copy"
     assert merged.inject_context == "ctx"
 
 
@@ -48,6 +57,9 @@ def test_merge_run_options_defaults_to_empty_options() -> None:
     assert merged.output_missing is None
     assert merged.input_binding is None
     assert merged.load_inputs is None
+    assert merged.input_paths is None
+    assert merged.input_materialization is None
+    assert merged.input_materialization_mode is None
     assert merged.executor is None
     assert merged.container is None
     assert merged.runtime_kwargs is None
@@ -71,7 +83,12 @@ def test_resolve_runtime_kwargs_alias_merges_into_execution_options() -> None:
     resolved = resolve_runtime_kwargs_alias(
         api_name="Tracker.run",
         execution_options=ExecutionOptions(
-            input_binding="paths", load_inputs=True, inject_context="ctx"
+            input_binding="paths",
+            load_inputs=True,
+            inject_context="ctx",
+            input_paths={"raw": "/tmp/raw.csv"},
+            input_materialization="requested",
+            input_materialization_mode="copy",
         ),
         runtime_kwargs={"threshold": 2},
     )
@@ -80,6 +97,9 @@ def test_resolve_runtime_kwargs_alias_merges_into_execution_options() -> None:
     assert resolved.input_binding == "paths"
     assert resolved.load_inputs is True
     assert resolved.inject_context == "ctx"
+    assert resolved.input_paths == {"raw": "/tmp/raw.csv"}
+    assert resolved.input_materialization == "requested"
+    assert resolved.input_materialization_mode == "copy"
     assert resolved.runtime_kwargs == {"threshold": 2}
 
 

--- a/tests/unit/core/test_tracker_run.py
+++ b/tests/unit/core/test_tracker_run.py
@@ -154,9 +154,7 @@ def test_tracker_run_path_binding_requires_materialized_local_path(tracker, samp
         )
 
 
-def test_tracker_run_path_binding_falls_back_from_stale_abs_path(
-    tracker, sample_csv
-):
+def test_tracker_run_path_binding_falls_back_from_stale_abs_path(tracker, sample_csv):
     input_path = sample_csv("stale_abs_path.csv", rows=3)
     stale_path = tracker.run_dir / "missing" / "stale.csv"
     seen: dict[str, Path] = {}

--- a/tests/unit/core/test_tracker_run.py
+++ b/tests/unit/core/test_tracker_run.py
@@ -154,6 +154,34 @@ def test_tracker_run_path_binding_requires_materialized_local_path(tracker, samp
         )
 
 
+def test_tracker_run_path_binding_falls_back_from_stale_abs_path(
+    tracker, sample_csv
+):
+    input_path = sample_csv("stale_abs_path.csv", rows=3)
+    stale_path = tracker.run_dir / "missing" / "stale.csv"
+    seen: dict[str, Path] = {}
+
+    artifact = tracker.artifacts.create_artifact(
+        input_path,
+        run_id=None,
+        key="data",
+        direction="input",
+    )
+    artifact.abs_path = str(stale_path)
+
+    def step(data: Path) -> None:
+        seen["data"] = data
+        assert list(pd.read_csv(data)["value"]) == [0, 1, 2]
+
+    tracker.run(
+        fn=step,
+        inputs={"data": artifact},
+        execution_options=ExecutionOptions(input_binding="paths"),
+    )
+
+    assert seen["data"] == input_path
+
+
 def test_tracker_run_cache_hit_skips_callable(tracker):
     calls: list[str] = []
 


### PR DESCRIPTION
## Summary

This PR adds first-class input staging for path-bound workflows.

Callers can now keep canonical artifacts in `inputs={...}` for identity and lineage, while also requesting concrete local input destinations through `ExecutionOptions`. Consist stages those inputs before execution and preserves the same behavior on cache hits.

## What changed

- added requested input materialization on the run surface via:
  - `ExecutionOptions(input_materialization="requested", input_paths={...})`
- added low-level staging helpers for manual orchestration:
  - `consist.stage_artifact(...)`
  - `consist.stage_inputs(...)`
  - `Tracker.stage_artifact(...)`
  - `Tracker.stage_inputs(...)`
- introduced keyed staging result types and status reporting for staged inputs
- wired requested input staging through run invocation, tracker lifecycle, and cache hydration paths so requested destinations are honored on both cache misses and cache hits
- added validation and safety checks for:
  - missing or unknown requested input keys
  - unsupported staging modes
  - symlink destinations
  - external destination restrictions
  - content-hash validation and reuse of matching existing destinations
  - fallback recovery from runtime paths and historical roots
- expanded docs across the README, quickstart, run API docs, materialization docs, and caching/hydration concepts
- added unit coverage for helper behavior, runtime behavior, error diagnostics, and public exports

## Why

This makes path-bound integrations easier to use without weakening provenance semantics.

The main use case is subprocesses, external tools, or legacy workflows that expect exact workspace-local filenames. With this change, those workflows can request staged local paths while Consist still tracks the canonical artifact identity upstream.