### PR TITLE
Tracker and Persistence services

### DIFF
--- a/src/consist/core/_db_ops_base.py
+++ b/src/consist/core/_db_ops_base.py
@@ -7,8 +7,27 @@ if TYPE_CHECKING:
 
 
 class _DatabaseOpsBase:
+    """
+    Internal transitional base for helpers extracted from ``DatabaseManager``.
+
+    Like ``_TrackerServiceBase``, this class keeps extracted database helpers
+    operating against the concrete owner while the persistence refactor settles.
+    It intentionally favors low-churn extraction over a finalized dependency
+    boundary.
+
+    New code should prefer explicit ``self.db`` / ``self._db`` access where
+    practical. The forwarding shim is here to preserve behavior during the
+    extraction, not to hide long-term contracts.
+    """
+
     def __init__(self, db: "DatabaseManager") -> None:
         self._db = db
 
+    @property
+    def db(self) -> "DatabaseManager":
+        """Return the concrete owning ``DatabaseManager`` instance."""
+        return self._db
+
     def __getattr__(self, name: str) -> Any:
+        # Transitional compatibility shim for extracted DB helper code.
         return getattr(self._db, name)

--- a/src/consist/core/_db_ops_base.py
+++ b/src/consist/core/_db_ops_base.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from consist.core.persistence import DatabaseManager
+
+
+class _DatabaseOpsBase:
+    def __init__(self, db: "DatabaseManager") -> None:
+        self._db = db
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._db, name)

--- a/src/consist/core/_tracker_service_base.py
+++ b/src/consist/core/_tracker_service_base.py
@@ -7,8 +7,31 @@ if TYPE_CHECKING:
 
 
 class _TrackerServiceBase:
+    """
+    Internal transitional base for services extracted from ``Tracker``.
+
+    These service classes were split out of ``Tracker`` to reduce file size and
+    localize related behavior, but they still operate over the concrete owning
+    ``Tracker`` instance. The forwarding behavior here is intentionally a
+    compatibility shim so extracted methods can move with minimal mechanical
+    rewrite during the refactor.
+
+    This is not intended to be a strong abstraction boundary. Dependencies
+    remain Tracker-shaped, and implicit forwarding can blur ownership if it is
+    overused. Prefer explicit ``self.tracker`` / ``self._tracker`` access in new
+    code when practical so service dependencies stay visible over time.
+    """
+
     def __init__(self, tracker: "Tracker") -> None:
         self._tracker = tracker
 
+    @property
+    def tracker(self) -> "Tracker":
+        """Return the concrete owning ``Tracker`` instance."""
+        return self._tracker
+
     def __getattr__(self, name: str) -> Any:
+        # Transitional compatibility shim for extracted service code. This keeps
+        # method bodies stable while logic moves out of Tracker, but it should
+        # not be mistaken for a hard service contract.
         return getattr(self._tracker, name)

--- a/src/consist/core/_tracker_service_base.py
+++ b/src/consist/core/_tracker_service_base.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from consist.core.tracker import Tracker
+
+
+class _TrackerServiceBase:
+    def __init__(self, tracker: "Tracker") -> None:
+        self._tracker = tracker
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._tracker, name)

--- a/src/consist/core/cache.py
+++ b/src/consist/core/cache.py
@@ -721,7 +721,9 @@ def materialize_missing_inputs(
 
         run_id = str(artifact.run_id)
         run = db.get_run(run_id)
-        original_run_dir = run.meta.get("_physical_run_dir") if run and run.meta else None
+        original_run_dir = (
+            run.meta.get("_physical_run_dir") if run and run.meta else None
+        )
         if not original_run_dir:
             continue
 

--- a/src/consist/core/db_runtime.py
+++ b/src/consist/core/db_runtime.py
@@ -170,6 +170,15 @@ def is_retryable_db_error(message: str) -> bool:
 
 
 class DatabaseRuntimeOps(_DatabaseOpsBase):
+    """
+    Runtime-only database operations extracted from ``DatabaseManager``.
+
+    This service currently owns retry behavior, shared session scoping, and
+    optional DB profiling. It still operates over the concrete
+    ``DatabaseManager`` via ``_DatabaseOpsBase`` while the refactor remains in a
+    transitional state.
+    """
+
     def execute_with_retry(
         self,
         func: Callable,

--- a/src/consist/core/db_runtime.py
+++ b/src/consist/core/db_runtime.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import atexit
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import logging
+import os
+import random
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional
+
+from sqlalchemy.exc import DatabaseError, OperationalError
+from sqlalchemy.orm.exc import ConcurrentModificationError
+from sqlmodel import Session
+
+from consist.core._db_ops_base import _DatabaseOpsBase
+
+RETRYABLE_DB_ERROR_MARKERS = (
+    "database is locked",
+    "database is busy",
+    "io error",
+    "lock",
+    "already active",
+    "already open",
+    "another connection",
+    "another process",
+)
+
+
+@dataclass
+class _DBProfileEntry:
+    count: int = 0
+    error_count: int = 0
+    total_seconds: float = 0.0
+    max_seconds: float = 0.0
+
+
+class _DBCallProfiler:
+    def __init__(self) -> None:
+        self.output_path = os.environ.get("CONSIST_DB_PROFILE_PATH")
+        self.enabled = bool(self.output_path)
+        self._lock = threading.Lock()
+        self._registered = False
+        self._calls: dict[str, _DBProfileEntry] = {}
+        self._session_open_count = 0
+        self._session_reuse_count = 0
+        self._session_close_count = 0
+        self._session_live_total_seconds = 0.0
+        self._session_live_max_seconds = 0.0
+
+    def _ensure_registered(self) -> None:
+        if not self.enabled or self._registered:
+            return
+        atexit.register(self.dump)
+        self._registered = True
+
+    @contextmanager
+    def track(self, name: str) -> Iterator[None]:
+        if not self.enabled:
+            yield
+            return
+        self._ensure_registered()
+        started = time.perf_counter()
+        failed = False
+        try:
+            yield
+        except Exception:
+            failed = True
+            raise
+        finally:
+            elapsed = time.perf_counter() - started
+            with self._lock:
+                entry = self._calls.setdefault(name, _DBProfileEntry())
+                entry.count += 1
+                entry.total_seconds += elapsed
+                entry.max_seconds = max(entry.max_seconds, elapsed)
+                if failed:
+                    entry.error_count += 1
+
+    def note_session_open(self) -> None:
+        if not self.enabled:
+            return
+        self._ensure_registered()
+        with self._lock:
+            self._session_open_count += 1
+
+    def note_session_reuse(self) -> None:
+        if not self.enabled:
+            return
+        self._ensure_registered()
+        with self._lock:
+            self._session_reuse_count += 1
+
+    def note_session_close(self, *, live_seconds: float) -> None:
+        if not self.enabled:
+            return
+        self._ensure_registered()
+        with self._lock:
+            self._session_close_count += 1
+            self._session_live_total_seconds += live_seconds
+            self._session_live_max_seconds = max(
+                self._session_live_max_seconds, live_seconds
+            )
+
+    def dump(self) -> None:
+        if not self.enabled or not self.output_path:
+            return
+        with self._lock:
+            calls = {
+                name: {
+                    "count": entry.count,
+                    "error_count": entry.error_count,
+                    "total_seconds": round(entry.total_seconds, 6),
+                    "avg_milliseconds": round(
+                        (entry.total_seconds / entry.count) * 1000, 3
+                    )
+                    if entry.count
+                    else 0.0,
+                    "max_milliseconds": round(entry.max_seconds * 1000, 3),
+                }
+                for name, entry in sorted(
+                    self._calls.items(),
+                    key=lambda item: item[1].total_seconds,
+                    reverse=True,
+                )
+            }
+            payload = {
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "session_scope": {
+                    "outer_session_open_count": self._session_open_count,
+                    "shared_session_reuse_count": self._session_reuse_count,
+                    "outer_session_close_count": self._session_close_count,
+                    "total_live_seconds": round(self._session_live_total_seconds, 6),
+                    "avg_live_milliseconds": round(
+                        (
+                            self._session_live_total_seconds
+                            / self._session_close_count
+                            * 1000
+                        ),
+                        3,
+                    )
+                    if self._session_close_count
+                    else 0.0,
+                    "max_live_milliseconds": round(
+                        self._session_live_max_seconds * 1000, 3
+                    ),
+                },
+                "calls": calls,
+            }
+        try:
+            output = Path(self.output_path)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n")
+        except Exception as exc:
+            logging.warning(
+                "Failed to write Consist DB profile to %s: %s", self.output_path, exc
+            )
+
+
+DB_CALL_PROFILER = _DBCallProfiler()
+
+
+def is_retryable_db_error(message: str) -> bool:
+    normalized = message.lower()
+    return any(marker in normalized for marker in RETRYABLE_DB_ERROR_MARKERS)
+
+
+class DatabaseRuntimeOps(_DatabaseOpsBase):
+    def execute_with_retry(
+        self,
+        func: Callable,
+        operation_name: str = "db_op",
+        retries: Optional[int] = None,
+        **kwargs,
+    ) -> Any:
+        default_retries = getattr(self, "_lock_retries", 20)
+        base_sleep_seconds = getattr(self, "_lock_base_sleep_seconds", 0.1)
+        max_sleep_seconds = getattr(self, "_lock_max_sleep_seconds", 2.0)
+        retry_count = default_retries if retries is None else max(1, int(retries))
+        for i in range(retry_count):
+            try:
+                return func()
+            except (OperationalError, DatabaseError) as e:
+                if is_retryable_db_error(str(e)):
+                    if i == retry_count - 1:
+                        raise e
+                    sleep_time = min(
+                        (base_sleep_seconds * (1.5**i)) + random.uniform(0.05, 0.2),
+                        max_sleep_seconds,
+                    )
+                    time.sleep(sleep_time)
+                else:
+                    raise e
+        raise ConcurrentModificationError(f"Concurrency problem in {operation_name}")
+
+    @contextmanager
+    def session_scope(self) -> Iterator[Session]:
+        session = self._session_ctx.get()
+        if session is not None:
+            DB_CALL_PROFILER.note_session_reuse()
+            try:
+                yield session
+            except Exception:
+                try:
+                    session.rollback()
+                except Exception:
+                    pass
+                raise
+            return
+        session = Session(self.engine)
+        token = self._session_ctx.set(session)
+        DB_CALL_PROFILER.note_session_open()
+        started = time.perf_counter()
+        try:
+            yield session
+        finally:
+            session.close()
+            DB_CALL_PROFILER.note_session_close(
+                live_seconds=time.perf_counter() - started
+            )
+            self._session_ctx.reset(token)

--- a/src/consist/core/db_snapshot.py
+++ b/src/consist/core/db_snapshot.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+import shutil
+import uuid
+from typing import Any, Dict, Optional
+
+from consist.core._db_ops_base import _DatabaseOpsBase
+
+
+class DatabaseSnapshotOps(_DatabaseOpsBase):
+    def _atomic_copy_file(self, src: Path, dest: Path) -> None:
+        temp_path = dest.parent / f".{dest.name}.{uuid.uuid4().hex}.tmp"
+        try:
+            shutil.copy2(src, temp_path)
+            temp_path.replace(dest)
+        finally:
+            try:
+                if temp_path.exists():
+                    temp_path.unlink()
+            except OSError:
+                pass
+
+    def _atomic_write_json_file(self, payload: Dict[str, Any], dest: Path) -> None:
+        temp_path = dest.parent / f".{dest.name}.{uuid.uuid4().hex}.tmp"
+        try:
+            temp_path.write_text(
+                json.dumps(payload, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            temp_path.replace(dest)
+        finally:
+            try:
+                if temp_path.exists():
+                    temp_path.unlink()
+            except OSError:
+                pass
+
+    def _snapshot_sidecar_path(self, destination: Path) -> Path:
+        base_name = destination.stem if destination.suffix else destination.name
+        return destination.with_name(f"{base_name}.snapshot_meta.json")
+
+    def snapshot_to(
+        self,
+        dest_path: str | os.PathLike[str],
+        checkpoint: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        if self.db_path == ":memory:":
+            raise ValueError("Cannot snapshot an in-memory DuckDB database.")
+
+        source_db_path = Path(self.db_path)
+        destination = Path(dest_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        if checkpoint:
+
+            def _checkpoint() -> None:
+                with self.engine.begin() as conn:
+                    conn.exec_driver_sql("CHECKPOINT")
+
+            self.execute_with_retry(_checkpoint, operation_name="snapshot_checkpoint")
+
+        self._atomic_copy_file(source_db_path, destination)
+
+        source_wal_path = Path(f"{source_db_path}.wal")
+        destination_wal_path = Path(f"{destination}.wal")
+        if checkpoint:
+            try:
+                if destination_wal_path.exists():
+                    destination_wal_path.unlink()
+            except OSError as exc:
+                logging.warning(
+                    "Failed to remove stale snapshot WAL at %s: %s",
+                    destination_wal_path,
+                    exc,
+                )
+        elif source_wal_path.exists():
+            self._atomic_copy_file(source_wal_path, destination_wal_path)
+
+        if metadata is not None:
+            snapshot_metadata = dict(metadata)
+            snapshot_metadata["snapshot_ts_utc"] = datetime.now(
+                timezone.utc
+            ).isoformat()
+            snapshot_metadata["source_db_path"] = str(source_db_path)
+            self._atomic_write_json_file(
+                snapshot_metadata,
+                self._snapshot_sidecar_path(destination),
+            )
+
+        return destination

--- a/src/consist/core/db_snapshot.py
+++ b/src/consist/core/db_snapshot.py
@@ -13,6 +13,15 @@ from consist.core._db_ops_base import _DatabaseOpsBase
 
 
 class DatabaseSnapshotOps(_DatabaseOpsBase):
+    """
+    Snapshot and atomic file-write helpers extracted from ``DatabaseManager``.
+
+    The implementation still delegates through the concrete owning
+    ``DatabaseManager`` for engine access and retry behavior. The split is meant
+    to isolate snapshot concerns, not to define a finalized independent
+    persistence layer yet.
+    """
+
     def _atomic_copy_file(self, src: Path, dest: Path) -> None:
         temp_path = dest.parent / f".{dest.name}.{uuid.uuid4().hex}.tmp"
         try:

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -346,7 +346,9 @@ class StagedInputsResult(MappingABC[str, StagedInput]):
 
     @property
     def failed_keys(self) -> list[str]:
-        return [key for key, output in self.outputs.items() if output.status == "failed"]
+        return [
+            key for key, output in self.outputs.items() if output.status == "failed"
+        ]
 
     @property
     def complete(self) -> bool:
@@ -1015,9 +1017,7 @@ def _stage_artifact_path(
 
         source_path = _resolve_staging_source_path(tracker, artifact=artifact)
         if source_path is None or not source_path.exists():
-            msg = (
-                f"[Consist] Cannot stage artifact {artifact.key!r}: source path missing."
-            )
+            msg = f"[Consist] Cannot stage artifact {artifact.key!r}: source path missing."
             logging.warning(msg)
             return _make_staged_output(
                 artifact,
@@ -1033,9 +1033,7 @@ def _stage_artifact_path(
             )
 
         if validate_content_hash == "always" and not artifact.hash:
-            msg = (
-                f"[Consist] Cannot validate artifact {artifact.key!r}: artifact.hash is missing."
-            )
+            msg = f"[Consist] Cannot validate artifact {artifact.key!r}: artifact.hash is missing."
             logging.warning(msg)
             return _make_staged_output(
                 artifact,
@@ -1082,9 +1080,7 @@ def _stage_artifact_path(
                     resolvable=False,
                 )
             if source_path.is_dir() != destination_path.is_dir():
-                msg = (
-                    f"Destination type mismatch for {destination_path}; refusing to overwrite."
-                )
+                msg = f"Destination type mismatch for {destination_path}; refusing to overwrite."
                 logging.warning("[Consist] %s", msg)
                 return _make_staged_output(
                     artifact,
@@ -1147,9 +1143,7 @@ def _stage_artifact_path(
             resolvable=False,
         )
     except (OSError, shutil.Error, RuntimeError, ValueError) as exc:
-        msg = (
-            f"[Consist] Failed to stage artifact {artifact.key!r} to {destination_path}: {exc}"
-        )
+        msg = f"[Consist] Failed to stage artifact {artifact.key!r} to {destination_path}: {exc}"
         logging.warning(msg)
         return _make_staged_output(
             artifact,
@@ -1175,7 +1169,9 @@ def stage_artifacts_to_destinations(
     staging helpers and run-time requested input materialization.
     """
     if mode != "copy":
-        raise ValueError(f"Unsupported staging mode {mode!r}; only 'copy' is supported.")
+        raise ValueError(
+            f"Unsupported staging mode {mode!r}; only 'copy' is supported."
+        )
 
     outputs: dict[str, StagedInput] = {}
     key_order: list[str] = []
@@ -1953,7 +1949,9 @@ def stage_inputs(
     for key, destination in destinations_by_key.items():
         artifact = inputs_by_key.get(key)
         if artifact is None:
-            raise KeyError(f"Input key {key!r} was not found in the resolved artifact set.")
+            raise KeyError(
+                f"Input key {key!r} was not found in the resolved artifact set."
+            )
         items.append((key, artifact, Path(destination)))
     return stage_artifacts_to_destinations(
         tracker,

--- a/src/consist/core/persistence.py
+++ b/src/consist/core/persistence.py
@@ -1,13 +1,10 @@
 import atexit
 import time
-import random
 import logging
 import re
 import os
 import uuid
 import json
-import shutil
-import tempfile
 import contextvars
 import threading
 from dataclasses import dataclass
@@ -30,17 +27,13 @@ from typing import (
 )
 
 import pandas as pd
-from sqlalchemy.exc import OperationalError, DatabaseError
-from sqlalchemy.orm.exc import ConcurrentModificationError
 from sqlalchemy.orm import aliased
 from sqlalchemy.pool import NullPool
 from sqlmodel import create_engine, Session, select, SQLModel, col, delete
 
 from consist.core.db_runtime import DatabaseRuntimeOps
 from consist.core.db_snapshot import DatabaseSnapshotOps
-from consist.core.provenance_writer import (
-    ProvenanceWriter as _ExtractedProvenanceWriter,
-)
+from consist.core.provenance_writer import ProvenanceWriter
 from consist.core.schema_compat import (
     apply_content_identity_compatibility,
     apply_run_stage_phase_compatibility,
@@ -66,10 +59,7 @@ from consist.models.run import (
 from consist.models.run_config_kv import RunConfigKV
 
 if TYPE_CHECKING:
-    from consist.core.tracker import Tracker
     from consist.models.artifact import Artifact
-    from consist.models.run import ConsistRecord
-    from consist.models.run import Run as RunModel
 
 
 MAX_JSON_DEPTH = 50
@@ -86,6 +76,13 @@ _RETRYABLE_DB_ERROR_MARKERS = (
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 SchemaProfileSource = Literal["file", "duckdb", "user_provided"]
+
+__all__ = [
+    "ArtifactSchemaSelection",
+    "DatabaseManager",
+    "ProvenanceWriter",
+    "SchemaProfileSource",
+]
 
 
 @dataclass(frozen=True)
@@ -349,12 +346,6 @@ class DatabaseManager:
         self._artifact_content_cache_lock = threading.Lock()
         self._runtime_ops = DatabaseRuntimeOps(self)
         self._snapshot_ops = DatabaseSnapshotOps(self)
-        self.execute_with_retry = self._runtime_ops.execute_with_retry
-        self.session_scope = self._runtime_ops.session_scope
-        self._atomic_copy_file = self._snapshot_ops._atomic_copy_file
-        self._atomic_write_json_file = self._snapshot_ops._atomic_write_json_file
-        self._snapshot_sidecar_path = self._snapshot_ops._snapshot_sidecar_path
-        self.snapshot_to = self._snapshot_ops.snapshot_to
         self._init_schema()
 
     def _init_schema(self):
@@ -581,32 +572,19 @@ class DatabaseManager:
 
     def _atomic_copy_file(self, src: Path, dest: Path) -> None:
         """Copy a file via temp path and atomic rename in destination directory."""
-        temp_path = dest.parent / f".{dest.name}.{uuid.uuid4().hex}.tmp"
-        try:
-            shutil.copy2(src, temp_path)
-            temp_path.replace(dest)
-        finally:
-            try:
-                if temp_path.exists():
-                    temp_path.unlink()
-            except OSError:
-                pass
+        snapshot_ops = getattr(self, "_snapshot_ops", None)
+        if snapshot_ops is None:
+            snapshot_ops = DatabaseSnapshotOps(self)
+            self._snapshot_ops = snapshot_ops
+        snapshot_ops._atomic_copy_file(src, dest)
 
     def _atomic_write_json_file(self, payload: Dict[str, Any], dest: Path) -> None:
         """Write JSON to a temp file then atomically replace target."""
-        temp_path = dest.parent / f".{dest.name}.{uuid.uuid4().hex}.tmp"
-        try:
-            temp_path.write_text(
-                json.dumps(payload, indent=2, sort_keys=True),
-                encoding="utf-8",
-            )
-            temp_path.replace(dest)
-        finally:
-            try:
-                if temp_path.exists():
-                    temp_path.unlink()
-            except OSError:
-                pass
+        snapshot_ops = getattr(self, "_snapshot_ops", None)
+        if snapshot_ops is None:
+            snapshot_ops = DatabaseSnapshotOps(self)
+            self._snapshot_ops = snapshot_ops
+        snapshot_ops._atomic_write_json_file(payload, dest)
 
     def _snapshot_sidecar_path(self, destination: Path) -> Path:
         """
@@ -614,8 +592,11 @@ class DatabaseManager:
 
         Example: provenance.duckdb -> provenance.snapshot_meta.json
         """
-        base_name = destination.stem if destination.suffix else destination.name
-        return destination.with_name(f"{base_name}.snapshot_meta.json")
+        snapshot_ops = getattr(self, "_snapshot_ops", None)
+        if snapshot_ops is None:
+            snapshot_ops = DatabaseSnapshotOps(self)
+            self._snapshot_ops = snapshot_ops
+        return snapshot_ops._snapshot_sidecar_path(destination)
 
     def snapshot_to(
         self,
@@ -640,50 +621,15 @@ class DatabaseManager:
         Path
             The destination snapshot database path.
         """
-        if self.db_path == ":memory:":
-            raise ValueError("Cannot snapshot an in-memory DuckDB database.")
-
-        source_db_path = Path(self.db_path)
-        destination = Path(dest_path)
-        destination.parent.mkdir(parents=True, exist_ok=True)
-
-        if checkpoint:
-
-            def _checkpoint() -> None:
-                with self.engine.begin() as conn:
-                    conn.exec_driver_sql("CHECKPOINT")
-
-            self.execute_with_retry(_checkpoint, operation_name="snapshot_checkpoint")
-
-        self._atomic_copy_file(source_db_path, destination)
-
-        source_wal_path = Path(f"{source_db_path}.wal")
-        destination_wal_path = Path(f"{destination}.wal")
-        if checkpoint:
-            try:
-                if destination_wal_path.exists():
-                    destination_wal_path.unlink()
-            except OSError as exc:
-                logging.warning(
-                    "Failed to remove stale snapshot WAL at %s: %s",
-                    destination_wal_path,
-                    exc,
-                )
-        elif source_wal_path.exists():
-            self._atomic_copy_file(source_wal_path, destination_wal_path)
-
-        if metadata is not None:
-            snapshot_metadata = dict(metadata)
-            snapshot_metadata["snapshot_ts_utc"] = datetime.now(
-                timezone.utc
-            ).isoformat()
-            snapshot_metadata["source_db_path"] = str(source_db_path)
-            self._atomic_write_json_file(
-                snapshot_metadata,
-                self._snapshot_sidecar_path(destination),
-            )
-
-        return destination
+        snapshot_ops = getattr(self, "_snapshot_ops", None)
+        if snapshot_ops is None:
+            snapshot_ops = DatabaseSnapshotOps(self)
+            self._snapshot_ops = snapshot_ops
+        return snapshot_ops.snapshot_to(
+            dest_path,
+            checkpoint=checkpoint,
+            metadata=metadata,
+        )
 
     def execute_with_retry(
         self,
@@ -693,25 +639,16 @@ class DatabaseManager:
         **kwargs,  # <--- Add this to absorb extra arguments
     ) -> Any:
         """Executes a function with exponential backoff for DB locks."""
-        default_retries = getattr(self, "_lock_retries", 20)
-        base_sleep_seconds = getattr(self, "_lock_base_sleep_seconds", 0.1)
-        max_sleep_seconds = getattr(self, "_lock_max_sleep_seconds", 2.0)
-        retry_count = default_retries if retries is None else max(1, int(retries))
-        for i in range(retry_count):
-            try:
-                return func()
-            except (OperationalError, DatabaseError) as e:
-                if _is_retryable_db_error(str(e)):
-                    if i == retry_count - 1:
-                        raise e
-                    sleep_time = min(
-                        (base_sleep_seconds * (1.5**i)) + random.uniform(0.05, 0.2),
-                        max_sleep_seconds,
-                    )
-                    time.sleep(sleep_time)
-                else:
-                    raise e
-        raise ConcurrentModificationError(f"Concurrency problem in {operation_name}")
+        runtime_ops = getattr(self, "_runtime_ops", None)
+        if runtime_ops is None:
+            runtime_ops = DatabaseRuntimeOps(self)
+            self._runtime_ops = runtime_ops
+        return runtime_ops.execute_with_retry(
+            func,
+            operation_name=operation_name,
+            retries=retries,
+            **kwargs,
+        )
 
     @contextmanager
     def session_scope(self) -> Iterator[Session]:
@@ -721,30 +658,12 @@ class DatabaseManager:
         This keeps CLI commands to a single DuckDB connection while preserving
         existing behavior for library usage.
         """
-        session = self._session_ctx.get()
-        if session is not None:
-            _DB_CALL_PROFILER.note_session_reuse()
-            try:
-                yield session
-            except Exception:
-                try:
-                    session.rollback()
-                except Exception:
-                    pass
-                raise
-            return
-        session = Session(self.engine)
-        token = self._session_ctx.set(session)
-        _DB_CALL_PROFILER.note_session_open()
-        started = time.perf_counter()
-        try:
+        runtime_ops = getattr(self, "_runtime_ops", None)
+        if runtime_ops is None:
+            runtime_ops = DatabaseRuntimeOps(self)
+            self._runtime_ops = runtime_ops
+        with runtime_ops.session_scope() as session:
             yield session
-        finally:
-            session.close()
-            _DB_CALL_PROFILER.note_session_close(
-                live_seconds=time.perf_counter() - started
-            )
-            self._session_ctx.reset(token)
 
     # --- Write Operations ---
 
@@ -3492,290 +3411,3 @@ class DatabaseManager:
         except Exception as e:
             logging.warning(f"Failed to fetch history: {e}")
             return pd.DataFrame()
-
-
-class ProvenanceWriter:
-    """
-    Lightweight persistence helper for JSON snapshots and DB synchronization.
-
-    This keeps non-public persistence mechanics out of managers while allowing
-    the tracker to remain the primary orchestrator.
-    """
-
-    def __init__(self, tracker: "Tracker"):
-        self._tracker = tracker
-        self._artifact_batch_depth = 0
-        self._batch_pending_json_flush = False
-        self._batch_pending_artifacts: list[tuple["Artifact", str]] = []
-        self._batch_pending_artifact_facet_bundles: list[
-            tuple[
-                "Artifact",
-                ArtifactFacet,
-                Dict[str, Any],
-                Optional[List[ArtifactKV]],
-            ]
-        ] = []
-
-    @contextmanager
-    def batch_artifact_writes(self) -> Iterator[None]:
-        """
-        Defer artifact JSON flushes and DB syncs until the end of a batch.
-
-        This keeps `log_artifact(...)` semantics unchanged while allowing callers
-        such as `log_artifacts(...)` to avoid redundant per-item persistence I/O.
-        """
-        is_outermost = self._artifact_batch_depth == 0
-        if is_outermost:
-            self._batch_pending_json_flush = False
-            self._batch_pending_artifacts = []
-            self._batch_pending_artifact_facet_bundles = []
-        self._artifact_batch_depth += 1
-        try:
-            yield
-        finally:
-            self._artifact_batch_depth -= 1
-            if self._artifact_batch_depth != 0:
-                return
-
-            pending_json_flush = self._batch_pending_json_flush
-            pending_artifacts = list(self._batch_pending_artifacts)
-            pending_artifact_facet_bundles = list(
-                self._batch_pending_artifact_facet_bundles
-            )
-            self._batch_pending_json_flush = False
-            self._batch_pending_artifacts = []
-            self._batch_pending_artifact_facet_bundles = []
-
-            if pending_json_flush:
-                self._flush_json_now()
-            if pending_artifacts:
-                self._sync_artifacts_now(pending_artifacts)
-            if pending_artifact_facet_bundles:
-                self._persist_artifact_facet_bundles_now(pending_artifact_facet_bundles)
-
-    def flush_json(self) -> None:
-        """
-        Flush the current in-memory run state to JSON snapshots on disk.
-
-        Uses an atomic write strategy for both the per-run snapshot and the
-        rolling latest snapshot.
-        """
-        if self._artifact_batch_depth > 0:
-            self._batch_pending_json_flush = True
-            return
-        self._flush_json_now()
-
-    def _flush_json_now(self) -> None:
-        """Immediate implementation behind `flush_json`."""
-        tracker = self._tracker
-        if not tracker.current_consist:
-            return
-        self._write_record_json(tracker.current_consist)
-
-    def flush_record_json(self, record: "ConsistRecord") -> None:
-        """
-        Flush a specific run snapshot record to JSON files on disk.
-
-        This is used when metadata is updated after run execution has ended and
-        there is no active ``current_consist`` context.
-        """
-        self._write_record_json(record)
-
-    def _write_record_json(self, record: "ConsistRecord") -> None:
-        """Write per-run and latest JSON snapshots for a record atomically."""
-        tracker = self._tracker
-        json_str = record.model_dump_json(indent=2)
-
-        run_id = record.run.id
-        safe_run_id = "".join(
-            c if (c.isalnum() or c in ("-", "_", ".")) else "_" for c in run_id
-        )
-
-        per_run_dir = tracker.fs.run_dir / "consist_runs"
-        per_run_dir.mkdir(parents=True, exist_ok=True)
-        per_run_target = per_run_dir / f"{safe_run_id}.json"
-        self._write_text_atomic(per_run_target, json_str)
-
-        latest_target = tracker.fs.run_dir / "consist.json"
-        self._write_text_atomic(latest_target, json_str)
-
-    def _write_text_atomic(self, target: Path, payload: str) -> None:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path: Optional[Path] = None
-        try:
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                encoding="utf-8",
-                dir=target.parent,
-                prefix=f".{target.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as handle:
-                handle.write(payload)
-                handle.flush()
-                tmp_path = Path(handle.name)
-            os.replace(tmp_path, target)
-        except Exception:
-            if tmp_path is not None:
-                try:
-                    tmp_path.unlink(missing_ok=True)
-                except Exception:
-                    pass
-            raise
-
-    def sync_run(self, run: "RunModel") -> None:
-        """
-        Sync a Run object to the database, if configured.
-
-        Parameters
-        ----------
-        run : Run
-            Run instance to upsert into the database.
-        """
-        tracker = self._tracker
-        if tracker.db:
-            try:
-                tracker.db.sync_run(run)
-            except Exception as e:
-                logging.warning("Database sync failed: %s", e)
-
-    def sync_run_with_links(
-        self,
-        run: "RunModel",
-        *,
-        artifact_ids: list[uuid.UUID],
-        direction: str = "output",
-    ) -> None:
-        """
-        Sync a Run and link artifacts in one database transaction.
-
-        Parameters
-        ----------
-        run : Run
-            Run instance to upsert into the database.
-        artifact_ids : list[uuid.UUID]
-            Artifact ids to link to the run.
-        direction : str, default "output"
-            Direction for all linked artifacts.
-        """
-        tracker = self._tracker
-        if tracker.db:
-            try:
-                tracker.db.sync_run_with_links(
-                    run=run, artifact_ids=artifact_ids, direction=direction
-                )
-            except Exception as e:
-                logging.warning("Database sync failed: %s", e)
-
-    def sync_artifact(
-        self,
-        artifact: "Artifact",
-        direction: str,
-        *,
-        profile_label: Optional[str] = None,
-    ) -> None:
-        """
-        Sync an Artifact and its run link to the database, if configured.
-
-        Parameters
-        ----------
-        artifact : Artifact
-            Artifact instance to upsert into the database.
-        direction : str
-            Direction of the artifact relative to the current run
-            ("input" or "output").
-        """
-        if self._artifact_batch_depth > 0:
-            self._batch_pending_artifacts.append((artifact, direction))
-            return
-
-        tracker = self._tracker
-        if tracker.db and tracker.current_consist:
-            try:
-                tracker.db.sync_artifact(
-                    artifact,
-                    tracker.current_consist.run.id,
-                    direction,
-                    profile_label=profile_label,
-                )
-            except Exception as e:
-                logging.warning("Database sync failed: %s", e)
-
-    def sync_artifact_with_facet_bundle(
-        self,
-        artifact: "Artifact",
-        direction: str,
-        *,
-        facet: ArtifactFacet,
-        meta_updates: Dict[str, Any],
-        kv_rows: Optional[List[ArtifactKV]] = None,
-    ) -> None:
-        """
-        Sync an Artifact, run link, and facet bundle in one database transaction.
-        """
-        if self._artifact_batch_depth > 0:
-            self._batch_pending_artifacts.append((artifact, direction))
-            self._batch_pending_artifact_facet_bundles.append(
-                (artifact, facet, meta_updates, kv_rows)
-            )
-            return
-
-        tracker = self._tracker
-        if tracker.db and tracker.current_consist:
-            try:
-                tracker.db.sync_artifact_with_facet_bundle(
-                    artifact,
-                    tracker.current_consist.run.id,
-                    direction,
-                    facet=facet,
-                    meta_updates=meta_updates,
-                    kv_rows=kv_rows,
-                )
-            except Exception as e:
-                logging.warning("Database sync failed: %s", e)
-
-    def _sync_artifacts_now(
-        self, artifacts_with_direction: Sequence[tuple["Artifact", str]]
-    ) -> None:
-        tracker = self._tracker
-        if not tracker.db or not tracker.current_consist:
-            return
-
-        run_id = tracker.current_consist.run.id
-        artifacts_by_direction: Dict[str, List["Artifact"]] = {}
-        for artifact, direction in artifacts_with_direction:
-            artifacts_by_direction.setdefault(direction, []).append(artifact)
-
-        for direction, artifacts in artifacts_by_direction.items():
-            try:
-                tracker.db.sync_artifacts(
-                    artifacts=artifacts,
-                    run_id=run_id,
-                    direction=direction,
-                )
-            except Exception as e:
-                logging.warning("Database sync failed: %s", e)
-
-    def _persist_artifact_facet_bundles_now(
-        self,
-        artifact_facet_bundles: Sequence[
-            tuple["Artifact", ArtifactFacet, Dict[str, Any], Optional[List[ArtifactKV]]]
-        ],
-    ) -> None:
-        tracker = self._tracker
-        if not tracker.db:
-            return
-
-        for artifact, facet, meta_updates, kv_rows in artifact_facet_bundles:
-            try:
-                tracker.db.persist_artifact_facet_bundle(
-                    artifact=artifact,
-                    facet=facet,
-                    meta_updates=meta_updates,
-                    kv_rows=kv_rows,
-                )
-            except Exception as e:
-                logging.warning("Database sync failed: %s", e)
-
-
-ProvenanceWriter = _ExtractedProvenanceWriter  # noqa: F811

--- a/src/consist/core/persistence.py
+++ b/src/consist/core/persistence.py
@@ -36,6 +36,11 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.pool import NullPool
 from sqlmodel import create_engine, Session, select, SQLModel, col, delete
 
+from consist.core.db_runtime import DatabaseRuntimeOps
+from consist.core.db_snapshot import DatabaseSnapshotOps
+from consist.core.provenance_writer import (
+    ProvenanceWriter as _ExtractedProvenanceWriter,
+)
 from consist.core.schema_compat import (
     apply_content_identity_compatibility,
     apply_run_stage_phase_compatibility,
@@ -342,6 +347,14 @@ class DatabaseManager:
         )
         self._artifact_content_cache: dict[tuple[str, str], ArtifactContent] = {}
         self._artifact_content_cache_lock = threading.Lock()
+        self._runtime_ops = DatabaseRuntimeOps(self)
+        self._snapshot_ops = DatabaseSnapshotOps(self)
+        self.execute_with_retry = self._runtime_ops.execute_with_retry
+        self.session_scope = self._runtime_ops.session_scope
+        self._atomic_copy_file = self._snapshot_ops._atomic_copy_file
+        self._atomic_write_json_file = self._snapshot_ops._atomic_write_json_file
+        self._snapshot_sidecar_path = self._snapshot_ops._snapshot_sidecar_path
+        self.snapshot_to = self._snapshot_ops.snapshot_to
         self._init_schema()
 
     def _init_schema(self):
@@ -3763,3 +3776,6 @@ class ProvenanceWriter:
                 )
             except Exception as e:
                 logging.warning("Database sync failed: %s", e)
+
+
+ProvenanceWriter = _ExtractedProvenanceWriter  # noqa: F811

--- a/src/consist/core/provenance_writer.py
+++ b/src/consist/core/provenance_writer.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
 
 
 class ProvenanceWriter:
+    """
+    Persistence-side helper for run JSON snapshots and artifact DB sync.
+
+    This keeps write-heavy provenance plumbing out of ``Tracker`` while leaving
+    the tracker as the composition root and lifecycle orchestrator.
+    """
+
     def __init__(self, tracker: "Tracker"):
         self._tracker = tracker
         self._artifact_batch_depth = 0

--- a/src/consist/core/provenance_writer.py
+++ b/src/consist/core/provenance_writer.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+import logging
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING
+import uuid
+
+from consist.models.artifact_facet import ArtifactFacet
+from consist.models.artifact_kv import ArtifactKV
+
+if TYPE_CHECKING:
+    from consist.core.tracker import Tracker
+    from consist.models.artifact import Artifact
+    from consist.models.run import ConsistRecord
+    from consist.models.run import Run as RunModel
+
+
+class ProvenanceWriter:
+    def __init__(self, tracker: "Tracker"):
+        self._tracker = tracker
+        self._artifact_batch_depth = 0
+        self._batch_pending_json_flush = False
+        self._batch_pending_artifacts: list[tuple["Artifact", str]] = []
+        self._batch_pending_artifact_facet_bundles: list[
+            tuple[
+                "Artifact",
+                ArtifactFacet,
+                Dict[str, Any],
+                Optional[List[ArtifactKV]],
+            ]
+        ] = []
+
+    @contextmanager
+    def batch_artifact_writes(self) -> Iterator[None]:
+        is_outermost = self._artifact_batch_depth == 0
+        if is_outermost:
+            self._batch_pending_json_flush = False
+            self._batch_pending_artifacts = []
+            self._batch_pending_artifact_facet_bundles = []
+        self._artifact_batch_depth += 1
+        try:
+            yield
+        finally:
+            self._artifact_batch_depth -= 1
+            if self._artifact_batch_depth != 0:
+                return
+
+            pending_json_flush = self._batch_pending_json_flush
+            pending_artifacts = list(self._batch_pending_artifacts)
+            pending_artifact_facet_bundles = list(
+                self._batch_pending_artifact_facet_bundles
+            )
+            self._batch_pending_json_flush = False
+            self._batch_pending_artifacts = []
+            self._batch_pending_artifact_facet_bundles = []
+
+            if pending_json_flush:
+                self._flush_json_now()
+            if pending_artifacts:
+                self._sync_artifacts_now(pending_artifacts)
+            if pending_artifact_facet_bundles:
+                self._persist_artifact_facet_bundles_now(pending_artifact_facet_bundles)
+
+    def flush_json(self) -> None:
+        if self._artifact_batch_depth > 0:
+            self._batch_pending_json_flush = True
+            return
+        self._flush_json_now()
+
+    def _flush_json_now(self) -> None:
+        tracker = self._tracker
+        if not tracker.current_consist:
+            return
+        self._write_record_json(tracker.current_consist)
+
+    def flush_record_json(self, record: "ConsistRecord") -> None:
+        self._write_record_json(record)
+
+    def _write_record_json(self, record: "ConsistRecord") -> None:
+        tracker = self._tracker
+        json_str = record.model_dump_json(indent=2)
+
+        run_id = record.run.id
+        safe_run_id = "".join(
+            c if (c.isalnum() or c in ("-", "_", ".")) else "_" for c in run_id
+        )
+
+        per_run_dir = tracker.fs.run_dir / "consist_runs"
+        per_run_dir.mkdir(parents=True, exist_ok=True)
+        per_run_target = per_run_dir / f"{safe_run_id}.json"
+        self._write_text_atomic(per_run_target, json_str)
+
+        latest_target = tracker.fs.run_dir / "consist.json"
+        self._write_text_atomic(latest_target, json_str)
+
+    def _write_text_atomic(self, target: Path, payload: str) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path: Optional[Path] = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=target.parent,
+                prefix=f".{target.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                handle.write(payload)
+                handle.flush()
+                tmp_path = Path(handle.name)
+            os.replace(tmp_path, target)
+        except Exception:
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+            raise
+
+    def sync_run(self, run: "RunModel") -> None:
+        tracker = self._tracker
+        if tracker.db:
+            try:
+                tracker.db.sync_run(run)
+            except Exception as e:
+                logging.warning("Database sync failed: %s", e)
+
+    def sync_run_with_links(
+        self,
+        run: "RunModel",
+        *,
+        artifact_ids: list[uuid.UUID],
+        direction: str = "output",
+    ) -> None:
+        tracker = self._tracker
+        if tracker.db:
+            try:
+                tracker.db.sync_run_with_links(
+                    run=run, artifact_ids=artifact_ids, direction=direction
+                )
+            except Exception as e:
+                logging.warning("Database sync failed: %s", e)
+
+    def sync_artifact(
+        self,
+        artifact: "Artifact",
+        direction: str,
+        *,
+        profile_label: Optional[str] = None,
+    ) -> None:
+        if self._artifact_batch_depth > 0:
+            self._batch_pending_artifacts.append((artifact, direction))
+            return
+
+        tracker = self._tracker
+        if tracker.db and tracker.current_consist:
+            try:
+                tracker.db.sync_artifact(
+                    artifact,
+                    tracker.current_consist.run.id,
+                    direction,
+                    profile_label=profile_label,
+                )
+            except Exception as e:
+                logging.warning("Database sync failed: %s", e)
+
+    def sync_artifact_with_facet_bundle(
+        self,
+        artifact: "Artifact",
+        direction: str,
+        *,
+        facet: ArtifactFacet,
+        meta_updates: Dict[str, Any],
+        kv_rows: Optional[List[ArtifactKV]] = None,
+    ) -> None:
+        if self._artifact_batch_depth > 0:
+            self._batch_pending_artifacts.append((artifact, direction))
+            self._batch_pending_artifact_facet_bundles.append(
+                (artifact, facet, meta_updates, kv_rows)
+            )
+            return
+
+        tracker = self._tracker
+        if tracker.db and tracker.current_consist:
+            try:
+                tracker.db.sync_artifact_with_facet_bundle(
+                    artifact,
+                    tracker.current_consist.run.id,
+                    direction,
+                    facet=facet,
+                    meta_updates=meta_updates,
+                    kv_rows=kv_rows,
+                )
+            except Exception as e:
+                logging.warning("Database sync failed: %s", e)
+
+    def _sync_artifacts_now(
+        self, artifacts_with_direction: Sequence[tuple["Artifact", str]]
+    ) -> None:
+        tracker = self._tracker
+        if not tracker.db or not tracker.current_consist:
+            return
+
+        run_id = tracker.current_consist.run.id
+        artifacts_by_direction: Dict[str, List["Artifact"]] = {}
+        for artifact, direction in artifacts_with_direction:
+            artifacts_by_direction.setdefault(direction, []).append(artifact)
+
+        for direction, artifacts in artifacts_by_direction.items():
+            try:
+                tracker.db.sync_artifacts(
+                    artifacts=artifacts,
+                    run_id=run_id,
+                    direction=direction,
+                )
+            except Exception as e:
+                logging.warning("Database sync failed: %s", e)
+
+    def _persist_artifact_facet_bundles_now(
+        self,
+        artifact_facet_bundles: Sequence[
+            tuple["Artifact", ArtifactFacet, Dict[str, Any], Optional[List[ArtifactKV]]]
+        ],
+    ) -> None:
+        tracker = self._tracker
+        if not tracker.db:
+            return
+
+        for artifact, facet, meta_updates, kv_rows in artifact_facet_bundles:
+            try:
+                tracker.db.persist_artifact_facet_bundle(
+                    artifact=artifact,
+                    facet=facet,
+                    meta_updates=meta_updates,
+                    kv_rows=kv_rows,
+                )
+            except Exception as e:
+                logging.warning("Database sync failed: %s", e)

--- a/src/consist/core/run_invocation.py
+++ b/src/consist/core/run_invocation.py
@@ -590,9 +590,7 @@ def resolve_run_invocation(
                         "execution_options.input_materialization='requested' "
                         "requires input_paths."
                     ),
-                    cause=(
-                        "Requested input staging needs explicit destination paths."
-                    ),
+                    cause=("Requested input staging needs explicit destination paths."),
                     fix=(
                         "Provide execution_options=ExecutionOptions("
                         "input_materialization='requested', input_paths={...})."

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -1,8 +1,5 @@
-import inspect
-import itertools
 import re
 import shutil
-from dataclasses import replace
 from collections.abc import Mapping as MappingABC
 from contextlib import contextmanager
 import logging
@@ -64,7 +61,6 @@ from consist.core.config_canonicalization import (
     ConfigContribution,
     ConfigPlan,
     SupportsRunWithConfigOverrides,
-    validate_config_plan,
 )
 from consist.core.config_facets import ConfigFacetManager
 from consist.core.decorators import define_step as define_step_decorator
@@ -399,65 +395,6 @@ class Tracker:
             self.on_run_failed(self._lifecycle.emit_failed)
         else:
             self._lifecycle = None
-
-        # Bind extracted service methods on the instance while keeping the
-        # public Tracker API and import path unchanged.
-        self.get_artifact = self._artifact_queries.get_artifact
-        self.find_artifacts_with_same_content = (
-            self._artifact_queries.find_artifacts_with_same_content
-        )
-        self.find_runs_producing_same_content = (
-            self._artifact_queries.find_runs_producing_same_content
-        )
-        self.select_artifact_schema_for_artifact = (
-            self._artifact_queries.select_artifact_schema_for_artifact
-        )
-        self.get_artifact_by_uri = self._artifact_queries.get_artifact_by_uri
-        self.find_artifacts = self._artifact_queries.find_artifacts
-        self._parse_artifact_param_value = (
-            self._artifact_queries._parse_artifact_param_value
-        )
-        self._parse_artifact_param_expression = (
-            self._artifact_queries._parse_artifact_param_expression
-        )
-        self.find_artifacts_by_params = self._artifact_queries.find_artifacts_by_params
-        self.get_artifact_kv = self._artifact_queries.get_artifact_kv
-
-        self.resolve_historical_path = self._history_service.resolve_historical_path
-        self.get_run = self._history_service.get_run
-        self.snapshot_db = self._history_service.snapshot_db
-        self.get_run_record = self._history_service.get_run_record
-        self.get_run_config = self._history_service.get_run_config
-        self.get_config_bundle = self._history_service.get_config_bundle
-        self.get_artifacts_for_run = self._history_service.get_artifacts_for_run
-        self.get_run_outputs = self._history_service.get_run_outputs
-        self.get_run_result = self._history_service.get_run_result
-        self.get_run_inputs = self._history_service.get_run_inputs
-        self.get_run_artifact = self._history_service.get_run_artifact
-        self.load_run_output = self._history_service.load_run_output
-        self.find_matching_run = self._history_service.find_matching_run
-        self.find_recent_completed_runs_for_model = (
-            self._history_service.find_recent_completed_runs_for_model
-        )
-        self.history = self._history_service.history
-        self.load_input_bundle = self._history_service.load_input_bundle
-
-        self._adapter_accepts_options = (
-            self._config_plan_service._adapter_accepts_options
-        )
-        self._discover_config = self._config_plan_service._discover_config
-        self._canonicalize_config = self._config_plan_service._canonicalize_config
-        self.canonicalize_config = self._config_plan_service.canonicalize_config
-        self.prepare_config = self._config_plan_service.prepare_config
-        self.prepare_config_resolver = self._config_plan_service.prepare_config_resolver
-        self.apply_config_plan = self._config_plan_service.apply_config_plan
-        self.identity_from_config_plan = (
-            self._config_plan_service.identity_from_config_plan
-        )
-        self._apply_config_contribution = (
-            self._config_plan_service._apply_config_contribution
-        )
-        self._ingest_cache_hit = self._config_plan_service._ingest_cache_hit
 
     @property
     def db(self) -> DatabaseManager | None:
@@ -3237,18 +3174,7 @@ class Tracker:
     def _adapter_accepts_options(
         self, adapter: ConfigAdapter, method_name: str
     ) -> bool:
-        method = getattr(adapter, method_name, None)
-        if method is None:
-            return False
-        try:
-            signature = inspect.signature(method)
-        except (TypeError, ValueError):
-            return False
-        if "options" in signature.parameters:
-            return True
-        return any(
-            param.kind == param.VAR_KEYWORD for param in signature.parameters.values()
-        )
+        return self._config_plan_service._adapter_accepts_options(adapter, method_name)
 
     def _discover_config(
         self,
@@ -3257,11 +3183,11 @@ class Tracker:
         strict: bool,
         options: Optional[ConfigAdapterOptions],
     ) -> CanonicalConfig:
-        kwargs: dict[str, Any] = {}
-        if options is not None and self._adapter_accepts_options(adapter, "discover"):
-            kwargs["options"] = options
-        return adapter.discover(
-            config_dir_paths, identity=self.identity, strict=strict, **kwargs
+        return self._config_plan_service._discover_config(
+            adapter,
+            config_dir_paths,
+            strict,
+            options,
         )
 
     def _canonicalize_config(
@@ -3275,18 +3201,14 @@ class Tracker:
         plan_only: bool,
         options: Optional[ConfigAdapterOptions],
     ) -> CanonicalizationResult:
-        kwargs: dict[str, Any] = {}
-        if options is not None and self._adapter_accepts_options(
-            adapter, "canonicalize"
-        ):
-            kwargs["options"] = options
-        return adapter.canonicalize(
+        return self._config_plan_service._canonicalize_config(
+            adapter,
             canonical,
             run=run,
             tracker=tracker,
             strict=strict,
             plan_only=plan_only,
-            **kwargs,
+            options=options,
         )
 
     def canonicalize_config(
@@ -3328,67 +3250,16 @@ class Tracker:
         ConfigContribution
             Structured summary of logged artifacts and ingestables.
         """
-        if run is not None and run_id is not None:
-            raise ValueError("Provide either run= or run_id=, not both.")
-        if options is not None and (strict is not False or ingest is not True):
-            raise ValueError(
-                "When options= is provided, do not pass strict= or ingest=."
-            )
-        if options is not None:
-            strict = options.strict
-            ingest = options.ingest
-
-        target_run = run
-        if target_run is None and run_id is not None:
-            if self.current_consist and self.current_consist.run.id == run_id:
-                target_run = self.current_consist.run
-            else:
-                raise RuntimeError(
-                    "canonicalize_config requires an active run matching run_id=."
-                )
-        if target_run is None and self.current_consist:
-            target_run = self.current_consist.run
-        if target_run is None:
-            raise RuntimeError("canonicalize_config requires an active run or run=.")
-
-        config_dir_paths = [Path(p).resolve() for p in config_dirs]
-        canonical = self._discover_config(adapter, config_dir_paths, strict, options)
-        result = self._canonicalize_config(
+        return self._config_plan_service.canonicalize_config(
             adapter,
-            canonical,
-            run=target_run,
-            tracker=self,
+            config_dirs,
+            run=run,
+            run_id=run_id,
             strict=strict,
-            plan_only=False,
-            options=options,
-        )
-
-        contribution = ConfigContribution(
-            identity_hash=canonical.content_hash,
-            adapter_version=getattr(adapter, "adapter_version", None),
-            artifacts=result.artifacts,
-            ingestables=result.ingestables,
-            meta={
-                "adapter": adapter.model_name,
-                "config_dirs": [str(p) for p in config_dir_paths],
-            },
-        )
-
-        self._apply_config_contribution(
-            contribution,
-            run=target_run,
             ingest=ingest,
             profile_schema=profile_schema,
+            options=options,
         )
-
-        if target_run.meta is None:
-            target_run.meta = {}
-        target_run.meta["config_bundle_hash"] = canonical.content_hash
-        target_run.meta["config_adapter"] = adapter.model_name
-        if contribution.adapter_version is not None:
-            target_run.meta["config_adapter_version"] = contribution.adapter_version
-
-        return contribution
 
     def prepare_config(
         self,
@@ -3432,52 +3303,17 @@ class Tracker:
         ConfigPlan
             Pre-run config plan containing artifacts and ingestables.
         """
-        if options is not None and strict is not False:
-            raise ValueError("When options= is provided, do not pass strict=.")
-        if options is not None:
-            strict = options.strict
-        config_dir_paths = [Path(p).resolve() for p in config_dirs]
-        canonical = self._discover_config(adapter, config_dir_paths, strict, options)
-        result = self._canonicalize_config(
+        return self._config_plan_service.prepare_config(
             adapter,
-            canonical,
-            run=None,
-            tracker=None,
+            config_dirs,
             strict=strict,
-            plan_only=True,
             options=options,
-        )
-        facet_data = None
-        if facet_spec is not None:
-            if hasattr(adapter, "build_facet"):
-                facet_data = adapter.build_facet(canonical, facet_spec=facet_spec)
-                if facet_data is not None:
-                    facet_data = self.identity.normalize_json(facet_data)
-            else:
-                raise ValueError(
-                    "facet_spec provided but adapter does not support build_facet()."
-                )
-
-        plan = ConfigPlan(
-            adapter_name=adapter.model_name,
-            adapter_version=getattr(adapter, "adapter_version", None),
-            canonical=canonical,
-            artifacts=result.artifacts,
-            ingestables=result.ingestables,
-            facet=facet_data,
+            validate_only=validate_only,
+            facet_spec=facet_spec,
             facet_schema_name=facet_schema_name,
             facet_schema_version=facet_schema_version,
             facet_index=facet_index,
-            meta={
-                "adapter": adapter.model_name,
-                "config_dirs": [str(p) for p in config_dir_paths],
-            },
-            adapter=adapter,
         )
-        if validate_only:
-            diagnostics = validate_config_plan(plan)
-            return replace(plan, diagnostics=diagnostics)
-        return plan
 
     def prepare_config_resolver(
         self,
@@ -3508,72 +3344,18 @@ class Tracker:
         The returned callable is metadata-safe (pre-run) and delegates to
         `prepare_config(...)`.
         """
-        if (config_dirs is None) == (config_dirs_from is None):
-            raise ValueError(
-                "prepare_config_resolver requires exactly one of "
-                "config_dirs= or config_dirs_from=."
-            )
-
-        static_dirs = tuple(config_dirs) if config_dirs is not None else None
-
-        def _resolve_runtime_path(ctx: "StepContext", path: str) -> object:
-            parts = [part for part in path.split(".") if part]
-            if not parts:
-                raise ValueError(
-                    "config_dirs_from path must be non-empty (e.g., "
-                    "'settings.config_dirs')."
-                )
-            value: object = ctx.require_runtime(parts[0])
-            for part in parts[1:]:
-                if isinstance(value, MappingABC):
-                    mapping_value = cast(Mapping[str, object], value)
-                    if part not in mapping_value:
-                        raise ValueError(
-                            f"Missing runtime mapping key {part!r} while resolving "
-                            f"config_dirs_from={path!r}."
-                        )
-                    value = mapping_value[part]
-                    continue
-                if not hasattr(value, part):
-                    raise ValueError(
-                        f"Missing runtime attribute {part!r} while resolving "
-                        f"config_dirs_from={path!r}."
-                    )
-                value = getattr(value, part)
-            return value
-
-        def _resolve_dirs(ctx: "StepContext") -> Iterable[Union[str, Path]]:
-            if static_dirs is not None:
-                return static_dirs
-            source = config_dirs_from
-            if isinstance(source, str):
-                candidate = _resolve_runtime_path(ctx, source)
-            else:
-                source_from_ctx = cast(
-                    Callable[["StepContext"], Iterable[Union[str, Path]]], source
-                )
-                candidate = source_from_ctx(ctx)
-            if isinstance(candidate, (str, Path)):
-                raise ValueError(
-                    "Resolved config_dirs must be an iterable of paths, not a single "
-                    f"value: {candidate!r}."
-                )
-            return cast(Iterable[Union[str, Path]], candidate)
-
-        def _resolver(ctx: "StepContext") -> ConfigPlan:
-            return self.prepare_config(
-                adapter=adapter,
-                config_dirs=_resolve_dirs(ctx),
-                strict=strict,
-                options=options,
-                validate_only=validate_only,
-                facet_spec=facet_spec,
-                facet_schema_name=facet_schema_name,
-                facet_schema_version=facet_schema_version,
-                facet_index=facet_index,
-            )
-
-        return _resolver
+        return self._config_plan_service.prepare_config_resolver(
+            adapter,
+            config_dirs=config_dirs,
+            config_dirs_from=config_dirs_from,
+            strict=strict,
+            options=options,
+            validate_only=validate_only,
+            facet_spec=facet_spec,
+            facet_schema_name=facet_schema_name,
+            facet_schema_version=facet_schema_version,
+            facet_index=facet_index,
+        )
 
     def apply_config_plan(
         self,
@@ -3608,87 +3390,17 @@ class Tracker:
         ConfigContribution
             Structured summary of logged artifacts and ingestables.
         """
-        if options is not None and ingest is not True:
-            raise ValueError("When options= is provided, do not pass ingest=.")
-        if options is not None:
-            ingest = options.ingest
-
-        target_run = run
-        if target_run is None and self.current_consist:
-            target_run = self.current_consist.run
-        if target_run is None:
-            raise RuntimeError("apply_config_plan requires an active run or run=.")
-
-        artifacts = list(plan.artifacts)
-        adapter_ref = adapter or plan.adapter
-        if adapter_ref is not None and (options is None or options.bundle):
-            bundle_artifact = getattr(adapter_ref, "bundle_artifact", None)
-            if callable(bundle_artifact):
-                bundle_spec = bundle_artifact(
-                    plan.canonical, run=target_run, tracker=self
-                )
-                if bundle_spec is not None:
-                    artifacts.append(bundle_spec)
-
-        contribution = ConfigContribution(
-            identity_hash=plan.identity_hash,
-            adapter_version=plan.adapter_version,
-            artifacts=artifacts,
-            ingestables=plan.ingestables,
-            facet=plan.facet,
-            facet_schema_name=plan.facet_schema_name,
-            facet_schema_version=plan.facet_schema_version,
-            meta=dict(plan.meta or {}),
-        )
-
-        self._apply_config_contribution(
-            contribution,
-            run=target_run,
+        return self._config_plan_service.apply_config_plan(
+            plan,
+            run=run,
             ingest=ingest,
             profile_schema=profile_schema,
+            adapter=adapter,
+            options=options,
         )
 
-        if target_run.meta is None:
-            target_run.meta = {}
-        target_run.meta["config_bundle_hash"] = plan.identity_hash
-        target_run.meta["config_adapter"] = plan.adapter_name
-        if plan.adapter_version is not None:
-            target_run.meta["config_adapter_version"] = plan.adapter_version
-
-        if plan.facet is not None:
-            facet_dict = plan.facet
-            if self.current_consist is not None:
-                self.current_consist.facet = facet_dict
-            schema_name = (
-                plan.facet_schema_name
-                or self.config_facets.infer_schema_name(None, facet_dict)
-            )
-            self.config_facets.persist_facet(
-                run=target_run,
-                model=target_run.model_name,
-                facet_dict=facet_dict,
-                schema_name=schema_name,
-                schema_version=plan.facet_schema_version,
-                index_kv=plan.facet_index if plan.facet_index is not None else True,
-            )
-
-        return contribution
-
     def identity_from_config_plan(self, plan: ConfigPlan) -> str:
-        """
-        Return the identity hash derived from a config plan.
-
-        Parameters
-        ----------
-        plan : ConfigPlan
-            Config plan produced by `prepare_config`.
-
-        Returns
-        -------
-        str
-            Stable hash representing the canonical config content.
-        """
-        return plan.identity_hash
+        return self._config_plan_service.identity_from_config_plan(plan)
 
     def _apply_config_contribution(
         self,
@@ -3698,82 +3410,15 @@ class Tracker:
         ingest: bool,
         profile_schema: bool,
     ) -> Dict[str, Artifact]:
-        artifacts_by_key: Dict[str, Artifact] = {}
-        with self.persistence.batch_artifact_writes():
-            for spec in contribution.artifacts:
-                art = self.log_artifact(
-                    spec.path,
-                    key=spec.key,
-                    direction=spec.direction,
-                    **spec.meta,
-                )
-                artifacts_by_key[spec.key] = art
-
-        if ingest:
-            for spec in contribution.ingestables:
-                source_key = spec.source
-                artifact = (
-                    artifacts_by_key.get(source_key)
-                    if source_key
-                    else next(iter(artifacts_by_key.values()), None)
-                )
-                if artifact is None:
-                    logging.warning(
-                        "[Consist] Skipping ingest for %s; no source artifact found.",
-                        spec.table_name,
-                    )
-                    continue
-                if spec.rows is None:
-                    logging.warning(
-                        "[Consist] Skipping ingest for %s; no rows provided.",
-                        spec.table_name,
-                    )
-                    continue
-                if spec.dedupe_on_hash and spec.content_hash:
-                    if self._ingest_cache_hit(spec.table_name, spec.content_hash):
-                        logging.info(
-                            "[Consist] Skipping ingest for %s; cache hit for %s.",
-                            spec.table_name,
-                            spec.content_hash,
-                        )
-                        continue
-                if source_key is None:
-                    logging.warning(
-                        "[Consist] Ingest spec for %s missing source; using %s.",
-                        spec.table_name,
-                        artifact.key,
-                    )
-                rows = spec.materialize_rows(run.id)
-                self.ingest(
-                    artifact,
-                    data=rows,
-                    schema=spec.schema,
-                    run=run,
-                    profile_schema=profile_schema,
-                )
-
-        return artifacts_by_key
+        return self._config_plan_service._apply_config_contribution(
+            contribution,
+            run=run,
+            ingest=ingest,
+            profile_schema=profile_schema,
+        )
 
     def _ingest_cache_hit(self, table_name: str, content_hash: str) -> bool:
-        store = getattr(self, "hot_data_store", None)
-        if store is not None:
-            return store.ingest_cache_hit(table_name, content_hash)
-
-        # Compatibility fallback for legacy/partial tracker stubs.
-        if self.engine is None:
-            return False
-        if not _is_safe_identifier(table_name):
-            return False
-        table_ref = f"{_quote_ident('global_tables')}.{_quote_ident(table_name)}"
-        try:
-            with self.engine.begin() as connection:
-                result = connection.exec_driver_sql(
-                    f"SELECT 1 FROM {table_ref} WHERE content_hash = ? LIMIT 1",
-                    (content_hash,),
-                ).fetchone()
-            return result is not None
-        except Exception:
-            return False
+        return self._config_plan_service._ingest_cache_hit(table_name, content_hash)
 
     # --- View Factory ---
 
@@ -4195,83 +3840,17 @@ class Tracker:
         *,
         run_id: Optional[str] = None,
     ) -> Optional[Artifact]:
-        """
-        Retrieves an Artifact by semantic key or UUID, optionally scoped to run_id.
-
-        Parameters
-        ----------
-        key_or_id : Union[str, uuid.UUID]
-            The artifact key (e.g., "households") or artifact UUID.
-        run_id : Optional[str], optional
-            If provided, limits results to artifacts linked to this run (as either
-            input or output) via ``run_artifact_link``.
-
-        Returns
-        -------
-        Optional[Artifact]
-            The found artifact, or ``None`` if not found.
-        """
-        if self.db:
-            artifact = self.db.get_artifact(key_or_id, run_id=run_id)
-            if artifact is not None:
-                set_tracker_ref(artifact, self)
-            return artifact
-        return None
+        return self._artifact_queries.get_artifact(key_or_id, run_id=run_id)
 
     def find_artifacts_with_same_content(
         self, artifact: Union[Artifact, str, uuid.UUID]
     ) -> List[Artifact]:
-        """
-        Return artifact occurrences that share the same content identity.
-
-        Parameters
-        ----------
-        artifact : Artifact | str | uuid.UUID
-            Artifact instance or artifact id to resolve.
-
-        Returns
-        -------
-        List[Artifact]
-            Artifacts sharing the same ``content_id``. Returns an empty list when
-            the artifact is unknown, has no content identity, or the database is not
-            configured.
-        """
-        if not self.db:
-            return []
-        target = (
-            artifact if isinstance(artifact, Artifact) else self.get_artifact(artifact)
-        )
-        if target is None or target.content_id is None:
-            return []
-        artifacts = self.db.find_artifacts_by_content_id(target.content_id)
-        for item in artifacts:
-            set_tracker_ref(item, self)
-        return artifacts
+        return self._artifact_queries.find_artifacts_with_same_content(artifact)
 
     def find_runs_producing_same_content(
         self, artifact: Union[Artifact, str, uuid.UUID]
     ) -> List[str]:
-        """
-        Return run ids that produced artifacts with the same content identity.
-
-        Parameters
-        ----------
-        artifact : Artifact | str | uuid.UUID
-            Artifact instance or artifact id to resolve.
-
-        Returns
-        -------
-        List[str]
-            Run ids linked to output artifacts sharing the resolved ``content_id``.
-        """
-        if not self.db:
-            return []
-        target = (
-            artifact if isinstance(artifact, Artifact) else self.get_artifact(artifact)
-        )
-        if target is None or target.content_id is None:
-            return []
-        return self.db.find_runs_producing_content(target.content_id)
+        return self._artifact_queries.find_runs_producing_same_content(artifact)
 
     def select_artifact_schema_for_artifact(
         self,
@@ -4280,22 +3859,9 @@ class Tracker:
         source: Optional[SchemaProfileSource] = None,
         strict_source: bool = False,
     ) -> Optional[ArtifactSchemaSelection]:
-        """
-        Resolve schema selection metadata for an artifact.
-
-        Returns selection details (schema_id/source/candidate_count/rule) used for
-        explainability and deterministic source selection in shell UX.
-        """
-        if not self.db:
-            raise ValueError(
-                "Schema selection requires a configured database (db_path)."
-            )
-        artifact_uuid = (
-            uuid.UUID(artifact_id) if isinstance(artifact_id, str) else artifact_id
-        )
-        return self.db.select_artifact_schema_for_artifact(
-            artifact_id=artifact_uuid,
-            prefer_source=source,
+        return self._artifact_queries.select_artifact_schema_for_artifact(
+            artifact_id=artifact_id,
+            source=source,
             strict_source=strict_source,
         )
 
@@ -4306,47 +3872,11 @@ class Tracker:
         table_path: Optional[str] = None,
         array_path: Optional[str] = None,
     ) -> Optional[Artifact]:
-        """
-        Find an artifact by its URI.
-
-        Useful for checking if a specific file has been logged,
-        or for retrieving artifact metadata by path.
-
-        Parameters
-        ----------
-        uri : str
-            The portable URI to search for (e.g., "inputs://households.csv").
-        table_path : Optional[str]
-            Optional table path to match.
-        array_path : Optional[str]
-            Optional array path to match.
-
-        Returns
-        -------
-        Optional[Artifact]
-            The found `Artifact` object, or `None` if no matching artifact is found.
-        """
-        # 1. Check In-Memory Context (Current Run)
-        if self.current_consist:
-            for art in self.current_consist.inputs + self.current_consist.outputs:
-                if art.container_uri != uri:
-                    continue
-                if table_path is not None and art.table_path != table_path:
-                    continue
-                if array_path is not None and art.array_path != array_path:
-                    continue
-                return art
-
-        # 2. Check Database
-        if self.db:
-            artifact = self.db.get_artifact_by_uri(
-                uri, table_path=table_path, array_path=array_path
-            )
-            if artifact is not None:
-                set_tracker_ref(artifact, self)
-            return artifact
-
-        return None
+        return self._artifact_queries.get_artifact_by_uri(
+            uri,
+            table_path=table_path,
+            array_path=array_path,
+        )
 
     def find_artifacts(
         self,
@@ -4356,102 +3886,19 @@ class Tracker:
         key: Optional[str] = None,
         limit: int = 100,
     ) -> List[Artifact]:
-        """
-        Find artifacts by producing/consuming runs and key.
-
-        Parameters
-        ----------
-        creator : Optional[Union[str, Run]]
-            Run ID (or Run) that logged the artifact as an output.
-        consumer : Optional[Union[str, Run]]
-            Run ID (or Run) that logged the artifact as an input.
-        key : Optional[str]
-            Exact artifact key to match.
-        limit : int, default 100
-            Maximum number of artifacts to return.
-
-        Returns
-        -------
-        list
-            Matching artifact records (empty if DB is not configured).
-        """
-        if not self.db:
-            return []
-
-        creator_id = creator.id if isinstance(creator, Run) else creator
-        consumer_id = consumer.id if isinstance(consumer, Run) else consumer
-
-        artifacts = self.db.find_artifacts(
-            creator=creator_id, consumer=consumer_id, key=key, limit=limit
+        return self._artifact_queries.find_artifacts(
+            creator=creator,
+            consumer=consumer,
+            key=key,
+            limit=limit,
         )
-        for artifact in artifacts:
-            set_tracker_ref(artifact, self)
-        return artifacts
 
     @staticmethod
     def _parse_artifact_param_value(raw: str) -> tuple[str, Any]:
-        value = raw.strip()
-        lowered = value.lower()
-        if lowered == "true":
-            return "bool", True
-        if lowered == "false":
-            return "bool", False
-        if lowered == "null":
-            return "null", None
-        try:
-            if "." not in value and "e" not in lowered:
-                return "num", int(value)
-            return "num", float(value)
-        except ValueError:
-            return "str", value
+        return TrackerArtifactQueryService._parse_artifact_param_value(raw)
 
     def _parse_artifact_param_expression(self, expression: str) -> Dict[str, Any]:
-        raw = expression.strip()
-        operator = None
-        for candidate in (">=", "<=", "="):
-            idx = raw.find(candidate)
-            if idx > 0:
-                operator = candidate
-                lhs = raw[:idx].strip()
-                rhs = raw[idx + len(candidate) :].strip()
-                break
-
-        if operator is None:
-            raise ValueError(
-                f"Invalid artifact facet predicate {expression!r}. "
-                "Expected <key>=<value>, <key>>=<value>, or <key><=<value>."
-            )
-        if not lhs:
-            raise ValueError(
-                f"Artifact facet predicate is missing a key: {expression!r}"
-            )
-        if rhs == "":
-            raise ValueError(
-                f"Artifact facet predicate is missing a value: {expression!r}"
-            )
-
-        namespace = None
-        key_path = lhs
-        if "." in lhs:
-            maybe_namespace, remainder = lhs.split(".", 1)
-            if maybe_namespace and remainder:
-                namespace = maybe_namespace
-                key_path = remainder
-
-        value_kind, value = self._parse_artifact_param_value(rhs)
-        if operator in {">=", "<="} and value_kind != "num":
-            raise ValueError(
-                f"Artifact facet predicate {expression!r} uses {operator} with a "
-                "non-numeric value."
-            )
-
-        return {
-            "namespace": namespace,
-            "key_path": key_path,
-            "op": operator,
-            "kind": value_kind,
-            "value": value,
-        }
+        return self._artifact_queries._parse_artifact_param_expression(expression)
 
     def find_artifacts_by_params(
         self,
@@ -4462,28 +3909,13 @@ class Tracker:
         artifact_family_prefix: Optional[str] = None,
         limit: int = 100,
     ) -> List[Artifact]:
-        """
-        Find artifacts by indexed facet predicates and optional prefix filters.
-        """
-        if not self.db:
-            return []
-
-        predicates = (
-            [self._parse_artifact_param_expression(param) for param in params]
-            if params
-            else []
-        )
-
-        artifacts = self.db.find_artifacts_by_facet_params(
-            predicates=predicates,
+        return self._artifact_queries.find_artifacts_by_params(
+            params=params,
             namespace=namespace,
             key_prefix=key_prefix,
             artifact_family_prefix=artifact_family_prefix,
             limit=limit,
         )
-        for artifact in artifacts:
-            set_tracker_ref(artifact, self)
-        return artifacts
 
     def get_artifact_kv(
         self,
@@ -4493,14 +3925,8 @@ class Tracker:
         prefix: Optional[str] = None,
         limit: int = 10_000,
     ):
-        """
-        Retrieve flattened artifact facet KV rows for an artifact.
-        """
-        if not self.db:
-            return []
-        artifact_id = artifact.id if isinstance(artifact, Artifact) else artifact
-        return self.db.get_artifact_kv(
-            artifact_id=artifact_id,
+        return self._artifact_queries.get_artifact_kv(
+            artifact,
             namespace=namespace,
             prefix=prefix,
             limit=limit,
@@ -4752,156 +4178,25 @@ class Tracker:
         )
 
     def resolve_historical_path(self, artifact: Artifact, run: Run) -> Path:
-        """
-        Resolve the on-disk path for an artifact from a prior run.
-
-        Parameters
-        ----------
-        artifact : Artifact
-            The artifact whose historical location should be resolved.
-        run : Run
-            The run that originally produced/consumed the artifact.
-
-        Returns
-        -------
-        Path
-            The resolved filesystem path for the artifact in its original run
-            workspace.
-        """
-        if not run:
-            return Path(self.resolve_uri(artifact.container_uri))
-
-        old_dir = run.meta.get("_physical_run_dir")
-
-        # Delegate the path math to the FS service
-        path_str = self.fs.resolve_historical_path(artifact.container_uri, old_dir)
-        return Path(path_str)
+        return self._history_service.resolve_historical_path(artifact, run)
 
     def get_run(self, run_id: str) -> Optional[Run]:
-        """
-        Retrieve a single Run by its ID from the database.
-
-        Parameters
-        ----------
-        run_id : str
-            The unique identifier of the run to retrieve.
-
-        Returns
-        -------
-        Optional[Run]
-            The Run object if found, or ``None`` if missing or no database is
-            configured.
-        """
-        if self.db:
-            return self.db.get_run(run_id)
-        return None
+        return self._history_service.get_run(run_id)
 
     def snapshot_db(
         self, dest_path: str | os.PathLike[str], checkpoint: bool = True
     ) -> Path:
-        """
-        Snapshot the configured provenance database to a destination path.
-
-        Parameters
-        ----------
-        dest_path : str | os.PathLike[str]
-            Destination path for the snapshot database file.
-        checkpoint : bool, default True
-            If True, checkpoint the source DB before copying.
-
-        Returns
-        -------
-        Path
-            Snapshot database path.
-        """
-        if self.db is None:
-            raise RuntimeError("Database snapshot requires a configured database.")
-
-        active_run_id = self.current_consist.run.id if self.current_consist else None
-        last_completed_run_id: Optional[str] = None
-        if (
-            self._last_consist is not None
-            and self._last_consist.run.status == "completed"
-        ):
-            last_completed_run_id = self._last_consist.run.id
-        else:
-            completed_runs = self.db.find_runs(status="completed", limit=1)
-            if completed_runs:
-                last_completed_run_id = completed_runs[0].id
-
-        return self.db.snapshot_to(
-            dest_path=dest_path,
-            checkpoint=checkpoint,
-            metadata={
-                "run_id": active_run_id,
-                "last_completed_run_id": last_completed_run_id,
-                "cache_epoch": self._cache_epoch,
-            },
-        )
+        return self._history_service.snapshot_db(dest_path, checkpoint=checkpoint)
 
     def get_run_record(
         self, run_id: str, *, allow_missing: bool = False
     ) -> Optional[ConsistRecord]:
-        """
-        Load the full run record snapshot from disk.
-
-        This reads the JSON snapshot produced at run time (``consist_runs/<id>.json``)
-        and returns the parsed ``ConsistRecord``.
-
-        Parameters
-        ----------
-        run_id : str
-            Run identifier.
-        allow_missing : bool, default False
-            Return ``None`` if the snapshot file is missing or unreadable instead
-            of raising.
-
-        Returns
-        -------
-        Optional[ConsistRecord]
-            The parsed run record, or ``None`` if missing and ``allow_missing``.
-        """
-        run = self.get_run(run_id) if self.db else None
-        snapshot_path = self._resolve_run_snapshot_path(run_id, run)
-        if not snapshot_path.exists():
-            if allow_missing:
-                return None
-            raise FileNotFoundError(
-                f"Run snapshot not found at {snapshot_path!s} for run_id={run_id}."
-            )
-        try:
-            return ConsistRecord.model_validate_json(
-                snapshot_path.read_text(encoding="utf-8")
-            )
-        except Exception as exc:
-            if allow_missing:
-                return None
-            raise ValueError(
-                f"Failed to parse run snapshot at {snapshot_path!s} for run_id={run_id}."
-            ) from exc
+        return self._history_service.get_run_record(run_id, allow_missing=allow_missing)
 
     def get_run_config(
         self, run_id: str, *, allow_missing: bool = False
     ) -> Optional[Dict[str, Any]]:
-        """
-        Load the full config snapshot for a historical run.
-
-        Parameters
-        ----------
-        run_id : str
-            Run identifier.
-        allow_missing : bool, default False
-            Return ``None`` if the snapshot is missing instead of raising.
-
-        Returns
-        -------
-        Optional[Dict[str, Any]]
-            The stored config payload, or ``None`` if missing and ``allow_missing``.
-        """
-        record = self.get_run_record(run_id, allow_missing=allow_missing)
-        if record is None:
-            return None
-        return record.config
+        return self._history_service.get_run_config(run_id, allow_missing=allow_missing)
 
     def materialize_run_outputs(
         self,
@@ -5073,146 +4368,18 @@ class Tracker:
         role: str = "bundle",
         allow_missing: bool = False,
     ) -> Path | None:
-        """
-        Resolve a config artifact path for a run by role.
-
-        This helper scans run-linked artifacts and selects those with
-        ``artifact.meta["config_role"] == role``. When ``adapter`` is provided,
-        matching uses existing adapter identity conventions:
-        ``run.meta["config_adapter"]`` and/or artifact metadata
-        (``artifact.meta["config_adapter"]`` or ``artifact.meta["adapter"]``).
-
-        If multiple artifacts match, selection is deterministic: sort by
-        ``(artifact.key, artifact.created_at, artifact.id)`` and return the first.
-        """
-        artifacts = self.get_artifacts_for_run(run_id)
-        input_artifacts = list(artifacts.inputs.values())
-
-        matching: list[Artifact] = []
-        for artifact in input_artifacts:
-            meta = artifact.meta if isinstance(artifact.meta, dict) else {}
-            if meta.get("config_role") == role:
-                matching.append(artifact)
-
-        run = self.get_run(run_id)
-        run_adapter: str | None = None
-        if run is not None and isinstance(run.meta, dict):
-            candidate = run.meta.get("config_adapter")
-            if isinstance(candidate, str) and candidate:
-                run_adapter = candidate
-
-        if adapter is not None:
-            if run_adapter is not None and run_adapter != adapter:
-                matching = []
-            else:
-                filtered: list[Artifact] = []
-                for artifact in matching:
-                    meta = artifact.meta if isinstance(artifact.meta, dict) else {}
-                    artifact_adapters: list[str] = []
-                    for key in ("config_adapter", "adapter"):
-                        value = meta.get(key)
-                        if isinstance(value, str) and value:
-                            artifact_adapters.append(value)
-                    if artifact_adapters:
-                        if adapter in artifact_adapters:
-                            filtered.append(artifact)
-                    elif run_adapter == adapter:
-                        filtered.append(artifact)
-                matching = filtered
-
-        if matching:
-            selected = sorted(
-                matching,
-                key=lambda artifact: (
-                    artifact.key,
-                    artifact.created_at.isoformat() if artifact.created_at else "",
-                    str(artifact.id),
-                ),
-            )[0]
-            resolved = Path(self.resolve_uri(selected.container_uri))
-            if resolved.exists():
-                return resolved
-
-            if allow_missing:
-                return None
-            raise FileNotFoundError(
-                "Config artifact was found but the resolved file is missing for "
-                f"run_id={run_id!r}, role={role!r}, key={selected.key!r}: {resolved!s}. "
-                "Check path mounts or regenerate config artifacts for this run."
-            )
-
-        if allow_missing:
-            return None
-        adapter_hint = f", adapter={adapter!r}" if adapter is not None else ""
-        raise FileNotFoundError(
-            "No config artifact found for "
-            f"run_id={run_id!r}, role={role!r}{adapter_hint}. "
-            "Ensure config artifacts were logged with meta['config_role'] and, when "
-            "adapter filtering is requested, run.meta['config_adapter'] and/or "
-            "artifact.meta['config_adapter'|'adapter'] match."
+        return self._history_service.get_config_bundle(
+            run_id,
+            adapter=adapter,
+            role=role,
+            allow_missing=allow_missing,
         )
 
     def get_artifacts_for_run(self, run_id: str) -> RunArtifacts:
-        """
-        Retrieve inputs and outputs for a specific run, organized by key.
-
-        Parameters
-        ----------
-        run_id : str
-            Run identifier.
-
-        Returns
-        -------
-        RunArtifacts
-            Container with ``inputs`` and ``outputs`` dicts. Returns empty
-            collections if the database is not configured.
-        """
-        if not self.db:
-            return RunArtifacts()
-
-        current_run_id = self.current_consist.run.id if self.current_consist else None
-        if run_id != current_run_id:
-            cached = self._run_artifacts_cache.get(run_id)
-            if cached is not None:
-                return cached
-
-        # Get raw list [(Artifact, "input"), (Artifact, "output")]
-        raw_list = self.db.get_artifacts_for_run(run_id)
-
-        inputs = {}
-        outputs = {}
-
-        for artifact, direction in raw_list:
-            if direction == "input":
-                inputs[artifact.key] = artifact
-            elif direction == "output":
-                outputs[artifact.key] = artifact
-
-        artifacts = RunArtifacts(inputs=inputs, outputs=outputs)
-        for artifact in itertools.chain(inputs.values(), outputs.values()):
-            set_tracker_ref(artifact, self)
-        if run_id != current_run_id:
-            self._run_artifacts_cache[run_id] = artifacts
-            if len(self._run_artifacts_cache) > self._run_artifacts_cache_max_entries:
-                self._run_artifacts_cache.pop(next(iter(self._run_artifacts_cache)))
-        return artifacts
+        return self._history_service.get_artifacts_for_run(run_id)
 
     def get_run_outputs(self, run_id: str) -> Dict[str, Artifact]:
-        """
-        Return output artifacts for a run, keyed by artifact key.
-
-        Parameters
-        ----------
-        run_id : str
-            Run identifier.
-
-        Returns
-        -------
-        Dict[str, Artifact]
-            Output artifacts keyed by artifact key. Returns an empty dict if the
-            database is not configured or the run is unknown.
-        """
-        return self.get_artifacts_for_run(run_id).outputs
+        return self._history_service.get_run_outputs(run_id)
 
     def get_run_result(
         self,
@@ -5221,97 +4388,14 @@ class Tracker:
         keys: Optional[Iterable[str]] = None,
         validate: Literal["lazy", "strict", "none"] = "lazy",
     ) -> RunResult:
-        """
-        Build a ``RunResult`` view for a historical run.
-
-        Parameters
-        ----------
-        run_id : str
-            Run identifier.
-        keys : Optional[Iterable[str]], optional
-            Optional subset of output keys to include. When provided, every key
-            must exist in the historical run outputs.
-        validate : {"lazy", "strict", "none"}, default "lazy"
-            Output validation policy.
-            - ``lazy`` / ``none``: no filesystem existence checks
-            - ``strict``: require non-ingested output files to exist on disk
-
-        Returns
-        -------
-        RunResult
-            Historical run metadata plus selected outputs.
-
-        Raises
-        ------
-        KeyError
-            If ``run_id`` is unknown or requested ``keys`` are missing.
-        ValueError
-            If ``validate`` is invalid or ``keys`` contain non-string values.
-        FileNotFoundError
-            If ``validate='strict'`` and a selected non-ingested output is missing.
-        """
-        run = self.get_run(run_id)
-        if run is None:
-            raise KeyError(f"Run {run_id!r} was not found.")
-
-        outputs = self.get_run_outputs(run_id)
-
-        selected_outputs: Dict[str, Artifact]
-        if keys is None:
-            selected_outputs = dict(outputs)
-        else:
-            key_list = list(keys)
-            if any(not isinstance(key, str) for key in key_list):
-                raise ValueError("keys must contain only strings.")
-            missing = sorted(key for key in key_list if key not in outputs)
-            if missing:
-                missing_str = ", ".join(repr(key) for key in missing)
-                available = ", ".join(repr(key) for key in sorted(outputs)) or "<none>"
-                raise KeyError(
-                    f"Run {run_id!r} missing requested output keys: {missing_str}. "
-                    f"Available keys: {available}."
-                )
-            selected_outputs = {key: outputs[key] for key in key_list}
-
-        validation_policy = str(validate).lower()
-        if validation_policy not in {"lazy", "strict", "none"}:
-            raise ValueError("validate must be one of: 'lazy', 'strict', 'none'.")
-
-        if validation_policy == "strict":
-            missing_paths: list[str] = []
-            for key, artifact in selected_outputs.items():
-                if artifact.meta.get("is_ingested", False):
-                    continue
-                resolved = Path(self.resolve_uri(artifact.container_uri))
-                if not resolved.exists():
-                    missing_paths.append(f"{key!r} -> {resolved!s}")
-            if missing_paths:
-                details = "; ".join(missing_paths)
-                raise FileNotFoundError(
-                    f"Run {run_id!r} has missing output files: {details}"
-                )
-
-        cache_hit = (
-            bool(run.meta.get("cache_hit")) if isinstance(run.meta, dict) else False
+        return self._history_service.get_run_result(
+            run_id,
+            keys=keys,
+            validate=validate,
         )
-        return RunResult(run=run, outputs=selected_outputs, cache_hit=cache_hit)
 
     def get_run_inputs(self, run_id: str) -> Dict[str, Artifact]:
-        """
-        Return input artifacts for a run, keyed by artifact key.
-
-        Parameters
-        ----------
-        run_id : str
-            Run identifier.
-
-        Returns
-        -------
-        Dict[str, Artifact]
-            Input artifacts keyed by artifact key. Returns an empty dict if the
-            database is not configured or the run is unknown.
-        """
-        return self.get_artifacts_for_run(run_id).inputs
+        return self._history_service.get_run_inputs(run_id)
 
     def get_run_artifact(
         self,
@@ -5320,49 +4404,15 @@ class Tracker:
         key_contains: Optional[str] = None,
         direction: str = "output",
     ) -> Optional[Artifact]:
-        """
-        Convenience helper to fetch a single artifact for a specific run.
-
-        Args:
-            run_id: Run identifier.
-            key: Exact key to match (if present in logged artifacts).
-            key_contains: Optional substring to match when the exact key is unknown.
-            direction: \"output\" (default) or \"input\".
-        """
-        record = self.get_artifacts_for_run(run_id)
-        collection = record.outputs if direction == "output" else record.inputs
-        if key and key in collection:
-            return collection[key]
-        if key_contains:
-            for k, art in collection.items():
-                if key_contains in k:
-                    return art
-        return next(iter(collection.values()), None)
+        return self._history_service.get_run_artifact(
+            run_id,
+            key=key,
+            key_contains=key_contains,
+            direction=direction,
+        )
 
     def load_run_output(self, run_id: str, key: str, **kwargs: Any) -> Any:
-        """
-        Load a specific output artifact from a run by key.
-
-        Parameters
-        ----------
-        run_id : str
-            Run identifier.
-        key : str
-            Output artifact key to load.
-        **kwargs : Any
-            Forwarded to `Tracker.load(...)`.
-
-        Returns
-        -------
-        Any
-            Loaded artifact data.
-        """
-        artifact = self.get_run_artifact(run_id, key=key, direction="output")
-        if artifact is None:
-            raise ValueError(
-                f"No output artifact found for run_id={run_id!r} key={key!r}."
-            )
-        return self.load(artifact, **kwargs)
+        return self._history_service.load_run_output(run_id, key, **kwargs)
 
     def find_matching_run(
         self,
@@ -5372,44 +4422,20 @@ class Tracker:
         *,
         signature: Optional[str] = None,
     ) -> Optional[Run]:
-        """
-        Find a previously completed run that matches the identity hashes.
-
-        Parameters
-        ----------
-        config_hash : str
-            Hash of the canonicalized config for the run.
-        input_hash : str
-            Hash of the run inputs.
-        git_hash : str
-            Git commit hash captured with the run.
-        signature : str | None, optional
-            Composite run signature. When provided, Consist attempts a direct
-            signature lookup first and falls back to the legacy component-hash
-            lookup for compatibility with older rows.
-
-        Returns
-        -------
-        Optional[Run]
-            The matching run, or ``None`` if not found or if no database is configured.
-        """
-        if self.db:
-            if signature:
-                matched = self.db.find_run_by_signature(signature)
-                if matched is not None:
-                    return matched
-            return self.db.find_matching_run(config_hash, input_hash, git_hash)
-        return None
+        return self._history_service.find_matching_run(
+            config_hash,
+            input_hash,
+            git_hash,
+            signature=signature,
+        )
 
     def find_recent_completed_runs_for_model(
         self, model_name: str, *, limit: int = 20
     ) -> list[Run]:
-        """
-        Return recent completed runs for a model, newest first.
-        """
-        if self.db:
-            return self.db.find_recent_completed_runs_for_model(model_name, limit=limit)
-        return []
+        return self._history_service.find_recent_completed_runs_for_model(
+            model_name,
+            limit=limit,
+        )
 
     def get_artifact_lineage(
         self,
@@ -5689,56 +4715,10 @@ class Tracker:
     def history(
         self, limit: int = 10, tags: Optional[List[str]] = None
     ) -> pd.DataFrame:
-        """
-        Return recent runs as a Pandas DataFrame.
-
-        Parameters
-        ----------
-        limit : int, default 10
-            Maximum number of runs to include.
-        tags : Optional[List[str]], optional
-            If provided, filter runs to those containing any of the given tags.
-
-        Returns
-        -------
-        pd.DataFrame
-            A DataFrame of recent runs (empty if DB is not configured).
-        """
-        if self.db:
-            return self.db.get_history(limit, tags)
-        return pd.DataFrame()
+        return self._history_service.history(limit=limit, tags=tags)
 
     def load_input_bundle(self, run_id: str) -> dict[str, Artifact]:
-        """
-        Load a set of input artifacts from a prior "bundle" run by run_id.
-
-        This is a convenience helper for shared DuckDB bundles where a dedicated
-        run logs all required inputs as outputs. The returned dict can be passed
-        directly to `inputs=[...]` on a new run.
-
-        Parameters
-        ----------
-        run_id : str
-            The run id that logged the bundle outputs.
-
-        Returns
-        -------
-        dict[str, Artifact]
-            Mapping of artifact key -> Artifact from the bundle run.
-
-        Raises
-        ------
-        ValueError
-            If the run does not exist or has no output artifacts.
-        """
-        run = self.get_run(run_id)
-        if not run:
-            raise ValueError(f"Input bundle run_id={run_id!r} not found.")
-
-        outputs = self.get_artifacts_for_run(run_id).outputs
-        if not outputs:
-            raise ValueError(f"Input bundle run_id={run_id!r} has no output artifacts.")
-        return outputs
+        return self._history_service.load_input_bundle(run_id)
 
     @contextmanager
     def capture_outputs(
@@ -5970,3 +4950,44 @@ class Tracker:
                     pass
             set_tracker_ref(artifact, self)
         return artifact
+
+
+_TRACKER_WRAPPER_DOCS = {
+    "get_artifact": TrackerArtifactQueryService.get_artifact,
+    "find_artifacts_with_same_content": (
+        TrackerArtifactQueryService.find_artifacts_with_same_content
+    ),
+    "find_runs_producing_same_content": (
+        TrackerArtifactQueryService.find_runs_producing_same_content
+    ),
+    "select_artifact_schema_for_artifact": (
+        TrackerArtifactQueryService.select_artifact_schema_for_artifact
+    ),
+    "get_artifact_by_uri": TrackerArtifactQueryService.get_artifact_by_uri,
+    "find_artifacts": TrackerArtifactQueryService.find_artifacts,
+    "find_artifacts_by_params": TrackerArtifactQueryService.find_artifacts_by_params,
+    "get_artifact_kv": TrackerArtifactQueryService.get_artifact_kv,
+    "resolve_historical_path": TrackerHistoryService.resolve_historical_path,
+    "get_run": TrackerHistoryService.get_run,
+    "snapshot_db": TrackerHistoryService.snapshot_db,
+    "get_run_record": TrackerHistoryService.get_run_record,
+    "get_run_config": TrackerHistoryService.get_run_config,
+    "get_config_bundle": TrackerHistoryService.get_config_bundle,
+    "get_artifacts_for_run": TrackerHistoryService.get_artifacts_for_run,
+    "get_run_outputs": TrackerHistoryService.get_run_outputs,
+    "get_run_result": TrackerHistoryService.get_run_result,
+    "get_run_inputs": TrackerHistoryService.get_run_inputs,
+    "get_run_artifact": TrackerHistoryService.get_run_artifact,
+    "load_run_output": TrackerHistoryService.load_run_output,
+    "find_matching_run": TrackerHistoryService.find_matching_run,
+    "find_recent_completed_runs_for_model": (
+        TrackerHistoryService.find_recent_completed_runs_for_model
+    ),
+    "history": TrackerHistoryService.history,
+    "load_input_bundle": TrackerHistoryService.load_input_bundle,
+}
+
+for _name, _source in _TRACKER_WRAPPER_DOCS.items():
+    getattr(Tracker, _name).__doc__ = _source.__doc__
+
+del _name, _source

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -49,9 +49,13 @@ from consist.core.run_resolution import (
     write_xarray_dataset as _write_xarray_dataset,
 )
 from consist.core.tracker_artifact_logging import ArtifactLoggingCoordinator
+from consist.core.tracker_artifact_queries import TrackerArtifactQueryService
 from consist.core.tracker_lifecycle import RunLifecycleCoordinator
+from consist.core.tracker_history import TrackerHistoryService
 from consist.core.tracker_orchestration import RunTraceCoordinator, RunTraceHelpers
+from consist.core.tracker_recovery import TrackerRecoveryService
 from consist.core.tracker_config import TrackerConfig
+from consist.core.tracker_config_plans import TrackerConfigPlanService
 from consist.core.config_canonicalization import (
     ConfigAdapter,
     ConfigAdapterOptions,
@@ -78,18 +82,9 @@ from consist.core.views import ViewFactory, ViewRegistry
 from consist.core.ingestion import ingest_artifact
 from consist.core.lineage import LineageService
 from consist.core.materialize import (
-    fold_hydrated_run_outputs_result,
-    hydrate_run_outputs as hydrate_run_outputs_core,
-    materialize_artifacts,
-    stage_artifact as stage_artifact_core,
-    stage_inputs as stage_inputs_core,
+    hydrate_run_outputs as hydrate_run_outputs_core,  # noqa: F401
 )
-from consist.core.materialize_options import (
-    VALID_MATERIALIZE_DB_FALLBACK as _VALID_MATERIALIZE_DB_FALLBACK,
-    VALID_MATERIALIZE_ON_MISSING as _VALID_MATERIALIZE_ON_MISSING,
-    normalize_materialize_output_keys,
-    validate_materialize_option,
-)
+from consist.core.materialize_options import normalize_materialize_output_keys
 from consist.core.matrix import MatrixViewFactory
 from consist.core.netcdf_views import NetCdfMetadataView
 from consist.core.openmatrix_views import OpenMatrixMetadataView
@@ -318,6 +313,10 @@ class Tracker:
                 write_xarray_dataset=_write_xarray_dataset,
             ),
         )
+        self._artifact_queries = TrackerArtifactQueryService(self)
+        self._history_service = TrackerHistoryService(self)
+        self._recovery_service = TrackerRecoveryService(self)
+        self._config_plan_service = TrackerConfigPlanService(self)
 
         self.views = ViewRegistry(self)
         # Store registered schemas by class name for cross-session lookup.
@@ -400,6 +399,65 @@ class Tracker:
             self.on_run_failed(self._lifecycle.emit_failed)
         else:
             self._lifecycle = None
+
+        # Bind extracted service methods on the instance while keeping the
+        # public Tracker API and import path unchanged.
+        self.get_artifact = self._artifact_queries.get_artifact
+        self.find_artifacts_with_same_content = (
+            self._artifact_queries.find_artifacts_with_same_content
+        )
+        self.find_runs_producing_same_content = (
+            self._artifact_queries.find_runs_producing_same_content
+        )
+        self.select_artifact_schema_for_artifact = (
+            self._artifact_queries.select_artifact_schema_for_artifact
+        )
+        self.get_artifact_by_uri = self._artifact_queries.get_artifact_by_uri
+        self.find_artifacts = self._artifact_queries.find_artifacts
+        self._parse_artifact_param_value = (
+            self._artifact_queries._parse_artifact_param_value
+        )
+        self._parse_artifact_param_expression = (
+            self._artifact_queries._parse_artifact_param_expression
+        )
+        self.find_artifacts_by_params = self._artifact_queries.find_artifacts_by_params
+        self.get_artifact_kv = self._artifact_queries.get_artifact_kv
+
+        self.resolve_historical_path = self._history_service.resolve_historical_path
+        self.get_run = self._history_service.get_run
+        self.snapshot_db = self._history_service.snapshot_db
+        self.get_run_record = self._history_service.get_run_record
+        self.get_run_config = self._history_service.get_run_config
+        self.get_config_bundle = self._history_service.get_config_bundle
+        self.get_artifacts_for_run = self._history_service.get_artifacts_for_run
+        self.get_run_outputs = self._history_service.get_run_outputs
+        self.get_run_result = self._history_service.get_run_result
+        self.get_run_inputs = self._history_service.get_run_inputs
+        self.get_run_artifact = self._history_service.get_run_artifact
+        self.load_run_output = self._history_service.load_run_output
+        self.find_matching_run = self._history_service.find_matching_run
+        self.find_recent_completed_runs_for_model = (
+            self._history_service.find_recent_completed_runs_for_model
+        )
+        self.history = self._history_service.history
+        self.load_input_bundle = self._history_service.load_input_bundle
+
+        self._adapter_accepts_options = (
+            self._config_plan_service._adapter_accepts_options
+        )
+        self._discover_config = self._config_plan_service._discover_config
+        self._canonicalize_config = self._config_plan_service._canonicalize_config
+        self.canonicalize_config = self._config_plan_service.canonicalize_config
+        self.prepare_config = self._config_plan_service.prepare_config
+        self.prepare_config_resolver = self._config_plan_service.prepare_config_resolver
+        self.apply_config_plan = self._config_plan_service.apply_config_plan
+        self.identity_from_config_plan = (
+            self._config_plan_service.identity_from_config_plan
+        )
+        self._apply_config_contribution = (
+            self._config_plan_service._apply_config_contribution
+        )
+        self._ingest_cache_hit = self._config_plan_service._ingest_cache_hit
 
     @property
     def db(self) -> DatabaseManager | None:
@@ -4064,12 +4122,11 @@ class Tracker:
             The destination path for the materialized artifact, or ``None`` if
             missing and ``on_missing="warn"``.
         """
-        result = materialize_artifacts(
-            tracker=self,
-            items=[(artifact, Path(destination_path))],
+        return self._recovery_service.materialize(
+            artifact,
+            destination_path,
             on_missing=on_missing,
         )
-        return result.get(artifact.key)
 
     def stage_artifact(
         self,
@@ -4094,10 +4151,9 @@ class Tracker:
         ``Tracker.run(...)`` when you want the staging side effect to happen as
         part of a normal run lifecycle.
         """
-        return stage_artifact_core(
-            self,
+        return self._recovery_service.stage_artifact(
             artifact,
-            Path(destination),
+            destination=destination,
             mode=mode,
             overwrite=overwrite,
             validate_content_hash=validate_content_hash,
@@ -4122,14 +4178,9 @@ class Tracker:
         behavior through ``ExecutionOptions`` on ``run(...)`` or
         ``ScenarioContext.run(...)``.
         """
-        normalized_destinations = {
-            str(key): Path(destination)
-            for key, destination in destinations_by_key.items()
-        }
-        return stage_inputs_core(
-            self,
+        return self._recovery_service.stage_inputs(
             inputs_by_key,
-            normalized_destinations,
+            destinations_by_key=destinations_by_key,
             mode=mode,
             overwrite=overwrite,
             validate_content_hash=validate_content_hash,
@@ -4902,16 +4953,14 @@ class Tracker:
         MaterializationResult
             Aggregate summary of the selected outputs.
         """
-        return fold_hydrated_run_outputs_result(
-            self.hydrate_run_outputs(
-                run_id,
-                target_root=target_root,
-                source_root=source_root,
-                keys=keys,
-                preserve_existing=preserve_existing,
-                on_missing=on_missing,
-                db_fallback=db_fallback,
-            )
+        return self._recovery_service.materialize_run_outputs(
+            run_id,
+            target_root=target_root,
+            source_root=source_root,
+            keys=keys,
+            preserve_existing=preserve_existing,
+            on_missing=on_missing,
+            db_fallback=db_fallback,
         )
 
     def hydrate_run_outputs(
@@ -5006,53 +5055,11 @@ class Tracker:
         >>> persons.artifact.as_path()
         PosixPath('.../restored/.../persons.parquet')
         """
-        normalized_keys = normalize_materialize_output_keys(
-            keys,
-            caller="hydrate_run_outputs",
-        )
-        validate_materialize_option(
-            name="on_missing",
-            value=on_missing,
-            allowed=_VALID_MATERIALIZE_ON_MISSING,
-        )
-        validate_materialize_option(
-            name="db_fallback",
-            value=db_fallback,
-            allowed=_VALID_MATERIALIZE_DB_FALLBACK,
-        )
-
-        if self.db is None:
-            raise RuntimeError(
-                "Cannot materialize run outputs: tracker has no database configured."
-            )
-
-        run = self.get_run(run_id)
-        if run is None:
-            raise KeyError(f"Run {run_id!r} was not found.")
-
-        from consist.core import materialize as materialize_core
-
-        destination_root = Path(target_root).resolve()
-        allowed_roots = materialize_core.build_allowed_materialization_roots(
-            run_dir=self.run_dir,
-            mounts=self.mounts,
-            allow_external_paths=self.allow_external_paths,
-        )
-        materialize_core.validate_allowed_materialization_destination(
-            destination_root, allowed_roots
-        )
-
-        source_root_override = (
-            Path(source_root).resolve() if source_root is not None else None
-        )
-
-        return hydrate_run_outputs_core(
-            tracker=self,
-            run=run,
-            target_root=destination_root,
-            source_root=source_root_override,
-            keys=normalized_keys,
-            allowed_base=allowed_roots,
+        return self._recovery_service.hydrate_run_outputs(
+            run_id,
+            target_root=target_root,
+            source_root=source_root,
+            keys=keys,
             preserve_existing=preserve_existing,
             on_missing=on_missing,
             db_fallback=db_fallback,

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -3418,7 +3418,13 @@ class Tracker:
         )
 
     def _ingest_cache_hit(self, table_name: str, content_hash: str) -> bool:
-        return self._config_plan_service._ingest_cache_hit(table_name, content_hash)
+        config_plan_service = getattr(self, "_config_plan_service", None)
+        if config_plan_service is None:
+            # Compatibility fallback for legacy/partial Tracker stubs that are
+            # constructed via ``Tracker.__new__`` in focused unit tests.
+            config_plan_service = TrackerConfigPlanService(self)
+            self._config_plan_service = config_plan_service
+        return config_plan_service._ingest_cache_hit(table_name, content_hash)
 
     # --- View Factory ---
 

--- a/src/consist/core/tracker_artifact_queries.py
+++ b/src/consist/core/tracker_artifact_queries.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Iterable, List, Optional, TYPE_CHECKING, Union
+
+from consist.core._tracker_service_base import _TrackerServiceBase
+from consist.models.artifact import Artifact, set_tracker_ref
+from consist.models.run import Run
+
+if TYPE_CHECKING:
+    from consist.core.persistence import ArtifactSchemaSelection, SchemaProfileSource
+
+
+class TrackerArtifactQueryService(_TrackerServiceBase):
+    def get_artifact(
+        self,
+        key_or_id: Union[str, uuid.UUID],
+        *,
+        run_id: Optional[str] = None,
+    ) -> Optional[Artifact]:
+        if self.db:
+            artifact = self.db.get_artifact(key_or_id, run_id=run_id)
+            if artifact is not None:
+                set_tracker_ref(artifact, self._tracker)
+            return artifact
+        return None
+
+    def find_artifacts_with_same_content(
+        self, artifact: Union[Artifact, str, uuid.UUID]
+    ) -> List[Artifact]:
+        if not self.db:
+            return []
+        target = (
+            artifact if isinstance(artifact, Artifact) else self.get_artifact(artifact)
+        )
+        if target is None or target.content_id is None:
+            return []
+        artifacts = self.db.find_artifacts_by_content_id(target.content_id)
+        for item in artifacts:
+            set_tracker_ref(item, self._tracker)
+        return artifacts
+
+    def find_runs_producing_same_content(
+        self, artifact: Union[Artifact, str, uuid.UUID]
+    ) -> List[str]:
+        if not self.db:
+            return []
+        target = (
+            artifact if isinstance(artifact, Artifact) else self.get_artifact(artifact)
+        )
+        if target is None or target.content_id is None:
+            return []
+        return self.db.find_runs_producing_content(target.content_id)
+
+    def select_artifact_schema_for_artifact(
+        self,
+        *,
+        artifact_id: Union[str, uuid.UUID],
+        source: Optional["SchemaProfileSource"] = None,
+        strict_source: bool = False,
+    ) -> Optional["ArtifactSchemaSelection"]:
+        if not self.db:
+            raise ValueError(
+                "Schema selection requires a configured database (db_path)."
+            )
+        artifact_uuid = (
+            uuid.UUID(artifact_id) if isinstance(artifact_id, str) else artifact_id
+        )
+        return self.db.select_artifact_schema_for_artifact(
+            artifact_id=artifact_uuid,
+            prefer_source=source,
+            strict_source=strict_source,
+        )
+
+    def get_artifact_by_uri(
+        self,
+        uri: str,
+        *,
+        table_path: Optional[str] = None,
+        array_path: Optional[str] = None,
+    ) -> Optional[Artifact]:
+        if self.current_consist:
+            for art in self.current_consist.inputs + self.current_consist.outputs:
+                if art.container_uri != uri:
+                    continue
+                if table_path is not None and art.table_path != table_path:
+                    continue
+                if array_path is not None and art.array_path != array_path:
+                    continue
+                return art
+
+        if self.db:
+            artifact = self.db.get_artifact_by_uri(
+                uri, table_path=table_path, array_path=array_path
+            )
+            if artifact is not None:
+                set_tracker_ref(artifact, self._tracker)
+            return artifact
+
+        return None
+
+    def find_artifacts(
+        self,
+        *,
+        creator: Optional[Union[str, Run]] = None,
+        consumer: Optional[Union[str, Run]] = None,
+        key: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Artifact]:
+        if not self.db:
+            return []
+
+        creator_id = creator.id if isinstance(creator, Run) else creator
+        consumer_id = consumer.id if isinstance(consumer, Run) else consumer
+
+        artifacts = self.db.find_artifacts(
+            creator=creator_id, consumer=consumer_id, key=key, limit=limit
+        )
+        for artifact in artifacts:
+            set_tracker_ref(artifact, self._tracker)
+        return artifacts
+
+    @staticmethod
+    def _parse_artifact_param_value(raw: str) -> tuple[str, Any]:
+        value = raw.strip()
+        lowered = value.lower()
+        if lowered == "true":
+            return "bool", True
+        if lowered == "false":
+            return "bool", False
+        if lowered == "null":
+            return "null", None
+        try:
+            if "." not in value and "e" not in lowered:
+                return "num", int(value)
+            return "num", float(value)
+        except ValueError:
+            return "str", value
+
+    def _parse_artifact_param_expression(self, expression: str) -> Dict[str, Any]:
+        raw = expression.strip()
+        operator = None
+        for candidate in (">=", "<=", "="):
+            idx = raw.find(candidate)
+            if idx > 0:
+                operator = candidate
+                lhs = raw[:idx].strip()
+                rhs = raw[idx + len(candidate) :].strip()
+                break
+
+        if operator is None:
+            raise ValueError(
+                f"Invalid artifact facet predicate {expression!r}. "
+                "Expected <key>=<value>, <key>>=<value>, or <key><=<value>."
+            )
+        if not lhs:
+            raise ValueError(
+                f"Artifact facet predicate is missing a key: {expression!r}"
+            )
+        if rhs == "":
+            raise ValueError(
+                f"Artifact facet predicate is missing a value: {expression!r}"
+            )
+
+        namespace = None
+        key_path = lhs
+        if "." in lhs:
+            maybe_namespace, remainder = lhs.split(".", 1)
+            if maybe_namespace and remainder:
+                namespace = maybe_namespace
+                key_path = remainder
+
+        value_kind, value = self._parse_artifact_param_value(rhs)
+        if operator in {">=", "<="} and value_kind != "num":
+            raise ValueError(
+                f"Artifact facet predicate {expression!r} uses {operator} with a "
+                "non-numeric value."
+            )
+
+        return {
+            "namespace": namespace,
+            "key_path": key_path,
+            "op": operator,
+            "kind": value_kind,
+            "value": value,
+        }
+
+    def find_artifacts_by_params(
+        self,
+        *,
+        params: Optional[Iterable[str]] = None,
+        namespace: Optional[str] = None,
+        key_prefix: Optional[str] = None,
+        artifact_family_prefix: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Artifact]:
+        if not self.db:
+            return []
+
+        predicates = (
+            [self._parse_artifact_param_expression(param) for param in params]
+            if params
+            else []
+        )
+
+        artifacts = self.db.find_artifacts_by_facet_params(
+            predicates=predicates,
+            namespace=namespace,
+            key_prefix=key_prefix,
+            artifact_family_prefix=artifact_family_prefix,
+            limit=limit,
+        )
+        for artifact in artifacts:
+            set_tracker_ref(artifact, self._tracker)
+        return artifacts
+
+    def get_artifact_kv(
+        self,
+        artifact: Union[Artifact, uuid.UUID],
+        *,
+        namespace: Optional[str] = None,
+        prefix: Optional[str] = None,
+        limit: int = 10_000,
+    ):
+        if not self.db:
+            return []
+        artifact_id = artifact.id if isinstance(artifact, Artifact) else artifact
+        return self.db.get_artifact_kv(
+            artifact_id=artifact_id,
+            namespace=namespace,
+            prefix=prefix,
+            limit=limit,
+        )

--- a/src/consist/core/tracker_artifact_queries.py
+++ b/src/consist/core/tracker_artifact_queries.py
@@ -18,6 +18,21 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         *,
         run_id: Optional[str] = None,
     ) -> Optional[Artifact]:
+        """
+        Retrieve an artifact by semantic key or artifact id.
+
+        Parameters
+        ----------
+        key_or_id : str | uuid.UUID
+            Artifact key or artifact UUID.
+        run_id : Optional[str], optional
+            Optional run id that limits lookup to artifacts linked to that run.
+
+        Returns
+        -------
+        Optional[Artifact]
+            Matching artifact, or ``None`` when no match exists.
+        """
         if self.db:
             artifact = self.db.get_artifact(key_or_id, run_id=run_id)
             if artifact is not None:
@@ -28,6 +43,19 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
     def find_artifacts_with_same_content(
         self, artifact: Union[Artifact, str, uuid.UUID]
     ) -> List[Artifact]:
+        """
+        Find artifacts that share the same content identity.
+
+        Parameters
+        ----------
+        artifact : Artifact | str | uuid.UUID
+            Artifact instance or identifier to resolve first.
+
+        Returns
+        -------
+        List[Artifact]
+            Artifacts with the same ``content_id`` as the target artifact.
+        """
         if not self.db:
             return []
         target = (
@@ -43,6 +71,19 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
     def find_runs_producing_same_content(
         self, artifact: Union[Artifact, str, uuid.UUID]
     ) -> List[str]:
+        """
+        Find run ids that produced artifacts with the same content identity.
+
+        Parameters
+        ----------
+        artifact : Artifact | str | uuid.UUID
+            Artifact instance or identifier to resolve first.
+
+        Returns
+        -------
+        List[str]
+            Run ids linked to output artifacts sharing the same ``content_id``.
+        """
         if not self.db:
             return []
         target = (
@@ -59,6 +100,23 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         source: Optional["SchemaProfileSource"] = None,
         strict_source: bool = False,
     ) -> Optional["ArtifactSchemaSelection"]:
+        """
+        Resolve schema-selection metadata for an artifact.
+
+        Parameters
+        ----------
+        artifact_id : str | uuid.UUID
+            Artifact identifier to inspect.
+        source : Optional[SchemaProfileSource], optional
+            Preferred schema profile source.
+        strict_source : bool, default False
+            Require the selected schema to come from ``source`` when provided.
+
+        Returns
+        -------
+        Optional[ArtifactSchemaSelection]
+            Selection metadata used to explain which schema was chosen.
+        """
         if not self.db:
             raise ValueError(
                 "Schema selection requires a configured database (db_path)."
@@ -79,6 +137,23 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         table_path: Optional[str] = None,
         array_path: Optional[str] = None,
     ) -> Optional[Artifact]:
+        """
+        Find an artifact by URI and optional sub-path selectors.
+
+        Parameters
+        ----------
+        uri : str
+            Artifact container URI to match.
+        table_path : Optional[str], optional
+            Optional table path to match for container-backed artifacts.
+        array_path : Optional[str], optional
+            Optional array path to match for array-backed artifacts.
+
+        Returns
+        -------
+        Optional[Artifact]
+            Matching artifact, or ``None`` when nothing matches.
+        """
         if self.current_consist:
             for art in self.current_consist.inputs + self.current_consist.outputs:
                 if art.container_uri != uri:
@@ -107,6 +182,25 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         key: Optional[str] = None,
         limit: int = 100,
     ) -> List[Artifact]:
+        """
+        Find artifacts by producing run, consuming run, and optional key.
+
+        Parameters
+        ----------
+        creator : Optional[str | Run], optional
+            Producing run or run id.
+        consumer : Optional[str | Run], optional
+            Consuming run or run id.
+        key : Optional[str], optional
+            Exact artifact key to match.
+        limit : int, default 100
+            Maximum number of artifacts to return.
+
+        Returns
+        -------
+        List[Artifact]
+            Matching artifact records.
+        """
         if not self.db:
             return []
 
@@ -194,6 +288,27 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         artifact_family_prefix: Optional[str] = None,
         limit: int = 100,
     ) -> List[Artifact]:
+        """
+        Find artifacts by indexed facet predicates and prefix filters.
+
+        Parameters
+        ----------
+        params : Optional[Iterable[str]], optional
+            Facet predicate expressions such as ``year=2018``.
+        namespace : Optional[str], optional
+            Default namespace for predicates without an explicit namespace.
+        key_prefix : Optional[str], optional
+            Optional artifact-key prefix filter.
+        artifact_family_prefix : Optional[str], optional
+            Optional artifact-family prefix filter.
+        limit : int, default 100
+            Maximum number of artifacts to return.
+
+        Returns
+        -------
+        List[Artifact]
+            Matching artifact records.
+        """
         if not self.db:
             return []
 
@@ -222,6 +337,25 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         prefix: Optional[str] = None,
         limit: int = 10_000,
     ):
+        """
+        Retrieve flattened artifact facet key/value rows.
+
+        Parameters
+        ----------
+        artifact : Artifact | uuid.UUID
+            Artifact instance or artifact id.
+        namespace : Optional[str], optional
+            Optional namespace filter.
+        prefix : Optional[str], optional
+            Optional key prefix filter.
+        limit : int, default 10_000
+            Maximum number of rows to return.
+
+        Returns
+        -------
+        list
+            Flattened key/value rows for the selected artifact.
+        """
         if not self.db:
             return []
         artifact_id = artifact.id if isinstance(artifact, Artifact) else artifact

--- a/src/consist/core/tracker_config_plans.py
+++ b/src/consist/core/tracker_config_plans.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import inspect
+import logging
+import re
+from collections.abc import Mapping as MappingABC
+from dataclasses import replace
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    TYPE_CHECKING,
+    Union,
+    cast,
+)
+
+from consist.core._tracker_service_base import _TrackerServiceBase
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    CanonicalizationResult,
+    ConfigAdapter,
+    ConfigAdapterOptions,
+    ConfigContribution,
+    ConfigPlan,
+    validate_config_plan,
+)
+from consist.models.run import Run
+
+if TYPE_CHECKING:
+    from consist.core.tracker import Tracker
+    from consist.models.artifact import Artifact
+    from consist.core.step_context import StepContext
+
+
+_SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _is_safe_identifier(identifier: str) -> bool:
+    return bool(_SAFE_IDENTIFIER_RE.fullmatch(identifier))
+
+
+def _quote_ident(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+class TrackerConfigPlanService(_TrackerServiceBase):
+    def _adapter_accepts_options(
+        self, adapter: ConfigAdapter, method_name: str
+    ) -> bool:
+        method = getattr(adapter, method_name, None)
+        if method is None:
+            return False
+        try:
+            signature = inspect.signature(method)
+        except (TypeError, ValueError):
+            return False
+        if "options" in signature.parameters:
+            return True
+        return any(
+            param.kind == param.VAR_KEYWORD for param in signature.parameters.values()
+        )
+
+    def _discover_config(
+        self,
+        adapter: ConfigAdapter,
+        config_dir_paths: list[Path],
+        strict: bool,
+        options: Optional[ConfigAdapterOptions],
+    ) -> CanonicalConfig:
+        kwargs: dict[str, Any] = {}
+        if options is not None and self._adapter_accepts_options(adapter, "discover"):
+            kwargs["options"] = options
+        return adapter.discover(
+            config_dir_paths, identity=self.identity, strict=strict, **kwargs
+        )
+
+    def _canonicalize_config(
+        self,
+        adapter: ConfigAdapter,
+        canonical: CanonicalConfig,
+        *,
+        run: Optional[Run],
+        tracker: Optional["Tracker"],
+        strict: bool,
+        plan_only: bool,
+        options: Optional[ConfigAdapterOptions],
+    ) -> CanonicalizationResult:
+        kwargs: dict[str, Any] = {}
+        if options is not None and self._adapter_accepts_options(
+            adapter, "canonicalize"
+        ):
+            kwargs["options"] = options
+        return adapter.canonicalize(
+            canonical,
+            run=run,
+            tracker=tracker,
+            strict=strict,
+            plan_only=plan_only,
+            **kwargs,
+        )
+
+    def canonicalize_config(
+        self,
+        adapter: ConfigAdapter,
+        config_dirs: Iterable[Union[str, Path]],
+        *,
+        run: Optional[Run] = None,
+        run_id: Optional[str] = None,
+        strict: bool = False,
+        ingest: bool = True,
+        profile_schema: bool = False,
+        options: Optional[ConfigAdapterOptions] = None,
+    ) -> ConfigContribution:
+        if run is not None and run_id is not None:
+            raise ValueError("Provide either run= or run_id=, not both.")
+        if options is not None and (strict is not False or ingest is not True):
+            raise ValueError(
+                "When options= is provided, do not pass strict= or ingest=."
+            )
+        if options is not None:
+            strict = options.strict
+            ingest = options.ingest
+
+        target_run = run
+        if target_run is None and run_id is not None:
+            if self.current_consist and self.current_consist.run.id == run_id:
+                target_run = self.current_consist.run
+            else:
+                raise RuntimeError(
+                    "canonicalize_config requires an active run matching run_id=."
+                )
+        if target_run is None and self.current_consist:
+            target_run = self.current_consist.run
+        if target_run is None:
+            raise RuntimeError("canonicalize_config requires an active run or run=.")
+
+        config_dir_paths = [Path(p).resolve() for p in config_dirs]
+        canonical = self._discover_config(adapter, config_dir_paths, strict, options)
+        result = self._canonicalize_config(
+            adapter,
+            canonical,
+            run=target_run,
+            tracker=self,
+            strict=strict,
+            plan_only=False,
+            options=options,
+        )
+
+        contribution = ConfigContribution(
+            identity_hash=canonical.content_hash,
+            adapter_version=getattr(adapter, "adapter_version", None),
+            artifacts=result.artifacts,
+            ingestables=result.ingestables,
+            meta={
+                "adapter": adapter.model_name,
+                "config_dirs": [str(p) for p in config_dir_paths],
+            },
+        )
+
+        self._apply_config_contribution(
+            contribution,
+            run=target_run,
+            ingest=ingest,
+            profile_schema=profile_schema,
+        )
+
+        if target_run.meta is None:
+            target_run.meta = {}
+        target_run.meta["config_bundle_hash"] = canonical.content_hash
+        target_run.meta["config_adapter"] = adapter.model_name
+        if contribution.adapter_version is not None:
+            target_run.meta["config_adapter_version"] = contribution.adapter_version
+
+        return contribution
+
+    def prepare_config(
+        self,
+        adapter: ConfigAdapter,
+        config_dirs: Iterable[Union[str, Path]],
+        *,
+        strict: bool = False,
+        options: Optional[ConfigAdapterOptions] = None,
+        validate_only: bool = False,
+        facet_spec: Optional[Dict[str, Any]] = None,
+        facet_schema_name: Optional[str] = None,
+        facet_schema_version: Optional[Union[str, int]] = None,
+        facet_index: Optional[bool] = None,
+    ) -> ConfigPlan:
+        if options is not None and strict is not False:
+            raise ValueError("When options= is provided, do not pass strict=.")
+        if options is not None:
+            strict = options.strict
+        config_dir_paths = [Path(p).resolve() for p in config_dirs]
+        canonical = self._discover_config(adapter, config_dir_paths, strict, options)
+        result = self._canonicalize_config(
+            adapter,
+            canonical,
+            run=None,
+            tracker=None,
+            strict=strict,
+            plan_only=True,
+            options=options,
+        )
+        facet_data = None
+        if facet_spec is not None:
+            if hasattr(adapter, "build_facet"):
+                facet_data = adapter.build_facet(canonical, facet_spec=facet_spec)
+                if facet_data is not None:
+                    facet_data = self.identity.normalize_json(facet_data)
+            else:
+                raise ValueError(
+                    "facet_spec provided but adapter does not support build_facet()."
+                )
+
+        plan = ConfigPlan(
+            adapter_name=adapter.model_name,
+            adapter_version=getattr(adapter, "adapter_version", None),
+            canonical=canonical,
+            artifacts=result.artifacts,
+            ingestables=result.ingestables,
+            facet=facet_data,
+            facet_schema_name=facet_schema_name,
+            facet_schema_version=facet_schema_version,
+            facet_index=facet_index,
+            meta={
+                "adapter": adapter.model_name,
+                "config_dirs": [str(p) for p in config_dir_paths],
+            },
+            adapter=adapter,
+        )
+        if validate_only:
+            diagnostics = validate_config_plan(plan)
+            return replace(plan, diagnostics=diagnostics)
+        return plan
+
+    def prepare_config_resolver(
+        self,
+        adapter: ConfigAdapter,
+        *,
+        config_dirs: Optional[Iterable[Union[str, Path]]] = None,
+        config_dirs_from: Optional[
+            Union[str, Callable[["StepContext"], Iterable[Union[str, Path]]]]
+        ] = None,
+        strict: bool = False,
+        options: Optional[ConfigAdapterOptions] = None,
+        validate_only: bool = False,
+        facet_spec: Optional[Dict[str, Any]] = None,
+        facet_schema_name: Optional[str] = None,
+        facet_schema_version: Optional[Union[str, int]] = None,
+        facet_index: Optional[bool] = None,
+    ) -> Callable[["StepContext"], ConfigPlan]:
+        if (config_dirs is None) == (config_dirs_from is None):
+            raise ValueError(
+                "prepare_config_resolver requires exactly one of "
+                "config_dirs= or config_dirs_from=."
+            )
+
+        static_dirs = tuple(config_dirs) if config_dirs is not None else None
+
+        def _resolve_runtime_path(ctx: "StepContext", path: str) -> object:
+            parts = [part for part in path.split(".") if part]
+            if not parts:
+                raise ValueError(
+                    "config_dirs_from path must be non-empty (e.g., "
+                    "'settings.config_dirs')."
+                )
+            value: object = ctx.require_runtime(parts[0])
+            for part in parts[1:]:
+                if isinstance(value, MappingABC):
+                    mapping_value = cast(Mapping[str, object], value)
+                    if part not in mapping_value:
+                        raise ValueError(
+                            f"Missing runtime mapping key {part!r} while resolving "
+                            f"config_dirs_from={path!r}."
+                        )
+                    value = mapping_value[part]
+                    continue
+                if not hasattr(value, part):
+                    raise ValueError(
+                        f"Missing runtime attribute {part!r} while resolving "
+                        f"config_dirs_from={path!r}."
+                    )
+                value = getattr(value, part)
+            return value
+
+        def _resolve_dirs(ctx: "StepContext") -> Iterable[Union[str, Path]]:
+            if static_dirs is not None:
+                return static_dirs
+            source = config_dirs_from
+            if isinstance(source, str):
+                candidate = _resolve_runtime_path(ctx, source)
+            else:
+                source_from_ctx = cast(
+                    Callable[["StepContext"], Iterable[Union[str, Path]]], source
+                )
+                candidate = source_from_ctx(ctx)
+            if isinstance(candidate, (str, Path)):
+                raise ValueError(
+                    "Resolved config_dirs must be an iterable of paths, not a single "
+                    f"value: {candidate!r}."
+                )
+            return cast(Iterable[Union[str, Path]], candidate)
+
+        def _resolver(ctx: "StepContext") -> ConfigPlan:
+            return self._tracker.prepare_config(
+                adapter=adapter,
+                config_dirs=_resolve_dirs(ctx),
+                strict=strict,
+                options=options,
+                validate_only=validate_only,
+                facet_spec=facet_spec,
+                facet_schema_name=facet_schema_name,
+                facet_schema_version=facet_schema_version,
+                facet_index=facet_index,
+            )
+
+        return _resolver
+
+    def apply_config_plan(
+        self,
+        plan: ConfigPlan,
+        *,
+        run: Optional[Run] = None,
+        ingest: bool = True,
+        profile_schema: bool = False,
+        adapter: Optional[ConfigAdapter] = None,
+        options: Optional[ConfigAdapterOptions] = None,
+    ) -> ConfigContribution:
+        if options is not None and ingest is not True:
+            raise ValueError("When options= is provided, do not pass ingest=.")
+        if options is not None:
+            ingest = options.ingest
+
+        target_run = run
+        if target_run is None and self.current_consist:
+            target_run = self.current_consist.run
+        if target_run is None:
+            raise RuntimeError("apply_config_plan requires an active run or run=.")
+
+        artifacts = list(plan.artifacts)
+        adapter_ref = adapter or plan.adapter
+        if adapter_ref is not None and (options is None or options.bundle):
+            bundle_artifact = getattr(adapter_ref, "bundle_artifact", None)
+            if callable(bundle_artifact):
+                bundle_spec = bundle_artifact(
+                    plan.canonical, run=target_run, tracker=self
+                )
+                if bundle_spec is not None:
+                    artifacts.append(bundle_spec)
+
+        contribution = ConfigContribution(
+            identity_hash=plan.identity_hash,
+            adapter_version=plan.adapter_version,
+            artifacts=artifacts,
+            ingestables=plan.ingestables,
+            facet=plan.facet,
+            facet_schema_name=plan.facet_schema_name,
+            facet_schema_version=plan.facet_schema_version,
+            meta=dict(plan.meta or {}),
+        )
+
+        self._apply_config_contribution(
+            contribution,
+            run=target_run,
+            ingest=ingest,
+            profile_schema=profile_schema,
+        )
+
+        if target_run.meta is None:
+            target_run.meta = {}
+        target_run.meta["config_bundle_hash"] = plan.identity_hash
+        target_run.meta["config_adapter"] = plan.adapter_name
+        if plan.adapter_version is not None:
+            target_run.meta["config_adapter_version"] = plan.adapter_version
+
+        if plan.facet is not None:
+            facet_dict = plan.facet
+            if self.current_consist is not None:
+                self.current_consist.facet = facet_dict
+            schema_name = (
+                plan.facet_schema_name
+                or self.config_facets.infer_schema_name(None, facet_dict)
+            )
+            self.config_facets.persist_facet(
+                run=target_run,
+                model=target_run.model_name,
+                facet_dict=facet_dict,
+                schema_name=schema_name,
+                schema_version=plan.facet_schema_version,
+                index_kv=plan.facet_index if plan.facet_index is not None else True,
+            )
+
+        return contribution
+
+    def identity_from_config_plan(self, plan: ConfigPlan) -> str:
+        return plan.identity_hash
+
+    def _apply_config_contribution(
+        self,
+        contribution: ConfigContribution,
+        *,
+        run: Run,
+        ingest: bool,
+        profile_schema: bool,
+    ) -> Dict[str, "Artifact"]:
+        artifacts_by_key: Dict[str, "Artifact"] = {}
+        with self.persistence.batch_artifact_writes():
+            for spec in contribution.artifacts:
+                art = self.log_artifact(
+                    spec.path,
+                    key=spec.key,
+                    direction=spec.direction,
+                    **spec.meta,
+                )
+                artifacts_by_key[spec.key] = art
+
+        if ingest:
+            for spec in contribution.ingestables:
+                source_key = spec.source
+                artifact = (
+                    artifacts_by_key.get(source_key)
+                    if source_key
+                    else next(iter(artifacts_by_key.values()), None)
+                )
+                if artifact is None:
+                    logging.warning(
+                        "[Consist] Skipping ingest for %s; no source artifact found.",
+                        spec.table_name,
+                    )
+                    continue
+                if spec.rows is None:
+                    logging.warning(
+                        "[Consist] Skipping ingest for %s; no rows provided.",
+                        spec.table_name,
+                    )
+                    continue
+                if spec.dedupe_on_hash and spec.content_hash:
+                    if self._ingest_cache_hit(spec.table_name, spec.content_hash):
+                        logging.info(
+                            "[Consist] Skipping ingest for %s; cache hit for %s.",
+                            spec.table_name,
+                            spec.content_hash,
+                        )
+                        continue
+                if source_key is None:
+                    logging.warning(
+                        "[Consist] Ingest spec for %s missing source; using %s.",
+                        spec.table_name,
+                        artifact.key,
+                    )
+                rows = spec.materialize_rows(run.id)
+                self.ingest(
+                    artifact,
+                    data=rows,
+                    schema=spec.schema,
+                    run=run,
+                    profile_schema=profile_schema,
+                )
+
+        return artifacts_by_key
+
+    def _ingest_cache_hit(self, table_name: str, content_hash: str) -> bool:
+        store = getattr(self, "hot_data_store", None)
+        if store is not None:
+            return store.ingest_cache_hit(table_name, content_hash)
+
+        if self.engine is None:
+            return False
+        if not _is_safe_identifier(table_name):
+            return False
+        table_ref = f"{_quote_ident('global_tables')}.{_quote_ident(table_name)}"
+        try:
+            with self.engine.begin() as connection:
+                result = connection.exec_driver_sql(
+                    f"SELECT 1 FROM {table_ref} WHERE content_hash = ? LIMIT 1",
+                    (content_hash,),
+                ).fetchone()
+            return result is not None
+        except Exception:
+            return False

--- a/src/consist/core/tracker_config_plans.py
+++ b/src/consist/core/tracker_config_plans.py
@@ -347,7 +347,7 @@ class TrackerConfigPlanService(_TrackerServiceBase):
             bundle_artifact = getattr(adapter_ref, "bundle_artifact", None)
             if callable(bundle_artifact):
                 bundle_spec = bundle_artifact(
-                    plan.canonical, run=target_run, tracker=self
+                    plan.canonical, run=target_run, tracker=self._tracker
                 )
                 if bundle_spec is not None:
                     artifacts.append(bundle_spec)

--- a/src/consist/core/tracker_config_plans.py
+++ b/src/consist/core/tracker_config_plans.py
@@ -144,7 +144,7 @@ class TrackerConfigPlanService(_TrackerServiceBase):
             adapter,
             canonical,
             run=target_run,
-            tracker=self,
+            tracker=self._tracker,
             strict=strict,
             plan_only=False,
             options=options,

--- a/src/consist/core/tracker_config_plans.py
+++ b/src/consist/core/tracker_config_plans.py
@@ -48,6 +48,15 @@ def _quote_ident(identifier: str) -> str:
 
 
 class TrackerConfigPlanService(_TrackerServiceBase):
+    """
+    Config planning and apply-time helpers extracted from ``Tracker``.
+
+    This service owns adapter-driven config discovery, planning, and application
+    logic. It remains intentionally tracker-backed for now, so callers should
+    treat ``Tracker`` as the public API surface and this class as an internal
+    organization boundary.
+    """
+
     def _adapter_accepts_options(
         self, adapter: ConfigAdapter, method_name: str
     ) -> bool:

--- a/src/consist/core/tracker_history.py
+++ b/src/consist/core/tracker_history.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import itertools
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Literal, Optional
+
+import pandas as pd
+
+from consist.core._tracker_service_base import _TrackerServiceBase
+from consist.models.artifact import Artifact, set_tracker_ref
+from consist.models.run import ConsistRecord, Run, RunArtifacts, RunResult
+
+
+class TrackerHistoryService(_TrackerServiceBase):
+    def resolve_historical_path(self, artifact: Artifact, run: Run) -> Path:
+        if not run:
+            return Path(self.resolve_uri(artifact.container_uri))
+
+        old_dir = run.meta.get("_physical_run_dir")
+        path_str = self.fs.resolve_historical_path(artifact.container_uri, old_dir)
+        return Path(path_str)
+
+    def get_run(self, run_id: str) -> Optional[Run]:
+        if self.db:
+            return self.db.get_run(run_id)
+        return None
+
+    def snapshot_db(
+        self, dest_path: str | os.PathLike[str], checkpoint: bool = True
+    ) -> Path:
+        if self.db is None:
+            raise RuntimeError("Database snapshot requires a configured database.")
+
+        active_run_id = self.current_consist.run.id if self.current_consist else None
+        last_completed_run_id: Optional[str] = None
+        if (
+            self._last_consist is not None
+            and self._last_consist.run.status == "completed"
+        ):
+            last_completed_run_id = self._last_consist.run.id
+        else:
+            completed_runs = self.db.find_runs(status="completed", limit=1)
+            if completed_runs:
+                last_completed_run_id = completed_runs[0].id
+
+        return self.db.snapshot_to(
+            dest_path=dest_path,
+            checkpoint=checkpoint,
+            metadata={
+                "run_id": active_run_id,
+                "last_completed_run_id": last_completed_run_id,
+                "cache_epoch": self._cache_epoch,
+            },
+        )
+
+    def get_run_record(
+        self, run_id: str, *, allow_missing: bool = False
+    ) -> Optional[ConsistRecord]:
+        run = self.get_run(run_id) if self.db else None
+        snapshot_path = self._resolve_run_snapshot_path(run_id, run)
+        if not snapshot_path.exists():
+            if allow_missing:
+                return None
+            raise FileNotFoundError(
+                f"Run snapshot not found at {snapshot_path!s} for run_id={run_id}."
+            )
+        try:
+            return ConsistRecord.model_validate_json(
+                snapshot_path.read_text(encoding="utf-8")
+            )
+        except Exception as exc:
+            if allow_missing:
+                return None
+            raise ValueError(
+                f"Failed to parse run snapshot at {snapshot_path!s} for run_id={run_id}."
+            ) from exc
+
+    def get_run_config(
+        self, run_id: str, *, allow_missing: bool = False
+    ) -> Optional[Dict[str, Any]]:
+        record = self.get_run_record(run_id, allow_missing=allow_missing)
+        if record is None:
+            return None
+        return record.config
+
+    def get_config_bundle(
+        self,
+        run_id: str,
+        *,
+        adapter: str | None = None,
+        role: str = "bundle",
+        allow_missing: bool = False,
+    ) -> Path | None:
+        artifacts = self.get_artifacts_for_run(run_id)
+        input_artifacts = list(artifacts.inputs.values())
+
+        matching: list[Artifact] = []
+        for artifact in input_artifacts:
+            meta = artifact.meta if isinstance(artifact.meta, dict) else {}
+            if meta.get("config_role") == role:
+                matching.append(artifact)
+
+        run = self.get_run(run_id)
+        run_adapter: str | None = None
+        if run is not None and isinstance(run.meta, dict):
+            candidate = run.meta.get("config_adapter")
+            if isinstance(candidate, str) and candidate:
+                run_adapter = candidate
+
+        if adapter is not None:
+            if run_adapter is not None and run_adapter != adapter:
+                matching = []
+            else:
+                filtered: list[Artifact] = []
+                for artifact in matching:
+                    meta = artifact.meta if isinstance(artifact.meta, dict) else {}
+                    artifact_adapters: list[str] = []
+                    for key in ("config_adapter", "adapter"):
+                        value = meta.get(key)
+                        if isinstance(value, str) and value:
+                            artifact_adapters.append(value)
+                    if artifact_adapters:
+                        if adapter in artifact_adapters:
+                            filtered.append(artifact)
+                    elif run_adapter == adapter:
+                        filtered.append(artifact)
+                matching = filtered
+
+        if matching:
+            selected = sorted(
+                matching,
+                key=lambda artifact: (
+                    artifact.key,
+                    artifact.created_at.isoformat() if artifact.created_at else "",
+                    str(artifact.id),
+                ),
+            )[0]
+            resolved = Path(self.resolve_uri(selected.container_uri))
+            if resolved.exists():
+                return resolved
+
+            if allow_missing:
+                return None
+            raise FileNotFoundError(
+                "Config artifact was found but the resolved file is missing for "
+                f"run_id={run_id!r}, role={role!r}, key={selected.key!r}: {resolved!s}. "
+                "Check path mounts or regenerate config artifacts for this run."
+            )
+
+        if allow_missing:
+            return None
+        adapter_hint = f", adapter={adapter!r}" if adapter is not None else ""
+        raise FileNotFoundError(
+            "No config artifact found for "
+            f"run_id={run_id!r}, role={role!r}{adapter_hint}. "
+            "Ensure config artifacts were logged with meta['config_role'] and, when "
+            "adapter filtering is requested, run.meta['config_adapter'] and/or "
+            "artifact.meta['config_adapter'|'adapter'] match."
+        )
+
+    def get_artifacts_for_run(self, run_id: str) -> RunArtifacts:
+        if not self.db:
+            return RunArtifacts()
+
+        current_run_id = self.current_consist.run.id if self.current_consist else None
+        if run_id != current_run_id:
+            cached = self._run_artifacts_cache.get(run_id)
+            if cached is not None:
+                return cached
+
+        raw_list = self.db.get_artifacts_for_run(run_id)
+
+        inputs = {}
+        outputs = {}
+
+        for artifact, direction in raw_list:
+            if direction == "input":
+                inputs[artifact.key] = artifact
+            elif direction == "output":
+                outputs[artifact.key] = artifact
+
+        artifacts = RunArtifacts(inputs=inputs, outputs=outputs)
+        for artifact in itertools.chain(inputs.values(), outputs.values()):
+            set_tracker_ref(artifact, self._tracker)
+        if run_id != current_run_id:
+            self._run_artifacts_cache[run_id] = artifacts
+            if len(self._run_artifacts_cache) > self._run_artifacts_cache_max_entries:
+                self._run_artifacts_cache.pop(next(iter(self._run_artifacts_cache)))
+        return artifacts
+
+    def get_run_outputs(self, run_id: str) -> Dict[str, Artifact]:
+        return self.get_artifacts_for_run(run_id).outputs
+
+    def get_run_result(
+        self,
+        run_id: str,
+        *,
+        keys: Optional[Iterable[str]] = None,
+        validate: Literal["lazy", "strict", "none"] = "lazy",
+    ) -> RunResult:
+        run = self.get_run(run_id)
+        if run is None:
+            raise KeyError(f"Run {run_id!r} was not found.")
+
+        outputs = self.get_run_outputs(run_id)
+
+        selected_outputs: Dict[str, Artifact]
+        if keys is None:
+            selected_outputs = dict(outputs)
+        else:
+            key_list = list(keys)
+            if any(not isinstance(key, str) for key in key_list):
+                raise ValueError("keys must contain only strings.")
+            missing = sorted(key for key in key_list if key not in outputs)
+            if missing:
+                missing_str = ", ".join(repr(key) for key in missing)
+                available = ", ".join(repr(key) for key in sorted(outputs)) or "<none>"
+                raise KeyError(
+                    f"Run {run_id!r} missing requested output keys: {missing_str}. "
+                    f"Available keys: {available}."
+                )
+            selected_outputs = {key: outputs[key] for key in key_list}
+
+        validation_policy = str(validate).lower()
+        if validation_policy not in {"lazy", "strict", "none"}:
+            raise ValueError("validate must be one of: 'lazy', 'strict', 'none'.")
+
+        if validation_policy == "strict":
+            missing_paths: list[str] = []
+            for key, artifact in selected_outputs.items():
+                if artifact.meta.get("is_ingested", False):
+                    continue
+                resolved = Path(self.resolve_uri(artifact.container_uri))
+                if not resolved.exists():
+                    missing_paths.append(f"{key!r} -> {resolved!s}")
+            if missing_paths:
+                details = "; ".join(missing_paths)
+                raise FileNotFoundError(
+                    f"Run {run_id!r} has missing output files: {details}"
+                )
+
+        cache_hit = (
+            bool(run.meta.get("cache_hit")) if isinstance(run.meta, dict) else False
+        )
+        return RunResult(run=run, outputs=selected_outputs, cache_hit=cache_hit)
+
+    def get_run_inputs(self, run_id: str) -> Dict[str, Artifact]:
+        return self.get_artifacts_for_run(run_id).inputs
+
+    def get_run_artifact(
+        self,
+        run_id: str,
+        key: Optional[str] = None,
+        key_contains: Optional[str] = None,
+        direction: str = "output",
+    ) -> Optional[Artifact]:
+        record = self.get_artifacts_for_run(run_id)
+        collection = record.outputs if direction == "output" else record.inputs
+        if key and key in collection:
+            return collection[key]
+        if key_contains:
+            for k, art in collection.items():
+                if key_contains in k:
+                    return art
+        return next(iter(collection.values()), None)
+
+    def load_run_output(self, run_id: str, key: str, **kwargs: Any) -> Any:
+        artifact = self.get_run_artifact(run_id, key=key, direction="output")
+        if artifact is None:
+            raise ValueError(
+                f"No output artifact found for run_id={run_id!r} key={key!r}."
+            )
+        return self.load(artifact, **kwargs)
+
+    def find_matching_run(
+        self,
+        config_hash: str,
+        input_hash: str,
+        git_hash: str,
+        *,
+        signature: Optional[str] = None,
+    ) -> Optional[Run]:
+        if self.db:
+            if signature:
+                matched = self.db.find_run_by_signature(signature)
+                if matched is not None:
+                    return matched
+            return self.db.find_matching_run(config_hash, input_hash, git_hash)
+        return None
+
+    def find_recent_completed_runs_for_model(
+        self, model_name: str, *, limit: int = 20
+    ) -> list[Run]:
+        if self.db:
+            return self.db.find_recent_completed_runs_for_model(model_name, limit=limit)
+        return []
+
+    def history(
+        self, limit: int = 10, tags: Optional[List[str]] = None
+    ) -> pd.DataFrame:
+        if self.db:
+            return self.db.get_history(limit, tags)
+        return pd.DataFrame()
+
+    def load_input_bundle(self, run_id: str) -> dict[str, Artifact]:
+        run = self.get_run(run_id)
+        if not run:
+            raise ValueError(f"Input bundle run_id={run_id!r} not found.")
+
+        outputs = self.get_artifacts_for_run(run_id).outputs
+        if not outputs:
+            raise ValueError(f"Input bundle run_id={run_id!r} has no output artifacts.")
+        return outputs

--- a/src/consist/core/tracker_history.py
+++ b/src/consist/core/tracker_history.py
@@ -13,6 +13,14 @@ from consist.models.run import ConsistRecord, Run, RunArtifacts, RunResult
 
 
 class TrackerHistoryService(_TrackerServiceBase):
+    """
+    Historical run lookup and recovery metadata helpers for ``Tracker``.
+
+    The service groups read-oriented APIs that were extracted from
+    ``Tracker``. It still depends on the concrete tracker owner through
+    ``_TrackerServiceBase`` while the larger refactor remains transitional.
+    """
+
     def resolve_historical_path(self, artifact: Artifact, run: Run) -> Path:
         """
         Resolve the original filesystem path for an artifact from a prior run.

--- a/src/consist/core/tracker_history.py
+++ b/src/consist/core/tracker_history.py
@@ -14,6 +14,21 @@ from consist.models.run import ConsistRecord, Run, RunArtifacts, RunResult
 
 class TrackerHistoryService(_TrackerServiceBase):
     def resolve_historical_path(self, artifact: Artifact, run: Run) -> Path:
+        """
+        Resolve the original filesystem path for an artifact from a prior run.
+
+        Parameters
+        ----------
+        artifact : Artifact
+            Artifact whose historical location should be resolved.
+        run : Run
+            Run that originally produced or consumed the artifact.
+
+        Returns
+        -------
+        Path
+            Resolved historical filesystem path.
+        """
         if not run:
             return Path(self.resolve_uri(artifact.container_uri))
 
@@ -22,6 +37,19 @@ class TrackerHistoryService(_TrackerServiceBase):
         return Path(path_str)
 
     def get_run(self, run_id: str) -> Optional[Run]:
+        """
+        Retrieve a run by id.
+
+        Parameters
+        ----------
+        run_id : str
+            Run identifier.
+
+        Returns
+        -------
+        Optional[Run]
+            Matching run, or ``None`` if it does not exist.
+        """
         if self.db:
             return self.db.get_run(run_id)
         return None
@@ -29,6 +57,21 @@ class TrackerHistoryService(_TrackerServiceBase):
     def snapshot_db(
         self, dest_path: str | os.PathLike[str], checkpoint: bool = True
     ) -> Path:
+        """
+        Snapshot the provenance database to a destination path.
+
+        Parameters
+        ----------
+        dest_path : str | os.PathLike[str]
+            Destination path for the snapshot database file.
+        checkpoint : bool, default True
+            Whether to checkpoint the source database before copying.
+
+        Returns
+        -------
+        Path
+            Snapshot database path.
+        """
         if self.db is None:
             raise RuntimeError("Database snapshot requires a configured database.")
 
@@ -57,6 +100,21 @@ class TrackerHistoryService(_TrackerServiceBase):
     def get_run_record(
         self, run_id: str, *, allow_missing: bool = False
     ) -> Optional[ConsistRecord]:
+        """
+        Load the JSON snapshot record for a historical run.
+
+        Parameters
+        ----------
+        run_id : str
+            Run identifier.
+        allow_missing : bool, default False
+            Return ``None`` instead of raising when the snapshot is absent.
+
+        Returns
+        -------
+        Optional[ConsistRecord]
+            Parsed run snapshot record.
+        """
         run = self.get_run(run_id) if self.db else None
         snapshot_path = self._resolve_run_snapshot_path(run_id, run)
         if not snapshot_path.exists():
@@ -79,6 +137,21 @@ class TrackerHistoryService(_TrackerServiceBase):
     def get_run_config(
         self, run_id: str, *, allow_missing: bool = False
     ) -> Optional[Dict[str, Any]]:
+        """
+        Load the full config snapshot for a historical run.
+
+        Parameters
+        ----------
+        run_id : str
+            Run identifier.
+        allow_missing : bool, default False
+            Return ``None`` instead of raising when the snapshot is absent.
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            Stored config payload for the run.
+        """
         record = self.get_run_record(run_id, allow_missing=allow_missing)
         if record is None:
             return None
@@ -92,6 +165,25 @@ class TrackerHistoryService(_TrackerServiceBase):
         role: str = "bundle",
         allow_missing: bool = False,
     ) -> Path | None:
+        """
+        Resolve a config artifact path for a run by role and optional adapter.
+
+        Parameters
+        ----------
+        run_id : str
+            Run identifier.
+        adapter : Optional[str], optional
+            Optional adapter name filter.
+        role : str, default "bundle"
+            Config artifact role to select.
+        allow_missing : bool, default False
+            Return ``None`` when the matching file is absent.
+
+        Returns
+        -------
+        Path | None
+            Resolved config artifact path.
+        """
         artifacts = self.get_artifacts_for_run(run_id)
         input_artifacts = list(artifacts.inputs.values())
 
@@ -160,6 +252,19 @@ class TrackerHistoryService(_TrackerServiceBase):
         )
 
     def get_artifacts_for_run(self, run_id: str) -> RunArtifacts:
+        """
+        Retrieve input and output artifacts for a run.
+
+        Parameters
+        ----------
+        run_id : str
+            Run identifier.
+
+        Returns
+        -------
+        RunArtifacts
+            Inputs and outputs grouped by artifact key.
+        """
         if not self.db:
             return RunArtifacts()
 
@@ -190,6 +295,9 @@ class TrackerHistoryService(_TrackerServiceBase):
         return artifacts
 
     def get_run_outputs(self, run_id: str) -> Dict[str, Artifact]:
+        """
+        Return output artifacts for a run, keyed by artifact key.
+        """
         return self.get_artifacts_for_run(run_id).outputs
 
     def get_run_result(
@@ -199,6 +307,23 @@ class TrackerHistoryService(_TrackerServiceBase):
         keys: Optional[Iterable[str]] = None,
         validate: Literal["lazy", "strict", "none"] = "lazy",
     ) -> RunResult:
+        """
+        Build a ``RunResult`` view for a historical run.
+
+        Parameters
+        ----------
+        run_id : str
+            Run identifier.
+        keys : Optional[Iterable[str]], optional
+            Optional subset of output keys to include.
+        validate : {"lazy", "strict", "none"}, default "lazy"
+            Output validation policy.
+
+        Returns
+        -------
+        RunResult
+            Historical run metadata plus selected outputs.
+        """
         run = self.get_run(run_id)
         if run is None:
             raise KeyError(f"Run {run_id!r} was not found.")
@@ -246,6 +371,9 @@ class TrackerHistoryService(_TrackerServiceBase):
         return RunResult(run=run, outputs=selected_outputs, cache_hit=cache_hit)
 
     def get_run_inputs(self, run_id: str) -> Dict[str, Artifact]:
+        """
+        Return input artifacts for a run, keyed by artifact key.
+        """
         return self.get_artifacts_for_run(run_id).inputs
 
     def get_run_artifact(
@@ -255,6 +383,9 @@ class TrackerHistoryService(_TrackerServiceBase):
         key_contains: Optional[str] = None,
         direction: str = "output",
     ) -> Optional[Artifact]:
+        """
+        Retrieve a single artifact from a run by exact key or substring match.
+        """
         record = self.get_artifacts_for_run(run_id)
         collection = record.outputs if direction == "output" else record.inputs
         if key and key in collection:
@@ -266,6 +397,9 @@ class TrackerHistoryService(_TrackerServiceBase):
         return next(iter(collection.values()), None)
 
     def load_run_output(self, run_id: str, key: str, **kwargs: Any) -> Any:
+        """
+        Load one output artifact from a historical run.
+        """
         artifact = self.get_run_artifact(run_id, key=key, direction="output")
         if artifact is None:
             raise ValueError(
@@ -281,6 +415,9 @@ class TrackerHistoryService(_TrackerServiceBase):
         *,
         signature: Optional[str] = None,
     ) -> Optional[Run]:
+        """
+        Find a previously completed run matching the supplied identity hashes.
+        """
         if self.db:
             if signature:
                 matched = self.db.find_run_by_signature(signature)
@@ -292,6 +429,9 @@ class TrackerHistoryService(_TrackerServiceBase):
     def find_recent_completed_runs_for_model(
         self, model_name: str, *, limit: int = 20
     ) -> list[Run]:
+        """
+        Return recent completed runs for a model, newest first.
+        """
         if self.db:
             return self.db.find_recent_completed_runs_for_model(model_name, limit=limit)
         return []
@@ -299,11 +439,17 @@ class TrackerHistoryService(_TrackerServiceBase):
     def history(
         self, limit: int = 10, tags: Optional[List[str]] = None
     ) -> pd.DataFrame:
+        """
+        Return recent runs as a Pandas DataFrame.
+        """
         if self.db:
             return self.db.get_history(limit, tags)
         return pd.DataFrame()
 
     def load_input_bundle(self, run_id: str) -> dict[str, Artifact]:
+        """
+        Load output artifacts from a prior bundle run as reusable inputs.
+        """
         run = self.get_run(run_id)
         if not run:
             raise ValueError(f"Input bundle run_id={run_id!r} not found.")

--- a/src/consist/core/tracker_lifecycle.py
+++ b/src/consist/core/tracker_lifecycle.py
@@ -447,11 +447,7 @@ class RunLifecycleCoordinator:
             requested_input_materialization=requested_input_materialization,
             requested_input_materialization_mode=(
                 requested_input_materialization_mode
-                or (
-                    "copy"
-                    if requested_input_materialization == "requested"
-                    else None
-                )
+                or ("copy" if requested_input_materialization == "requested" else None)
             ),
         )
 

--- a/src/consist/core/tracker_orchestration.py
+++ b/src/consist/core/tracker_orchestration.py
@@ -309,15 +309,14 @@ class RunTraceCoordinator:
             )
         if requested_input_paths is not None:
             start_kwargs["requested_input_paths"] = {
-                str(key): str(Path(value)) for key, value in requested_input_paths.items()
+                str(key): str(Path(value))
+                for key, value in requested_input_paths.items()
             }
         requested_mode = requested_input_materialization_mode or (
             "copy" if requested_input_materialization == "requested" else None
         )
         if requested_mode is not None:
-            start_kwargs["requested_input_materialization_mode"] = (
-                requested_mode
-            )
+            start_kwargs["requested_input_materialization_mode"] = requested_mode
         optional_values: Dict[str, Any] = {
             "cache_version": invocation.cache_version,
             "phase": phase,
@@ -621,9 +620,7 @@ class RunTraceCoordinator:
             ),
             requested_input_paths=requested_input_paths,
             requested_input_materialization=requested_input_materialization,
-            requested_input_materialization_mode=(
-                requested_input_materialization_mode
-            ),
+            requested_input_materialization_mode=(requested_input_materialization_mode),
         )
 
         return RunInvocationContext(
@@ -648,9 +645,7 @@ class RunTraceCoordinator:
                 else None
             ),
             requested_input_materialization=requested_input_materialization,
-            requested_input_materialization_mode=(
-                requested_input_materialization_mode
-            ),
+            requested_input_materialization_mode=(requested_input_materialization_mode),
             run_id=run_id,
             start_kwargs=start_kwargs,
         )
@@ -1147,7 +1142,10 @@ class RunTraceCoordinator:
                     if get_tracker_ref(artifact) is None:
                         set_tracker_ref(artifact, tracker)
                     if input_binding == "paths":
-                        if requested_input_paths and param_name in requested_input_paths:
+                        if (
+                            requested_input_paths
+                            and param_name in requested_input_paths
+                        ):
                             artifact_path = Path(requested_input_paths[param_name])
                         else:
                             artifact_path = artifact.path

--- a/src/consist/core/tracker_recovery.py
+++ b/src/consist/core/tracker_recovery.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, Mapping, Optional, Sequence, TYPE_CHECKING, Union
+
+from consist.core._tracker_service_base import _TrackerServiceBase
+from consist.core.materialize import (
+    fold_hydrated_run_outputs_result,
+    materialize_artifacts,
+    stage_artifact as stage_artifact_core,
+    stage_inputs as stage_inputs_core,
+)
+from consist.core.materialize_options import (
+    VALID_MATERIALIZE_DB_FALLBACK as _VALID_MATERIALIZE_DB_FALLBACK,
+    VALID_MATERIALIZE_ON_MISSING as _VALID_MATERIALIZE_ON_MISSING,
+    normalize_materialize_output_keys,
+    validate_materialize_option,
+)
+from consist.models.artifact import Artifact
+
+if TYPE_CHECKING:
+    from consist.core.materialize import (
+        HydratedRunOutputsResult,
+        MaterializationResult,
+        StagedInput,
+        StagedInputsResult,
+    )
+
+
+class TrackerRecoveryService(_TrackerServiceBase):
+    def materialize(
+        self,
+        artifact: Artifact,
+        destination_path: Union[str, Path],
+        *,
+        on_missing: Literal["warn", "raise"] = "warn",
+    ) -> Optional[str]:
+        result = materialize_artifacts(
+            tracker=self,
+            items=[(artifact, Path(destination_path))],
+            on_missing=on_missing,
+        )
+        return result.get(artifact.key)
+
+    def stage_artifact(
+        self,
+        artifact: Artifact,
+        *,
+        destination: str | Path,
+        mode: Literal["copy", "hardlink", "symlink"] = "copy",
+        overwrite: bool = False,
+        validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+        allow_external_paths: Optional[bool] = None,
+    ) -> "StagedInput":
+        return stage_artifact_core(
+            self,
+            artifact,
+            Path(destination),
+            mode=mode,
+            overwrite=overwrite,
+            validate_content_hash=validate_content_hash,
+            allow_external_paths=allow_external_paths,
+        )
+
+    def stage_inputs(
+        self,
+        inputs_by_key: Mapping[str, Artifact],
+        *,
+        destinations_by_key: Mapping[str, str | Path],
+        mode: Literal["copy", "hardlink", "symlink"] = "copy",
+        overwrite: bool = False,
+        validate_content_hash: Literal["never", "if-present", "always"] = "if-present",
+        allow_external_paths: Optional[bool] = None,
+    ) -> "StagedInputsResult":
+        normalized_destinations = {
+            str(key): Path(destination)
+            for key, destination in destinations_by_key.items()
+        }
+        return stage_inputs_core(
+            self,
+            inputs_by_key,
+            normalized_destinations,
+            mode=mode,
+            overwrite=overwrite,
+            validate_content_hash=validate_content_hash,
+            allow_external_paths=allow_external_paths,
+        )
+
+    def materialize_run_outputs(
+        self,
+        run_id: str,
+        *,
+        target_root: str | Path,
+        source_root: str | Path | None = None,
+        keys: Sequence[str] | None = None,
+        preserve_existing: bool = True,
+        on_missing: Literal["warn", "raise"] = "warn",
+        db_fallback: Literal["never", "if_ingested"] = "if_ingested",
+    ) -> "MaterializationResult":
+        return fold_hydrated_run_outputs_result(
+            self._tracker.hydrate_run_outputs(
+                run_id,
+                target_root=target_root,
+                source_root=source_root,
+                keys=keys,
+                preserve_existing=preserve_existing,
+                on_missing=on_missing,
+                db_fallback=db_fallback,
+            )
+        )
+
+    def hydrate_run_outputs(
+        self,
+        run_id: str,
+        *,
+        target_root: str | Path,
+        source_root: str | Path | None = None,
+        keys: Sequence[str] | None = None,
+        preserve_existing: bool = True,
+        on_missing: Literal["warn", "raise"] = "warn",
+        db_fallback: Literal["never", "if_ingested"] = "if_ingested",
+    ) -> "HydratedRunOutputsResult":
+        normalized_keys = normalize_materialize_output_keys(
+            keys,
+            caller="hydrate_run_outputs",
+        )
+        validate_materialize_option(
+            name="on_missing",
+            value=on_missing,
+            allowed=_VALID_MATERIALIZE_ON_MISSING,
+        )
+        validate_materialize_option(
+            name="db_fallback",
+            value=db_fallback,
+            allowed=_VALID_MATERIALIZE_DB_FALLBACK,
+        )
+
+        if self.db is None:
+            raise RuntimeError(
+                "Cannot materialize run outputs: tracker has no database configured."
+            )
+
+        run = self.get_run(run_id)
+        if run is None:
+            raise KeyError(f"Run {run_id!r} was not found.")
+
+        from consist.core import materialize as materialize_core
+
+        destination_root = Path(target_root).resolve()
+        allowed_roots = materialize_core.build_allowed_materialization_roots(
+            run_dir=self.run_dir,
+            mounts=self.mounts,
+            allow_external_paths=self.allow_external_paths,
+        )
+        materialize_core.validate_allowed_materialization_destination(
+            destination_root, allowed_roots
+        )
+
+        source_root_override = (
+            Path(source_root).resolve() if source_root is not None else None
+        )
+
+        from consist.core import tracker as tracker_module
+
+        return tracker_module.hydrate_run_outputs_core(
+            tracker=self._tracker,
+            run=run,
+            target_root=destination_root,
+            source_root=source_root_override,
+            keys=normalized_keys,
+            allowed_base=allowed_roots,
+            preserve_existing=preserve_existing,
+            on_missing=on_missing,
+            db_fallback=db_fallback,
+        )

--- a/src/consist/core/tracker_recovery.py
+++ b/src/consist/core/tracker_recovery.py
@@ -28,6 +28,13 @@ if TYPE_CHECKING:
 
 
 class TrackerRecoveryService(_TrackerServiceBase):
+    """
+    Artifact staging and historical output recovery helpers for ``Tracker``.
+
+    This service centralizes low-level materialization and staging flows while
+    the public ``Tracker`` methods remain the stable entry points.
+    """
+
     def materialize(
         self,
         artifact: Artifact,

--- a/src/consist/core/tracker_recovery.py
+++ b/src/consist/core/tracker_recovery.py
@@ -36,7 +36,7 @@ class TrackerRecoveryService(_TrackerServiceBase):
         on_missing: Literal["warn", "raise"] = "warn",
     ) -> Optional[str]:
         result = materialize_artifacts(
-            tracker=self,
+            tracker=self._tracker,
             items=[(artifact, Path(destination_path))],
             on_missing=on_missing,
         )
@@ -53,7 +53,7 @@ class TrackerRecoveryService(_TrackerServiceBase):
         allow_external_paths: Optional[bool] = None,
     ) -> "StagedInput":
         return stage_artifact_core(
-            self,
+            self._tracker,
             artifact,
             Path(destination),
             mode=mode,
@@ -77,7 +77,7 @@ class TrackerRecoveryService(_TrackerServiceBase):
             for key, destination in destinations_by_key.items()
         }
         return stage_inputs_core(
-            self,
+            self._tracker,
             inputs_by_key,
             normalized_destinations,
             mode=mode,

--- a/src/consist/integrations/activitysim/config_adapter.py
+++ b/src/consist/integrations/activitysim/config_adapter.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 import csv
-import hashlib
 import gzip
+import hashlib
 import json
 import logging
 import re
 import shutil
-import tempfile
 import tarfile
+import tempfile
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -21,7 +22,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    TYPE_CHECKING,
     Union,
 )
 
@@ -39,24 +39,42 @@ from consist.core.config_canonicalization import (
 from consist.core.identity import IdentityManager
 from consist.integrations._config_adapter_shared import (
     OverrideRunHooks as _shared_OverrideRunHooks,
+)
+from consist.integrations._config_adapter_shared import (
     artifact_key_for_path as _shared_artifact_key_for_path,
+)
+from consist.integrations._config_adapter_shared import (
     build_override_runtime_kwargs as _shared_build_override_runtime_kwargs,
+)
+from consist.integrations._config_adapter_shared import (
     callable_accepts_kwarg as _shared_callable_accepts_kwarg,
+)
+from consist.integrations._config_adapter_shared import (
     digest_path as _shared_digest_path,
+)
+from consist.integrations._config_adapter_shared import (
     file_sha256 as _shared_file_sha256,
+)
+from consist.integrations._config_adapter_shared import (
     get_nested_value as _shared_get_nested_value,
+)
+from consist.integrations._config_adapter_shared import (
     resolve_base_config_dirs as _shared_resolve_base_config_dirs,
+)
+from consist.integrations._config_adapter_shared import (
     resolve_override_base_selector as _shared_resolve_override_base_selector,
+)
+from consist.integrations._config_adapter_shared import (
     run_with_config_overrides_orchestrated as _shared_run_with_config_overrides_orchestrated,
 )
 from consist.models.activitysim import (
     ActivitySimCoefficientsCache,
     ActivitySimCoefficientTemplateRefsCache,
+    ActivitySimConfigIngestRunLink,
     ActivitySimConstantsCache,
     ActivitySimProbabilitiesCache,
     ActivitySimProbabilitiesEntriesCache,
     ActivitySimProbabilitiesMetaEntriesCache,
-    ActivitySimConfigIngestRunLink,
 )
 from consist.models.run import Run
 
@@ -858,7 +876,7 @@ class ActivitySimConfigAdapter:
         model: str | None = None,
         config: dict[str, Any] | None = None,
         outputs: list[str] | None = None,
-        execution_options: "ExecutionOptions" | None = None,
+        execution_options: "ExecutionOptions | None" = None,
         strict: bool = True,
         identity_inputs: "IdentityInputs" = None,
         resolved_config_identity: Literal["auto", "off"] = "auto",
@@ -1142,7 +1160,7 @@ class ActivitySimConfigAdapter:
         self,
         config_dirs: list[Path] | None = None,
         run_id: str | None = None,
-        tracker: "Tracker" | None = None,
+        tracker: "Tracker | None" = None,
         file_name: str = "",
         coefficient_name: str = "",
         segment: str = "",

--- a/tests/integration/tracker/test_persistence_retries.py
+++ b/tests/integration/tracker/test_persistence_retries.py
@@ -6,15 +6,22 @@ from typing import List
 import pytest
 from sqlalchemy.exc import DatabaseError, OperationalError
 
+from consist.core.db_runtime import DatabaseRuntimeOps
 from consist.core.persistence import DatabaseManager
 from consist.models.run_config_kv import RunConfigKV
+
+
+def _build_retry_only_db() -> DatabaseManager:
+    db = DatabaseManager.__new__(DatabaseManager)
+    db._runtime_ops = DatabaseRuntimeOps(db)
+    return db
 
 
 def test_execute_with_retry_retries_on_lock(monkeypatch) -> None:
     """
     execute_with_retry should retry lock/IO errors and eventually return.
     """
-    db = DatabaseManager.__new__(DatabaseManager)
+    db = _build_retry_only_db()
     calls: List[int] = []
 
     def flaky():
@@ -23,7 +30,7 @@ def test_execute_with_retry_retries_on_lock(monkeypatch) -> None:
             raise OperationalError("stmt", {}, Exception("database is locked"))
         return "ok"
 
-    monkeypatch.setattr("time.sleep", lambda _s: None)
+    monkeypatch.setattr("consist.core.db_runtime.time.sleep", lambda _s: None)
     assert db.execute_with_retry(flaky, retries=3) == "ok"
     assert len(calls) == 3
 
@@ -32,7 +39,7 @@ def test_execute_with_retry_raises_on_non_lock_errors() -> None:
     """
     execute_with_retry should not retry non-lock errors (e.g., constraint violations).
     """
-    db = DatabaseManager.__new__(DatabaseManager)
+    db = _build_retry_only_db()
     calls: List[int] = []
 
     def fail_fast():
@@ -48,7 +55,7 @@ def test_execute_with_retry_raises_on_constraint_operational_error() -> None:
     """
     Constraint-like OperationalError should not be retried.
     """
-    db = DatabaseManager.__new__(DatabaseManager)
+    db = _build_retry_only_db()
     calls: List[int] = []
 
     def fail_fast():
@@ -64,7 +71,7 @@ def test_execute_with_retry_retries_on_active_connection_lock(monkeypatch) -> No
     """
     execute_with_retry should retry connection-lock errors from DuckDB.
     """
-    db = DatabaseManager.__new__(DatabaseManager)
+    db = _build_retry_only_db()
     calls: List[int] = []
 
     def flaky():
@@ -77,7 +84,7 @@ def test_execute_with_retry_retries_on_active_connection_lock(monkeypatch) -> No
             )
         return "ok"
 
-    monkeypatch.setattr("time.sleep", lambda _s: None)
+    monkeypatch.setattr("consist.core.db_runtime.time.sleep", lambda _s: None)
     assert db.execute_with_retry(flaky, retries=3) == "ok"
     assert len(calls) == 3
 

--- a/tests/unit/core/test_input_staging.py
+++ b/tests/unit/core/test_input_staging.py
@@ -84,7 +84,9 @@ def test_stage_artifact_copies_file_and_detaches_artifact(tmp_path: Path) -> Non
     assert destination.read_text(encoding="utf-8") == "value\n1\n"
 
 
-def test_stage_artifact_preserves_existing_identical_destination(tmp_path: Path) -> None:
+def test_stage_artifact_preserves_existing_identical_destination(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "inputs" / "source.csv"
     destination = tmp_path / "runs" / "staged" / "source.csv"
     source.parent.mkdir(parents=True, exist_ok=True)
@@ -117,7 +119,9 @@ def test_stage_artifact_stages_directories(tmp_path: Path) -> None:
     result = stage_artifact(tracker, artifact, destination)
 
     assert result.status == "staged"
-    assert (destination / "nested" / "data.txt").read_text(encoding="utf-8") == "payload"
+    assert (destination / "nested" / "data.txt").read_text(
+        encoding="utf-8"
+    ) == "payload"
 
 
 def test_stage_artifact_uses_runtime_abs_path_when_canonical_resolution_missing(

--- a/tests/unit/core/test_persistence_error_paths.py
+++ b/tests/unit/core/test_persistence_error_paths.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy.exc import DatabaseError, OperationalError
 
+from consist.core.db_runtime import DatabaseRuntimeOps
 from consist.core.persistence import (
     DatabaseManager,
     ProvenanceWriter,
@@ -54,10 +55,16 @@ def test_table_has_column_returns_false_for_unsafe_table_name() -> None:
     )
 
 
+def _build_retry_only_db() -> DatabaseManager:
+    db = DatabaseManager.__new__(DatabaseManager)
+    db._runtime_ops = DatabaseRuntimeOps(db)
+    return db
+
+
 def test_execute_with_retry_retries_retryable_operational_error_then_succeeds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    db = DatabaseManager.__new__(DatabaseManager)
+    db = _build_retry_only_db()
     db._lock_retries = 5
     db._lock_base_sleep_seconds = 0.01
     db._lock_max_sleep_seconds = 0.05
@@ -75,9 +82,9 @@ def test_execute_with_retry_retries_retryable_operational_error_then_succeeds(
             )
         return "ok"
 
-    monkeypatch.setattr("consist.core.persistence.random.uniform", lambda _a, _b: 0.0)
+    monkeypatch.setattr("consist.core.db_runtime.random.uniform", lambda _a, _b: 0.0)
     monkeypatch.setattr(
-        "consist.core.persistence.time.sleep", lambda s: sleeps.append(s)
+        "consist.core.db_runtime.time.sleep", lambda s: sleeps.append(s)
     )
 
     result = db.execute_with_retry(flaky, operation_name="test_retry")
@@ -87,7 +94,7 @@ def test_execute_with_retry_retries_retryable_operational_error_then_succeeds(
 
 
 def test_execute_with_retry_does_not_retry_non_retryable_db_error() -> None:
-    db = DatabaseManager.__new__(DatabaseManager)
+    db = _build_retry_only_db()
     calls: list[int] = []
 
     def fail_fast() -> None:

--- a/tests/unit/core/test_tracker_artifact_query_service.py
+++ b/tests/unit/core/test_tracker_artifact_query_service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+import uuid
+
+import pytest
+
+from consist.models.artifact import Artifact, get_tracker_ref
+from consist.models.run import Run
+
+
+def test_artifact_query_service_prefers_current_run_artifacts_by_uri(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker,
+) -> None:
+    service = tracker._artifact_queries
+    input_path = tracker.run_dir / "query_input.csv"
+    input_path.write_text("value\n1\n", encoding="utf-8")
+
+    with tracker.start_run("query_service_run", "demo"):
+        artifact = tracker.log_artifact(input_path, key="input", direction="input")
+
+        if tracker.db is not None:
+            monkeypatch.setattr(
+                tracker.db,
+                "get_artifact_by_uri",
+                lambda *args, **kwargs: pytest.fail(
+                    "DB lookup should not run when the artifact is present in "
+                    "current_consist."
+                ),
+            )
+
+        found = service.get_artifact_by_uri(artifact.container_uri)
+
+    assert found is artifact
+
+
+def test_artifact_query_service_normalizes_run_filters_and_attaches_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker,
+) -> None:
+    service = tracker._artifact_queries
+    producer = Run(id="producer-run", model_name="demo", config_hash=None, git_hash=None)
+    consumer = Run(id="consumer-run", model_name="demo", config_hash=None, git_hash=None)
+    artifact = Artifact(
+        id=uuid.uuid4(),
+        key="result",
+        container_uri="outputs://result.csv",
+        driver="csv",
+    )
+    captured: dict[str, object] = {}
+
+    if tracker.db is None:
+        pytest.skip("Tracker fixture should provide a DB-backed tracker.")
+
+    def fake_find_artifacts(*, creator, consumer, key, limit):
+        captured.update(
+            creator=creator,
+            consumer=consumer,
+            key=key,
+            limit=limit,
+        )
+        return [artifact]
+
+    monkeypatch.setattr(tracker.db, "find_artifacts", fake_find_artifacts)
+
+    results = service.find_artifacts(
+        creator=producer,
+        consumer=consumer,
+        key="result",
+        limit=7,
+    )
+
+    assert results == [artifact]
+    assert captured == {
+        "creator": producer.id,
+        "consumer": consumer.id,
+        "key": "result",
+        "limit": 7,
+    }
+    tracker_ref = get_tracker_ref(artifact)
+    assert tracker_ref is not None
+    assert tracker_ref() is tracker

--- a/tests/unit/core/test_tracker_artifact_query_service.py
+++ b/tests/unit/core/test_tracker_artifact_query_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 import uuid
 
 import pytest
@@ -40,8 +39,12 @@ def test_artifact_query_service_normalizes_run_filters_and_attaches_tracker(
     tracker,
 ) -> None:
     service = tracker._artifact_queries
-    producer = Run(id="producer-run", model_name="demo", config_hash=None, git_hash=None)
-    consumer = Run(id="consumer-run", model_name="demo", config_hash=None, git_hash=None)
+    producer = Run(
+        id="producer-run", model_name="demo", config_hash=None, git_hash=None
+    )
+    consumer = Run(
+        id="consumer-run", model_name="demo", config_hash=None, git_hash=None
+    )
     artifact = Artifact(
         id=uuid.uuid4(),
         key="result",

--- a/tests/unit/core/test_tracker_config_plan_service.py
+++ b/tests/unit/core/test_tracker_config_plan_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    CanonicalizationResult,
+)
+
+
+class _BundleTrackerProbeAdapter:
+    model_name = "bundle_probe"
+
+    def __init__(self) -> None:
+        self.seen_tracker = None
+
+    def discover(
+        self,
+        root_dirs: list[Path],
+        *,
+        identity,
+        strict: bool = False,
+        options=None,
+    ) -> CanonicalConfig:
+        return CanonicalConfig(
+            root_dirs=root_dirs,
+            primary_config=None,
+            config_files=[],
+            external_files=[],
+            content_hash="bundle-probe-hash",
+        )
+
+    def canonicalize(
+        self,
+        config: CanonicalConfig,
+        *,
+        run=None,
+        tracker=None,
+        strict: bool = False,
+        plan_only: bool = False,
+        options=None,
+    ) -> CanonicalizationResult:
+        return CanonicalizationResult(artifacts=[], ingestables=[])
+
+    def bundle_artifact(self, config: CanonicalConfig, *, run, tracker):
+        self.seen_tracker = tracker
+        return None
+
+
+def test_apply_config_plan_passes_concrete_tracker_to_bundle_hook(
+    tracker,
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    adapter = _BundleTrackerProbeAdapter()
+
+    plan = tracker.prepare_config(adapter, [config_dir])
+
+    with tracker.start_run("bundle_probe_run", "bundle_probe"):
+        tracker.apply_config_plan(plan, adapter=adapter, ingest=False)
+
+    assert adapter.seen_tracker is tracker

--- a/tests/unit/core/test_tracker_history_service.py
+++ b/tests/unit/core/test_tracker_history_service.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from consist.models.artifact import get_tracker_ref
+from consist.models.run import ConsistRecord, Run
+
+
+def test_history_service_caches_non_current_run_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker,
+) -> None:
+    service = tracker._history_service
+    output_path = tracker.run_dir / "history_output.csv"
+    output_path.write_text("value\n1\n", encoding="utf-8")
+
+    with tracker.start_run("history_run", "demo"):
+        tracker.log_artifact(output_path, key="result", direction="output")
+
+    if tracker.db is None:
+        pytest.skip("Tracker fixture should provide a DB-backed tracker.")
+
+    call_count = 0
+    original = tracker.db.get_artifacts_for_run
+
+    def wrapped(run_id: str):
+        nonlocal call_count
+        call_count += 1
+        return original(run_id)
+
+    monkeypatch.setattr(tracker.db, "get_artifacts_for_run", wrapped)
+
+    first = service.get_artifacts_for_run("history_run")
+    second = service.get_artifacts_for_run("history_run")
+
+    assert call_count == 1
+    assert second is first
+    tracker_ref = get_tracker_ref(first.outputs["result"])
+    assert tracker_ref is not None
+    assert tracker_ref() is tracker
+
+
+def test_history_service_snapshot_db_uses_active_and_last_completed_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker,
+    tmp_path: Path,
+) -> None:
+    service = tracker._history_service
+    active_run = Run(
+        id="active-run",
+        model_name="demo",
+        config_hash=None,
+        git_hash=None,
+    )
+    completed_run = Run(
+        id="completed-run",
+        model_name="demo",
+        config_hash=None,
+        git_hash=None,
+        status="completed",
+    )
+    tracker.current_consist = ConsistRecord(run=active_run, config={})
+    tracker._last_consist = ConsistRecord(run=completed_run, config={})
+    captured: dict[str, object] = {}
+
+    if tracker.db is None:
+        pytest.skip("Tracker fixture should provide a DB-backed tracker.")
+
+    def fake_snapshot_to(*, dest_path, checkpoint, metadata):
+        captured.update(
+            dest_path=dest_path,
+            checkpoint=checkpoint,
+            metadata=metadata,
+        )
+        return Path(dest_path)
+
+    monkeypatch.setattr(tracker.db, "snapshot_to", fake_snapshot_to)
+
+    destination = tmp_path / "snapshot.duckdb"
+    result = service.snapshot_db(destination, checkpoint=False)
+
+    assert result == destination
+    assert captured["dest_path"] == destination
+    assert captured["checkpoint"] is False
+    assert captured["metadata"] == {
+        "run_id": "active-run",
+        "last_completed_run_id": "completed-run",
+        "cache_epoch": tracker._cache_epoch,
+    }

--- a/tests/unit/core/test_tracker_recovery_service.py
+++ b/tests/unit/core/test_tracker_recovery_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+import uuid
+
+from consist.core.materialize import (
+    HydratedRunOutput,
+    HydratedRunOutputsResult,
+)
+from consist.models.artifact import Artifact
+
+
+def test_recovery_service_stage_inputs_normalizes_destination_paths(
+    monkeypatch,
+    tracker,
+) -> None:
+    service = tracker._recovery_service
+    artifact = Artifact(
+        id=uuid.uuid4(),
+        key="input",
+        container_uri="inputs://input.csv",
+        driver="csv",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_stage_inputs(
+        tracker_arg,
+        inputs_by_key,
+        destinations_by_key,
+        **kwargs,
+    ):
+        captured.update(
+            tracker=tracker_arg,
+            inputs_by_key=inputs_by_key,
+            destinations_by_key=destinations_by_key,
+            kwargs=kwargs,
+        )
+        return "sentinel"
+
+    monkeypatch.setattr(
+        "consist.core.tracker_recovery.stage_inputs_core",
+        fake_stage_inputs,
+    )
+
+    result = service.stage_inputs(
+        {"input": artifact},
+        destinations_by_key={"input": "relative/staged.csv"},
+        overwrite=True,
+    )
+
+    assert result == "sentinel"
+    assert captured["tracker"] is tracker
+    assert captured["inputs_by_key"] == {"input": artifact}
+    assert captured["destinations_by_key"] == {"input": Path("relative/staged.csv")}
+    assert captured["kwargs"]["overwrite"] is True
+
+
+def test_recovery_service_materialize_run_outputs_folds_tracker_results(
+    monkeypatch,
+    tracker,
+    tmp_path: Path,
+) -> None:
+    service = tracker._recovery_service
+    artifact = Artifact(
+        id=uuid.uuid4(),
+        key="result",
+        container_uri="outputs://result.csv",
+        driver="csv",
+    )
+    restored_path = tmp_path / "restored" / "result.csv"
+    hydrated = HydratedRunOutputsResult(
+        outputs={
+            "result": HydratedRunOutput(
+                key="result",
+                artifact=artifact,
+                path=restored_path,
+                status="materialized_from_filesystem",
+                resolvable=True,
+            )
+        }
+    )
+    captured: dict[str, object] = {}
+
+    def fake_hydrate_run_outputs(run_id: str, **kwargs):
+        captured.update(run_id=run_id, kwargs=kwargs)
+        return hydrated
+
+    monkeypatch.setattr(tracker, "hydrate_run_outputs", fake_hydrate_run_outputs)
+
+    result = service.materialize_run_outputs(
+        "prior-run",
+        target_root=tmp_path / "restored",
+        keys=["result"],
+        preserve_existing=False,
+    )
+
+    assert captured["run_id"] == "prior-run"
+    assert captured["kwargs"]["keys"] == ["result"]
+    assert captured["kwargs"]["preserve_existing"] is False
+    assert result.materialized_from_filesystem == {"result": str(restored_path)}

--- a/tests/unit/core/test_tracker_run.py
+++ b/tests/unit/core/test_tracker_run.py
@@ -154,9 +154,7 @@ def test_tracker_run_path_binding_requires_materialized_local_path(tracker, samp
         )
 
 
-def test_tracker_run_path_binding_falls_back_from_stale_abs_path(
-    tracker, sample_csv
-):
+def test_tracker_run_path_binding_falls_back_from_stale_abs_path(tracker, sample_csv):
     input_path = sample_csv("stale_abs_path.csv", rows=3)
     stale_path = tracker.run_dir / "missing" / "stale.csv"
     seen: dict[str, Path] = {}


### PR DESCRIPTION
## Summary

This PR extracts a large amount of tracker and persistence logic into focused internal service modules, while keeping `Tracker` and `DatabaseManager` as the public composition roots.

It also adds follow-up docs and direct service-level tests to make those new internal boundaries safer and easier to evolve.

## What changed

### Extracted tracker services
Logic that previously lived directly in `Tracker` has been split into focused internal modules:

- `tracker_artifact_queries.py`
- `tracker_history.py`
- `tracker_recovery.py`
- `tracker_config_plans.py`

`Tracker` still owns the public API and delegates to these services.

### Extracted persistence / DB helpers
Logic that previously lived directly in `DatabaseManager` has been split into:

- `db_runtime.py`
- `db_snapshot.py`
- `provenance_writer.py`

This separates runtime DB concerns, snapshot/copy behavior, and provenance write flows from the main persistence class.

### Tracker / persistence cleanup
- `tracker.py` and `persistence.py` are substantially slimmer.
- Thin delegation remains in `Tracker` so the public API shape does not change.
- Small compatibility updates were made around related call sites touched by the extraction.

### Developer-facing architecture docs
- `_tracker_service_base.py` and `_db_ops_base.py` now have explicit developer-facing docstrings describing them as transitional extraction helpers.
- Added typed `tracker` / `db` accessors on the base helpers.
- Added short class docstrings to the new service modules to clarify intended ownership and scope.

### Test coverage
Added direct unit tests for the cleanest extracted service boundaries:

- `test_tracker_artifact_query_service.py`
- `test_tracker_history_service.py`
- `test_tracker_recovery_service.py`
- `test_tracker_config_plan_service.py`

Also updated existing persistence / tracker tests around the extraction.

## Why

Before this change, `Tracker` and `DatabaseManager` had accumulated too many unrelated responsibilities in single files. This made the code harder to navigate, reason about, and safely extend.

This PR improves that by:
- isolating query/history/recovery/config-plan concerns
- isolating runtime DB / snapshot / provenance-write concerns
- keeping the existing public API intact
- adding enough service-local tests and documentation to make the extraction safer

## Notes on architecture

The new service base classes are intentionally transitional. They are meant to support the extraction with minimal churn, not to represent a finalized dependency-injection design.

This PR makes that intent explicit in code comments/docstrings and adds boundary tests so future tightening of those contracts is easier and safer.

## Follow-ups

Likely follow-up work after this PR:
- expand direct service-level test coverage where the seams are already crisp
- gradually reduce reliance on implicit forwarding in extracted services
- tighten service contracts further once the extraction pattern settles
