### PR TITLE
clean up consist api, mark some unneeded patterns for depreciation

### DIFF
--- a/docs/advanced/execution-style-decision-tree.md
+++ b/docs/advanced/execution-style-decision-tree.md
@@ -21,13 +21,13 @@ Start
  |                 |
  |                 +-- Should user code skip execution on cache hit?
  |                 |      |
- |                 |      +-- Yes --> consist.run(...) / tracker.run(...)
- |                 |      +-- No  --> consist.trace(...) / tracker.trace(...)
+ |                 |      +-- Yes --> tracker.run(...)
+ |                 |      +-- No  --> tracker.trace(...)
  |                 |
  |                 +-- Need explicit object wiring (library/app code)?
  |                        |
  |                        +-- Yes --> tracker.run(...) / tracker.trace(...)
- |                        +-- No  --> consist.run(...) / consist.trace(...)
+ |                        +-- No  --> consist.run(...) / consist.trace(...) (deprecated compatibility wrappers)
  |
  +-- Need manual lifecycle split across call sites?
         |

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -3,7 +3,8 @@
 This section collects supported but non-onboarding patterns.
 
 Use these pages when you need framework integration, low-level lifecycle
-control, or explicit metadata/decorator defaults beyond the recommended path.
+control, or explicit metadata/decorator defaults beyond the preferred
+execution path.
 
 ## Start here
 

--- a/docs/advanced/manual-lifecycle-and-decorators.md
+++ b/docs/advanced/manual-lifecycle-and-decorators.md
@@ -1,7 +1,7 @@
 # Manual Lifecycle and Decorators
 
 These APIs are supported for integrations and framework glue, but are not part
-of the quickstart recommended path.
+of the quickstart preferred execution path.
 
 ## Manual lifecycle APIs
 

--- a/docs/api/advanced.md
+++ b/docs/api/advanced.md
@@ -1,8 +1,8 @@
 # API Advanced
 
 Advanced APIs are fully supported, but they are not part of the onboarding
-recommended path. Reach for these when integrating Consist into larger frameworks,
-adapters, or custom orchestration layers.
+preferred execution path. Reach for these when integrating Consist into larger
+frameworks, adapters, or custom orchestration layers.
 
 ## Manual lifecycle and decorator patterns
 

--- a/docs/api/essentials.md
+++ b/docs/api/essentials.md
@@ -1,15 +1,18 @@
 # API Essentials
 
-Use this page for day-to-day Consist usage. These APIs are the recommended path 
-for new projects and onboarding docs/examples.
+Use this page for day-to-day Consist usage. These are the preferred execution
+patterns for new projects and onboarding docs/examples.
 
 ## Core execution patterns
 
-- **Cacheable function step**: [`consist.run`](api_helpers.md#consist.api.run)
-- **Always-execute traced step**: [`consist.trace`](api_helpers.md#consist.api.trace)
+- **Cacheable function step**: [`Tracker.run`](tracker.md#consist.core.tracker.Tracker.run)
+- **Always-execute traced step**: [`Tracker.trace`](tracker.md#consist.core.tracker.Tracker.trace)
 - **Workflow composition**: [`consist.scenario`](api_helpers.md#consist.api.scenario),
   [`ScenarioContext.run`](workflow.md#consist.core.workflow.ScenarioContext.run),
   [`ScenarioContext.trace`](workflow.md#consist.core.workflow.ScenarioContext.trace)
+- **Compatibility wrappers**: [`consist.run`](api_helpers.md#consist.api.run) and
+  [`consist.trace`](api_helpers.md#consist.api.trace) remain available, but they
+  now warn and simply resolve a tracker before forwarding to the explicit APIs.
 
 If you already have a resolved binding plan from a planner or orchestrator,
 pass `binding=BindingResult(...)` to `ScenarioContext.run(...)`. That envelope
@@ -48,11 +51,9 @@ These run/trace entry points share the same public identity kwargs:
 - `adapter=...`
 - `identity_inputs=[...]`
 
-This parity applies across:
-
-- `consist.run(...)` and `consist.trace(...)`
-- `Tracker.run(...)` and `Tracker.trace(...)`
-- `ScenarioContext.run(...)` and `ScenarioContext.trace(...)`
+This parity applies across `Tracker.run(...)`, `Tracker.trace(...)`,
+`ScenarioContext.run(...)`, `ScenarioContext.trace(...)`, and the deprecated
+`consist.run(...)` / `consist.trace(...)` compatibility wrappers.
 
 ## Minimal essentials example
 
@@ -68,17 +69,16 @@ def produce(*, value: int) -> Path:
     out.write_text(f"{value}\n", encoding="utf-8")
     return out
 
-with consist.use_tracker(tracker):
-    result = consist.run(
-        fn=produce,
-        name="produce",
-        config={"value": 42},
-        outputs=["value"],
-        execution_options=ExecutionOptions(runtime_kwargs={"value": 42}),
-    )
+result = tracker.run(
+    fn=produce,
+    name="produce",
+    config={"value": 42},
+    outputs=["value"],
+    execution_options=ExecutionOptions(runtime_kwargs={"value": 42}),
+)
 
-    with consist.trace("inspect", inputs={"value": consist.ref(result, key="value")}):
-        pass
+with tracker.trace("inspect", inputs={"value": consist.ref(result, key="value")}):
+    pass
 ```
 
 For lower-level patterns (`start_run`, `begin_run/end_run`, `define_step`, and

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,7 +6,7 @@ icon: lucide/book-open
 
 The API reference is organized into two tiers:
 
-- **Essentials**: the recommended path API for most users (`run`, `trace`, `scenario`)
+- **Essentials**: the preferred execution path for most users (`Tracker.run`, `Tracker.trace`, `scenario`)
 - **Advanced**: lifecycle, decorators, and lower-level utilities for integrations
 
 ## Start Here
@@ -19,9 +19,9 @@ The API reference is organized into two tiers:
 
 | If you need | Start here | Why |
 |---|---|---|
-| One cache-aware function call | [`consist.run`](api_helpers.md#consist.api.run) | Smallest API surface; uses active/default tracker |
+| One cache-aware function call | [`Tracker.run`](tracker.md#consist.core.tracker.Tracker.run) | Explicit tracker ownership without compatibility warnings |
 | Multi-step workflow with shared context | [`consist.scenario`](api_helpers.md#consist.api.scenario) | Groups steps and lineage under one scenario header |
-| Always-execute run-scoped block | [`consist.trace`](api_helpers.md#consist.api.trace) | Records provenance but executes block every time |
+| Always-execute run-scoped block | [`Tracker.trace`](tracker.md#consist.core.tracker.Tracker.trace) | Records provenance but executes block every time |
 | Multi-run grouping and pairwise comparison | [`RunSet`](runset.md#runset-and-alignment) / [`consist.run_set`](api_helpers.md#consist.api.run_set) | Fluent partitioning, recency selection, and alignment |
 
 ## Minimal first run

--- a/docs/api/public_api.md
+++ b/docs/api/public_api.md
@@ -6,24 +6,24 @@ more verbose, lower-level, or easier to misuse.
 
 For tiered guidance:
 
-- [API Essentials](essentials.md) for onboarding and recommended path usage
+- [API Essentials](essentials.md) for onboarding and preferred execution patterns
 - [API Advanced](advanced.md) for manual lifecycle, decorators, and lower-level APIs
 
 ## When to use each run entry point
 
 | Entry point | Use when | Notes |
 |---|---|---|
-| [`consist.run`](api_helpers.md#consist.api.run) | You want the quickest cache-aware call for one function | Convenience wrapper around `Tracker.run` |
-| [`consist.trace`](api_helpers.md#consist.api.trace) | You need inline `with`-block execution with run recording | Convenience wrapper around `Tracker.trace` |
-| [`Tracker.run`](tracker.md#consist.core.tracker.Tracker.run) | You want explicit tracker ownership in app/library code | Same core behavior as `consist.run` |
+| [`Tracker.run`](tracker.md#consist.core.tracker.Tracker.run) | You want explicit tracker ownership for one cache-aware function | Preferred single-step entry point |
 | [`Tracker.trace`](tracker.md#consist.core.tracker.Tracker.trace) | You need inline execution with explicit tracker control | Block executes every time |
 | [`consist.scenario`](api_helpers.md#consist.api.scenario) | You need multi-step workflows with shared scenario context | Returns [`ScenarioContext`](workflow.md#consist.core.workflow.ScenarioContext) |
 | [`ScenarioContext.run`](workflow.md#consist.core.workflow.ScenarioContext.run) | You are inside a scenario and want cache-aware steps | Step-level equivalent of `Tracker.run`; also accepts `binding=BindingResult(...)` for orchestrator-resolved inputs |
 | [`ScenarioContext.trace`](workflow.md#consist.core.workflow.ScenarioContext.trace) | You are inside a scenario and need inline step execution | Step-level equivalent of `Tracker.trace` |
+| [`consist.run`](api_helpers.md#consist.api.run) | You need the legacy context-resolving convenience wrapper | Deprecated compatibility wrapper around `Tracker.run` |
+| [`consist.trace`](api_helpers.md#consist.api.trace) | You need the legacy context-resolving tracing wrapper | Deprecated compatibility wrapper around `Tracker.trace` |
+| [`consist.start_run`](api_helpers.md#consist.api.start_run) | You need the legacy context-resolving lifecycle wrapper | Deprecated compatibility wrapper around `Tracker.start_run` |
 
 ## Relationship: `consist.scenario`, `consist.run`, and `Tracker.run`
 
-- `consist.run(...)` resolves the active/default tracker and then calls `Tracker.run(...)`.
 - `Tracker.run(...)` is the explicit class method for a single cache-aware step.
 - `consist.scenario(...)` creates a scenario context; inside it, call `sc.run(...)`
   for cache-aware steps or `sc.trace(...)` for inline blocks that execute each time.
@@ -31,6 +31,35 @@ For tiered guidance:
   `binding=BindingResult(...)` to `sc.run(...)` instead of unpacking primitive
   input kwargs. That is the preferred scenario-level envelope for complex or
   externally orchestrated workflows.
+- `consist.run(...)` resolves the active/default tracker and then calls `Tracker.run(...)`,
+  but it is now a deprecated compatibility wrapper.
+
+## Top-level API policy
+
+Consist keeps top-level `consist.*` helpers when they add one of two things:
+
+- **Ambient run-scoped behavior**: helpers that attach metadata, artifacts, or
+  side effects to an already-active run without forcing tracker plumbing
+  through nested workflow code. Examples include
+  `consist.log_artifact(...)`, `consist.log_artifacts(...)`,
+  `consist.log_input(...)`, `consist.log_output(...)`,
+  `consist.ingest(...)`, `consist.log_meta(...)`, and
+  `consist.capture_outputs(...)`.
+- **Pure/context utilities**: helpers that do not create tracker-owned
+  execution state, such as `consist.ref(...)`, `consist.refs(...)`,
+  `consist.output_path(...)`, and `consist.output_dir(...)`.
+
+Consist deprecates top-level helpers when they are only duplicate
+tracker-owning execution entry points:
+
+- `consist.run(...)`
+- `consist.trace(...)`
+- `consist.start_run(...)`
+
+`consist.scenario(...)` remains a deliberate exception. It is still a top-level
+workflow entry point, but it carries meaningful API-level behavior beyond
+simple forwarding, including the `enabled=False` noop branch and the scenario
+ergonomics used throughout examples and multi-step workflows.
 
 ## Run/trace identity kwargs (public surface)
 
@@ -64,12 +93,8 @@ def write_result() -> Path:
     out.write_text("ok\n")
     return out
 
-# Convenience helper: resolves tracker from context.
-with consist.use_tracker(tracker):
-    one = consist.run(fn=write_result, outputs=["result"])
-
-# Explicit class API: same run behavior, explicit object wiring.
-two = tracker.run(fn=write_result, outputs=["result"])
+# Preferred class API: explicit tracker ownership.
+one = tracker.run(fn=write_result, outputs=["result"])
 
 # Scenario API: grouped multi-step workflows.
 with tracker.scenario("baseline") as sc:
@@ -95,13 +120,15 @@ with tracker.scenario("baseline") as sc:
 
 - [`consist.scenario`](api_helpers.md#consist.api.scenario)
 - [`consist.single_step_scenario`](api_helpers.md#consist.api.single_step_scenario)
-- [`consist.run`](api_helpers.md#consist.api.run)
-- [`consist.trace`](api_helpers.md#consist.api.trace)
-- [`consist.start_run`](api_helpers.md#consist.api.start_run)
 - [`consist.define_step`](api_helpers.md#consist.api.define_step)
 - [`consist.use_tracker`](api_helpers.md#consist.api.use_tracker)
 - [`consist.output_dir`](api_helpers.md#consist.api.output_dir)
 - [`consist.output_path`](api_helpers.md#consist.api.output_path)
+- [`Tracker.run`](tracker.md#consist.core.tracker.Tracker.run)
+- [`Tracker.trace`](tracker.md#consist.core.tracker.Tracker.trace)
+- [`consist.run`](api_helpers.md#consist.api.run) (deprecated compatibility wrapper)
+- [`consist.trace`](api_helpers.md#consist.api.trace) (deprecated compatibility wrapper)
+- [`consist.start_run`](api_helpers.md#consist.api.start_run) (deprecated compatibility wrapper)
 - [`ScenarioContext`](workflow.md#consist.core.workflow.ScenarioContext) (returned by `consist.scenario(...)`)
   - `run_id`, `config`, `inputs`, `add_input`, `declare_outputs`, `require_outputs`, `collect_by_keys`, `run`, `trace`
   - `run(..., binding=BindingResult(...))` for resolved orchestrator plans
@@ -119,6 +146,10 @@ Scenario defaults like `name_template` and `cache_epoch` are configured via `con
 ### Artifact logging and loading
 
 - [`consist.log_artifact`](api_helpers.md#consist.api.log_artifact)
+- [`consist.log_artifacts`](api_helpers.md#consist.api.log_artifacts)
+- [`consist.log_input`](api_helpers.md#consist.api.log_input)
+- [`consist.log_output`](api_helpers.md#consist.api.log_output)
+- [`consist.ingest`](api_helpers.md#consist.api.ingest)
 - [`consist.log_dataframe`](api_helpers.md#consist.api.log_dataframe)
 - [`consist.load`](api_helpers.md#consist.api.load)
 - [`consist.capture_outputs`](api_helpers.md#consist.api.capture_outputs)

--- a/docs/api/run.md
+++ b/docs/api/run.md
@@ -2,8 +2,12 @@
 
 ## `consist.run` options contract
 
-`consist.run(...)` rejects legacy direct policy kwargs (for example
+`consist.run(...)` is a deprecated compatibility wrapper around
+`Tracker.run(...)`. It still rejects legacy direct policy kwargs (for example
 `cache_mode`, `output_missing`, `inject_context`) with a `TypeError`.
+
+For new code, prefer `tracker.run(...)` for single-step execution or
+`scenario.run(...)` inside an active scenario.
 
 Use options objects instead:
 
@@ -16,10 +20,11 @@ requested input staging:
 
 ```python
 from pathlib import Path
-import consist
-from consist import ExecutionOptions
+from consist import ExecutionOptions, Tracker
 
-result = consist.run(
+tracker = Tracker(run_dir="./runs", db_path="./provenance.duckdb")
+
+result = tracker.run(
     fn=run_tool,
     inputs={"config_path": Path("./configs/baseline.yaml")},
     outputs=["report"],
@@ -41,9 +46,9 @@ For migration details, see
 
 ## Identity kwargs for run/trace surfaces
 
-Public identity kwargs for `consist.run(...)`, `consist.trace(...)`,
-`Tracker.run(...)`, `Tracker.trace(...)`, `ScenarioContext.run(...)`, and
-`ScenarioContext.trace(...)` are:
+Public identity kwargs for `Tracker.run(...)`, `Tracker.trace(...)`,
+`ScenarioContext.run(...)`, `ScenarioContext.trace(...)`, and the deprecated
+`consist.run(...)` / `consist.trace(...)` wrappers are:
 
 - `adapter=...`
 - `identity_inputs=[...]`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,11 @@
 # Architecture
 
 !!! note "Recommended path"
-    For most user workflows, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)`. Low-level lifecycle snippets
-    in this page (for example `tracker.start_run(...)` + `tracker.log_artifact(...)`)
-    are advanced and primarily explain internal behavior.
+    For most user workflows, prefer `tracker.run(...)`, `tracker.trace(...)`,
+    or `consist.scenario(...)` with `scenario.run(...)` / `scenario.trace(...)`.
+    Low-level lifecycle snippets in this page (for example
+    `tracker.start_run(...)` + `tracker.log_artifact(...)`) are advanced and
+    primarily explain internal behavior.
 
 ## How Caching Works
 

--- a/docs/concepts/caching-and-hydration.md
+++ b/docs/concepts/caching-and-hydration.md
@@ -8,10 +8,11 @@ Consist's core loop: declare inputs → compute signature → check cache → lo
 This page covers patterns for making caching reliable, keeping pipelines portable, and choosing when artifacts should be hydrated or materialized.
 
 !!! note "Recommended path"
-    For routine workflow code, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)`. Low-level lifecycle snippets
-    in this page (for example `tracker.start_run(...)`) are advanced examples to
-    make hydration/materialization mechanics explicit.
+    For routine workflow code, prefer `tracker.run(...)`, `tracker.trace(...)`,
+    or `consist.scenario(...)` with `scenario.run(...)` / `scenario.trace(...)`.
+    Low-level lifecycle snippets in this page (for example
+    `tracker.start_run(...)`) are advanced examples to make
+    hydration/materialization mechanics explicit.
 
 ---
 
@@ -53,7 +54,7 @@ Materialize cached outputs (copy bytes to your current run) in three cases:
 
 !!! note "Advanced lifecycle example"
     This walkthrough uses low-level lifecycle APIs to show cache and hydration
-    behavior step-by-step. Prefer the recommended path (`run`/`trace`/`scenario`)
+    behavior step-by-step. Prefer the explicit tracker/scenario execution path
     for new workflow code.
 
 ``` python
@@ -392,7 +393,7 @@ Use `ScenarioContext.run(...)` to skip execution on cache hits. The `output_path
 
 ## Pattern 2: Cached Runs with `consist.run`
 
-Use `consist.run(...)` with declared outputs for cache-aware function execution.
+Use `tracker.run(...)` with declared outputs for cache-aware function execution.
 
 ```python
 def clean(raw_file: Path):
@@ -505,12 +506,12 @@ with tracker.start_run(
     ...
 ```
 
-Equivalent with `consist.run(...)`:
+Equivalent with `tracker.run(...)`:
 
 ```python
 from consist import CacheOptions
 
-result = consist.run(
+result = tracker.run(
     fn=step,
     cache_options=CacheOptions(cache_hydration="outputs-requested"),
     output_paths={"features": Path("outputs/features.csv")},
@@ -518,7 +519,7 @@ result = consist.run(
 ```
 
 Default is `cache_hydration="metadata"` (artifact hydration only). For
-`consist.run(...)` or `sc.run(...)`, use `output_paths={...}` with
+`tracker.run(...)` or `sc.run(...)`, use `output_paths={...}` with
 `cache_options=CacheOptions(cache_hydration="outputs-requested")`.
 
 | Policy | Requires | Rejects |
@@ -552,10 +553,10 @@ print(features.artifact.as_path())
 
 Cache hydration exposes an archive-mirror override via
 `materialize_cached_outputs_source_root=...` for `outputs-requested` and
-`outputs-all`. On the recommended path, pass it through
+`outputs-all`. On the preferred execution path, pass it through
 `cache_options=CacheOptions(materialize_cached_outputs_source_root=...)` on
-`consist.run(...)`, `Tracker.run(...)`, or scenario steps. The same override is
-also available on low-level `tracker.start_run(...)` /
+`tracker.run(...)` or scenario steps. The deprecated `consist.run(...)`
+wrapper also forwards it. The same override is available on low-level `tracker.start_run(...)` /
 `tracker.begin_run(...)` flows.
 
 For recurring archive workflows, prefer artifact-level recovery metadata over

--- a/docs/concepts/data-materialization.md
+++ b/docs/concepts/data-materialization.md
@@ -7,10 +7,11 @@ materialization live in [Core Concepts Overview](overview.md). This page focuses
 on decision criteria and implementation patterns.
 
 !!! note "Recommended path"
-    For standard execution flow, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)`. The ingestion snippets below
-    use low-level lifecycle APIs (`tracker.start_run(...)`, `tracker.log_artifact(...)`)
-    because ingestion is attached to explicit artifact logging.
+    For standard execution flow, prefer `tracker.run(...)`, `tracker.trace(...)`,
+    or `consist.scenario(...)` with `scenario.run(...)` / `scenario.trace(...)`.
+    The ingestion snippets below use low-level lifecycle APIs
+    (`tracker.start_run(...)`, `tracker.log_artifact(...)`) because ingestion is
+    attached to explicit artifact logging.
 
 ---
 
@@ -67,8 +68,8 @@ Cold data lives only on disk; provenance metadata is tracked but data is not que
 
 !!! note "Advanced lifecycle examples"
     The following snippets intentionally show explicit run lifecycle calls for
-    ingestion control. Keep regular compute steps on the recommended path
-    (`run`/`trace`/`scenario`).
+    ingestion control. Keep regular compute steps on the explicit
+    tracker/scenario execution path.
 
 Install the optional DLT dependency:
 

--- a/docs/concepts/decorators-and-metadata.md
+++ b/docs/concepts/decorators-and-metadata.md
@@ -4,8 +4,8 @@ This page explains how `@define_step` metadata, templates, and resolver defaults
 so you can reduce boilerplate without losing clarity or cache correctness.
 
 !!! note "Recommended path"
-    This page is centered on metadata used with the recommended path:
-    `consist.run(...)`, `consist.trace(...)`, and `consist.scenario(...)`.
+    This page is centered on metadata used with the preferred execution path:
+    `tracker.run(...)`, `tracker.trace(...)`, and `consist.scenario(...)`.
     Adapter/identity metadata examples here are advanced integration patterns,
     not the default onboarding run surface.
 
@@ -133,8 +133,8 @@ Declarative adapter handoff metadata:
 
 !!! note "Advanced integration pattern"
     Adapter metadata on `@define_step` is a low-level/advanced option for
-    integration workflows. Keep typical runs on the recommended path
-    (`run`/`trace`/`scenario`).
+    integration workflows. Keep typical runs on the explicit tracker/scenario
+    execution path.
 
 ```python
 @define_step(

--- a/docs/containers-guide.md
+++ b/docs/containers-guide.md
@@ -7,8 +7,8 @@ Consist executes containerized tools (Docker, Singularity) with automatic proven
 
 !!! note "Recommended path"
     `run_container(...)` is an integration-specific API for external tools. For
-    Python workflow steps, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)`.
+    Python workflow steps, prefer `tracker.run(...)`, `tracker.trace(...)`, or
+    `consist.scenario(...)` with `scenario.run(...)` / `scenario.trace(...)`.
 
 ---
 
@@ -20,8 +20,8 @@ Consist executes containerized tools (Docker, Singularity) with automatic proven
 | Complex dependencies easier to package than install | Container |
 | Black-box or non-deterministic tools | Container |
 | Tool expects specific file paths | Container |
-| Simple Python functions | `consist.run()` |
-| Fine-grained step caching | `scenario()` + `consist.run()` |
+| Simple Python functions | `tracker.run()` |
+| Fine-grained step caching | `scenario()` + `sc.run()` |
 | Development/debugging with fast iteration | Native execution |
 
 ---
@@ -503,7 +503,7 @@ To force re-execution even with matching signature:
 
 !!! note "Advanced lifecycle pattern"
     The `tracker.begin_run(...)`/`tracker.end_run()` wrapper below is low-level.
-    Prefer the recommended path (`run`/`trace`/`scenario`) unless you need manual
+    Prefer the explicit tracker/scenario execution path unless you need manual
     lifecycle control around container orchestration.
 
 ```python

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,8 +2,8 @@
 
 Examples are grouped into two tiers:
 
-- **Essentials**: onboarding notebooks/scripts using the recommended path
-  (`run`, `trace`, `scenario`)
+- **Essentials**: onboarding notebooks/scripts using the preferred execution path
+  (`Tracker.run`, `Tracker.trace`, `scenario`)
 - **Advanced**: larger workflows and integration templates that still use the
   same execution patterns, but add scale and system complexity
 
@@ -12,7 +12,7 @@ Examples are grouped into two tiers:
 | Example                                                                                         |                                                                                                                                                         Quick Links                                                                                                                                                         | Key Learning Outcomes                                                                                  |
 |:------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------------|
 | **00 Quickstart**<br>A 5-minute introduction to the core API.                                   |                  [📖 View on GitHub](https://github.com/LBNL-UCB-STI/consist/blob/main/examples/00_quickstart.ipynb)<br>[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/LBNL-UCB-STI/consist/blob/main/examples/00_quickstart.ipynb)                  | • Create a tracked run<br>• Observe cache hits on repeated runs<br>• Query run history                 |
-| **01 Monte Carlo Sweeps**<br>Recommended path `scenario + run + trace` usage at moderate scale. | [📖 View on GitHub](https://github.com/LBNL-UCB-STI/consist/blob/main/examples/01_parameter_sweep_monte_carlo.ipynb)<br>[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/LBNL-UCB-STI/consist/blob/main/examples/01_parameter_sweep_monte_carlo.ipynb) | • Parameter sweeps with provenance<br>• Mixed `run` and `trace` step styles<br>• Hybrid query workflow |
+| **01 Monte Carlo Sweeps**<br>Preferred `scenario + tracker.run/trace` usage at moderate scale. | [📖 View on GitHub](https://github.com/LBNL-UCB-STI/consist/blob/main/examples/01_parameter_sweep_monte_carlo.ipynb)<br>[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/LBNL-UCB-STI/consist/blob/main/examples/01_parameter_sweep_monte_carlo.ipynb) | • Parameter sweeps with provenance<br>• Mixed `run` and `trace` step styles<br>• Hybrid query workflow |
 
 ## Advanced
 
@@ -21,7 +21,7 @@ Examples are grouped into two tiers:
 | **02 Iterative Workflows**<br>Scenario workflows with feedback loops. |            [📖 View on GitHub](https://github.com/LBNL-UCB-STI/consist/blob/main/examples/02_iterative_workflows.ipynb)<br>[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/LBNL-UCB-STI/consist/blob/main/examples/02_iterative_workflows.ipynb)            | • Iterative scenario loops<br>• Cache hydration choices across iterations<br>• Provenance queries for extension runs |
 | **03 Demand Modeling**<br>End-to-end transportation simulation.       | [📖 View on GitHub](https://github.com/LBNL-UCB-STI/consist/blob/main/examples/03_transportation_demand_modeling.ipynb)<br>[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/LBNL-UCB-STI/consist/blob/main/examples/03_transportation_demand_modeling.ipynb) | • Multi-step model pipelines<br>• Scenario comparison and lineage tracing<br>• Matrix-style downstream analysis      |
 
-For non-recommended lifecycle/decorator APIs, see
+For non-preferred lifecycle/decorator APIs, see
 [Advanced Usage](advanced/index.md), especially
 [Manual Lifecycle and Decorators](advanced/manual-lifecycle-and-decorators.md).
 

--- a/docs/integrations/config_adapters_activitysim.md
+++ b/docs/integrations/config_adapters_activitysim.md
@@ -4,11 +4,11 @@ The ActivitySim config adapter discovers and canonicalizes ActivitySim configura
 directories (with support for YAML inheritance, CSV references, and config bundling).
 
 !!! note "Recommended path"
-    For workflow execution, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)` with `adapter=` and
-    `identity_inputs=`. Lifecycle snippets using `tracker.begin_run(...)`,
-    `tracker.canonicalize_config(...)`, and `tracker.end_run()` are
-    integration-specific advanced patterns for manual orchestration.
+    For workflow execution, prefer `tracker.run(...)`, `tracker.trace(...)`, or
+    `consist.scenario(...)` with `adapter=` and `identity_inputs=`. Lifecycle
+    snippets using `tracker.begin_run(...)`, `tracker.canonicalize_config(...)`,
+    and `tracker.end_run()` are integration-specific advanced patterns for
+    manual orchestration.
 
 ## Overview
 
@@ -29,7 +29,7 @@ Compare how constants and coefficients change between runs:
 
 !!! note "Integration-specific advanced lifecycle snippet"
     This example uses explicit lifecycle APIs for adapter-centric ingestion and
-    diagnostics. Use the recommended path (`run`/`trace`/`scenario`) for day-to-day
+    diagnostics. Use the explicit tracker/scenario execution path for day-to-day
     workflow execution.
 
 ```python
@@ -113,8 +113,8 @@ Use the `materialize()` method to apply overrides to a baseline config:
 
 !!! note "Integration-specific advanced lifecycle snippet"
     The final `begin_run`/`canonicalize_config`/`end_run` block below is advanced
-    adapter orchestration. Keep standard execution on the recommended path
-    (`run`/`trace`/`scenario`).
+    adapter orchestration. Keep standard execution on the explicit
+    tracker/scenario execution path.
 
 ```python
 from consist.integrations.activitysim import ConfigOverrides

--- a/docs/integrations/config_adapters_beam.md
+++ b/docs/integrations/config_adapters_beam.md
@@ -9,17 +9,16 @@ Dependencies:
 - Requires `pandas` only if you use tabular ingestion via `BeamIngestSpec`.
 
 !!! note "Recommended path"
-    For workflow execution, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)` with `adapter=` and
-    `identity_inputs=`. Examples using `tracker.begin_run(...)`,
-    `tracker.canonicalize_config(...)`, and `tracker.end_run()` are
-    integration-specific advanced lifecycle patterns.
+    For workflow execution, prefer `tracker.run(...)`, `tracker.trace(...)`, or
+    `consist.scenario(...)` with `adapter=` and `identity_inputs=`. Examples
+    using `tracker.begin_run(...)`, `tracker.canonicalize_config(...)`, and
+    `tracker.end_run()` are integration-specific advanced lifecycle patterns.
 
 ## Usage
 
 !!! note "Integration-specific advanced lifecycle snippet"
     This usage block shows explicit adapter lifecycle control. Prefer the
-    recommended path (`run`/`trace`/`scenario`) for regular BEAM runs.
+    explicit tracker/scenario execution path for regular BEAM runs.
 
 ```python
 from pathlib import Path
@@ -39,9 +38,9 @@ tracker.end_run()
 
 ## Run/Trace Adapter Handoff (Public Surface)
 
-For `consist.run(...)`, `consist.trace(...)`, `Tracker.run(...)`,
-`Tracker.trace(...)`, `ScenarioContext.run(...)`, and `ScenarioContext.trace(...)`,
-use `adapter=` and `identity_inputs=`:
+For `Tracker.run(...)`, `Tracker.trace(...)`, `ScenarioContext.run(...)`,
+`ScenarioContext.trace(...)`, and the deprecated `consist.run(...)` /
+`consist.trace(...)` wrappers, use `adapter=` and `identity_inputs=`:
 
 ```python
 import consist

--- a/docs/mounts-and-portability.md
+++ b/docs/mounts-and-portability.md
@@ -5,10 +5,10 @@ between machines without breaking lineage. This page explains how mounts, worksp
 URIs, and historical path resolution work.
 
 !!! note "Recommended path"
-    For most workflow code, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)`. This page includes
-    `tracker.start_run(...)`/`consist.log_artifact(...)` snippets as low-level
-    examples for path and URI mechanics.
+    For most workflow code, prefer `tracker.run(...)`, `tracker.trace(...)`, or
+    `consist.scenario(...)` with `scenario.run(...)` / `scenario.trace(...)`.
+    This page includes `tracker.start_run(...)` / `consist.log_artifact(...)`
+    snippets as low-level examples for path and URI mechanics.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,10 +7,11 @@ This guide organizes issues by symptom. For concept definitions, see [Core Conce
 - [Mounts & Portability](mounts-and-portability.md#troubleshooting)
 
 !!! note "Recommended path"
-    For normal workflow code, the recommended path is `consist.run(...)`,
-    `consist.trace(...)`, or `consist.scenario(...)`. Some troubleshooting sections
-    intentionally use low-level lifecycle APIs (for example `tracker.start_run(...)`
-    and manual materialization helpers) to isolate specific failure modes.
+    For normal workflow code, prefer `tracker.run(...)`, `tracker.trace(...)`,
+    or `consist.scenario(...)` with `scenario.run(...)` / `scenario.trace(...)`.
+    Some troubleshooting sections intentionally use low-level lifecycle APIs
+    (for example `tracker.start_run(...)` and manual materialization helpers) to
+    isolate specific failure modes.
 
 ---
 
@@ -142,7 +143,7 @@ Common messages and fixes:
 ### "Scenario input string did not resolve ..."
 
 - `Cause`: the scenario input string matched neither a Coupler key nor an existing filesystem path.
-- `Fix`: pass a real path, or on the recommended path use `consist.refs(...)` between steps.
+- `Fix`: pass a real path, or on the preferred execution path use `consist.refs(...)` between steps.
 
 ---
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1105,8 +1105,9 @@ For archive-mirror recovery, cache hydration supports
 `materialize_cached_outputs_source_root=Path(...)` for `outputs-requested` and
 `outputs-all`. You can pass it through
 `cache_options=CacheOptions(materialize_cached_outputs_source_root=...)` on
-`consist.run(...)`, `Tracker.run(...)`, and scenario steps, or via the low-level
-`tracker.start_run(...)` / `tracker.begin_run(...)` APIs directly.
+`tracker.run(...)` and scenario steps. The deprecated `consist.run(...)`
+wrapper also forwards it, or you can use the low-level `tracker.start_run(...)`
+/ `tracker.begin_run(...)` APIs directly.
 
 For recurring archive workflows, prefer recording archive roots on the artifact
 once instead of passing `source_root` overrides repeatedly. This is useful when
@@ -1223,14 +1224,15 @@ with use_tracker(tracker):
 
 ### Mixing Runs and Scenarios
 
-Call `consist.run(...)` inside a scenario when a step should cache independently:
+Call `tracker.run(...)` inside a scenario when a step should cache
+independently:
 
 ``` python
 from consist import ExecutionOptions
 
 with use_tracker(tracker):
     with consist.scenario("baseline") as sc:
-        preprocess = consist.run(
+        preprocess = tracker.run(
             fn=expensive_preprocessing,
             inputs={"network_file": Path("network.geojson")},
             outputs=["processed"],

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -48,17 +48,7 @@ from consist.core.decorators import (
 )
 from consist.core.drivers import ARRAY_DRIVERS, TABLE_DRIVERS, ArrayInfo, TableInfo
 from consist.core.noop import NoopRunContext, NoopScenarioContext
-from consist.core.materialize_options import (
-    VALID_MATERIALIZE_DB_FALLBACK as _VALID_MATERIALIZE_DB_FALLBACK,
-    VALID_MATERIALIZE_ON_MISSING as _VALID_MATERIALIZE_ON_MISSING,
-    normalize_materialize_output_keys,
-    validate_materialize_option,
-)
 from consist.core.run_options import raise_legacy_policy_kwargs_error
-from consist.core.materialize import (
-    stage_artifact as stage_artifact_core,
-    stage_inputs as stage_inputs_core,
-)
 from consist.core.stores import get_hot_data_db_path
 from consist.core.views import _quote_ident, create_view_model
 from consist.core.workflow import OutputCapture, RunContext
@@ -274,6 +264,14 @@ def _resolve_tracker(tracker: Optional["Tracker"]) -> "Tracker":
             "  3. Use Tracker directly: my_tracker.run(fn=...)"
         )
     return default
+
+
+def _warn_deprecated_global_wrapper(wrapper: str, replacement: str) -> None:
+    warnings.warn(
+        f"{wrapper} is deprecated; prefer {replacement}.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 @contextmanager
@@ -536,6 +534,10 @@ def start_run(
         consist.log_artifact("data.csv", "input_data")
     ```
     """
+    _warn_deprecated_global_wrapper(
+        "consist.start_run(...)",
+        "tracker.start_run(...)",
+    )
     tr = _resolve_tracker(tracker)
     with tr.start_run(run_id=run_id, model=model, **kwargs) as active:
         yield active
@@ -610,6 +612,7 @@ def run(
         api_name="consist.run",
         kwargs=kwargs,
     )
+    _warn_deprecated_global_wrapper("consist.run(...)", "tracker.run(...)")
     tr = _resolve_tracker(tracker)
     return tr.run(
         fn=fn,
@@ -840,6 +843,10 @@ def trace(
     Tracker
         The active tracker instance.
     """
+    _warn_deprecated_global_wrapper(
+        "consist.trace(...)",
+        "tracker.trace(...) or scenario.trace(...)",
+    )
     tr = _resolve_tracker(tracker)
     with tr.trace(
         name=name,
@@ -1046,8 +1053,9 @@ def get_run_result(
     RunResult
         Historical run metadata plus selected outputs.
     """
-    tr = _resolve_tracker(tracker)
-    return tr.get_run_result(run_id, keys=keys, validate=validate)
+    return _resolve_tracker(tracker).get_run_result(
+        run_id, keys=keys, validate=validate
+    )
 
 
 def materialize_run_outputs(
@@ -1105,27 +1113,11 @@ def materialize_run_outputs(
     >>> restored.materialized
     {'persons': '.../restored/.../persons.parquet'}
     """
-    normalized_keys = normalize_materialize_output_keys(
-        keys,
-        caller="materialize_run_outputs",
-    )
-    validate_materialize_option(
-        name="on_missing",
-        value=on_missing,
-        allowed=_VALID_MATERIALIZE_ON_MISSING,
-    )
-    validate_materialize_option(
-        name="db_fallback",
-        value=db_fallback,
-        allowed=_VALID_MATERIALIZE_DB_FALLBACK,
-    )
-
-    tr = _resolve_tracker(tracker)
-    return tr.materialize_run_outputs(
+    return _resolve_tracker(tracker).materialize_run_outputs(
         run_id,
         target_root=target_root,
         source_root=source_root,
-        keys=normalized_keys,
+        keys=keys,
         preserve_existing=preserve_existing,
         on_missing=on_missing,
         db_fallback=db_fallback,
@@ -1187,27 +1179,11 @@ def hydrate_run_outputs(
     >>> hydrated["persons"].artifact.as_path()
     PosixPath('.../restored/.../persons.parquet')
     """
-    normalized_keys = normalize_materialize_output_keys(
-        keys,
-        caller="hydrate_run_outputs",
-    )
-    validate_materialize_option(
-        name="on_missing",
-        value=on_missing,
-        allowed=_VALID_MATERIALIZE_ON_MISSING,
-    )
-    validate_materialize_option(
-        name="db_fallback",
-        value=db_fallback,
-        allowed=_VALID_MATERIALIZE_DB_FALLBACK,
-    )
-
-    tr = _resolve_tracker(tracker)
-    return tr.hydrate_run_outputs(
+    return _resolve_tracker(tracker).hydrate_run_outputs(
         run_id,
         target_root=target_root,
         source_root=source_root,
-        keys=normalized_keys,
+        keys=keys,
         preserve_existing=preserve_existing,
         on_missing=on_missing,
         db_fallback=db_fallback,
@@ -1237,11 +1213,9 @@ def stage_artifact(
     the goal is to prepare declared inputs for one execution. Use this helper
     when you need the same staging behavior outside a run lifecycle.
     """
-    tr = _resolve_tracker(tracker)
-    return stage_artifact_core(
-        tr,
+    return _resolve_tracker(tracker).stage_artifact(
         artifact,
-        Path(destination),
+        destination=destination,
         mode=mode,
         overwrite=overwrite,
         validate_content_hash=validate_content_hash,
@@ -1269,14 +1243,9 @@ def stage_inputs(
     code. Use this helper when you already have resolved artifacts and need to
     stage them before or outside normal run execution.
     """
-    tr = _resolve_tracker(tracker)
-    normalized_destinations = {
-        key: Path(destination) for key, destination in destinations_by_key.items()
-    }
-    return stage_inputs_core(
-        tr,
+    return _resolve_tracker(tracker).stage_inputs(
         inputs_by_key,
-        normalized_destinations,
+        destinations_by_key=destinations_by_key,
         mode=mode,
         overwrite=overwrite,
         validate_content_hash=validate_content_hash,
@@ -1313,8 +1282,9 @@ def set_artifact_recovery_roots(
         Tracker used for persistence. If omitted, resolves the active/default
         tracker.
     """
-    tr = _resolve_tracker(tracker)
-    return tr.set_artifact_recovery_roots(artifact, roots, append=append)
+    return _resolve_tracker(tracker).set_artifact_recovery_roots(
+        artifact, roots, append=append
+    )
 
 
 def archive_artifact(
@@ -1334,8 +1304,7 @@ def archive_artifact(
     workflows where outputs are promoted into long-lived storage but retain
     their canonical ``container_uri``.
     """
-    tr = _resolve_tracker(tracker)
-    return tr.archive_artifact(
+    return _resolve_tracker(tracker).archive_artifact(
         artifact,
         archive_root,
         mode=mode,
@@ -1358,8 +1327,7 @@ def archive_run_outputs(
     This is the bulk form of ``archive_artifact(...)`` for iteration/archive
     workflows that promote all or a subset of outputs after a run completes.
     """
-    tr = _resolve_tracker(tracker)
-    return tr.archive_run_outputs(
+    return _resolve_tracker(tracker).archive_run_outputs(
         run_id,
         archive_root,
         keys=keys,
@@ -1383,8 +1351,7 @@ def archive_current_run_outputs(
     that archive outputs immediately after logging them, without separately
     pulling ``result.run.id`` or ``tracker.current_consist.run.id``.
     """
-    tr = _resolve_tracker(tracker)
-    return tr.archive_current_run_outputs(
+    return _resolve_tracker(tracker).archive_current_run_outputs(
         archive_root,
         keys=keys,
         mode=mode,
@@ -1433,8 +1400,7 @@ def register_artifact_facet_parser(
 
     The parser is invoked when logging an artifact without an explicit ``facet=``.
     """
-    tr = _resolve_tracker(tracker)
-    tr.register_artifact_facet_parser(prefix, parser_fn)
+    _resolve_tracker(tracker).register_artifact_facet_parser(prefix, parser_fn)
 
 
 # --- Proxy Functions ---

--- a/tests/integration/workflow/test_global_context.py
+++ b/tests/integration/workflow/test_global_context.py
@@ -118,11 +118,13 @@ def test_default_tracker_and_introspection_helpers(tracker):
     with pytest.raises(
         RuntimeError, match="No default tracker configured for consist.run"
     ):
-        consist.run(fn=noop)
+        with pytest.warns(DeprecationWarning, match="consist.run"):
+            consist.run(fn=noop)
 
     # Default tracker resolves consist.run
     with consist.use_tracker(tracker):
-        result = consist.run(fn=noop, name="noop")
+        with pytest.warns(DeprecationWarning, match="consist.run"):
+            result = consist.run(fn=noop, name="noop")
         assert result.run.model_name == "noop"
 
     # Default tracker fallback for current_tracker
@@ -148,25 +150,33 @@ def test_use_tracker_nested_and_override_precedence(tracker, tmp_path):
     )
 
     with consist.use_tracker(tracker):
-        outer = consist.run(fn=noop, name="outer_default")
+        with pytest.warns(DeprecationWarning, match="consist.run"):
+            outer = consist.run(fn=noop, name="outer_default")
         assert tracker.last_run.run.id == outer.run.id
 
         with consist.use_tracker(other_tracker):
-            inner = consist.run(fn=noop, name="inner_default")
+            with pytest.warns(DeprecationWarning, match="consist.run"):
+                inner = consist.run(fn=noop, name="inner_default")
             assert other_tracker.last_run.run.id == inner.run.id
 
-            overridden = consist.run(
-                fn=noop, name="override", tracker=tracker, run_id="explicit_override"
-            )
+            with pytest.warns(DeprecationWarning, match="consist.run"):
+                overridden = consist.run(
+                    fn=noop,
+                    name="override",
+                    tracker=tracker,
+                    run_id="explicit_override",
+                )
             assert tracker.last_run.run.id == overridden.run.id
 
-        after_inner = consist.run(fn=noop, name="after_inner")
+        with pytest.warns(DeprecationWarning, match="consist.run"):
+            after_inner = consist.run(fn=noop, name="after_inner")
         assert tracker.last_run.run.id == after_inner.run.id
 
     with pytest.raises(
         RuntimeError, match="No default tracker configured for consist.run"
     ):
-        consist.run(fn=noop)
+        with pytest.warns(DeprecationWarning, match="consist.run"):
+            consist.run(fn=noop)
 
 
 def test_active_run_context_beats_default_tracker_for_logging(tracker, tmp_path):

--- a/tests/unit/api/test_run_materialize_outputs_api.py
+++ b/tests/unit/api/test_run_materialize_outputs_api.py
@@ -927,37 +927,77 @@ def test_run_hydrate_outputs_rejects_invalid_runtime_options_before_delegation(
 
 
 @pytest.mark.parametrize("bad_keys", ["out", b"out"])
-def test_api_materialize_run_outputs_rejects_scalar_string_keys_before_delegation(
+def test_api_materialize_run_outputs_passes_scalar_string_keys_to_tracker(
     monkeypatch: pytest.MonkeyPatch,
     bad_keys: str | bytes,
 ) -> None:
+    calls: dict[str, object] = {}
+
     class _FakeTracker:
         def materialize_run_outputs(self, run_id: str, **kwargs):
-            raise AssertionError("delegation should not happen for invalid keys")
+            calls["run_id"] = run_id
+            calls["kwargs"] = kwargs
+            return "api-result"
 
     monkeypatch.setattr(
         "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
     )
 
-    with pytest.raises(TypeError, match="keys must be a sequence"):
-        materialize_run_outputs_api("run_1", target_root="/tmp/restored", keys=bad_keys)
+    result = materialize_run_outputs_api(
+        "run_1",
+        target_root="/tmp/restored",
+        keys=bad_keys,
+    )
+
+    assert result == "api-result"
+    assert calls == {
+        "run_id": "run_1",
+        "kwargs": {
+            "target_root": "/tmp/restored",
+            "source_root": None,
+            "keys": bad_keys,
+            "preserve_existing": True,
+            "on_missing": "warn",
+            "db_fallback": "if_ingested",
+        },
+    }
 
 
 @pytest.mark.parametrize("bad_keys", ["out", b"out"])
-def test_api_hydrate_run_outputs_rejects_scalar_string_keys_before_delegation(
+def test_api_hydrate_run_outputs_passes_scalar_string_keys_to_tracker(
     monkeypatch: pytest.MonkeyPatch,
     bad_keys: str | bytes,
 ) -> None:
+    calls: dict[str, object] = {}
+
     class _FakeTracker:
         def hydrate_run_outputs(self, run_id: str, **kwargs):
-            raise AssertionError("delegation should not happen for invalid keys")
+            calls["run_id"] = run_id
+            calls["kwargs"] = kwargs
+            return "hydrated-api-result"
 
     monkeypatch.setattr(
         "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
     )
 
-    with pytest.raises(TypeError, match="keys must be a sequence"):
-        hydrate_run_outputs_api("run_1", target_root="/tmp/restored", keys=bad_keys)
+    result = hydrate_run_outputs_api(
+        "run_1",
+        target_root="/tmp/restored",
+        keys=bad_keys,
+    )
+
+    assert result == "hydrated-api-result"
+    assert calls == {
+        "run_id": "run_1",
+        "kwargs": {
+            "target_root": "/tmp/restored",
+            "source_root": None,
+            "keys": bad_keys,
+            "preserve_existing": True,
+            "on_missing": "warn",
+            "db_fallback": "if_ingested",
+        },
+    }
 
 
 @pytest.mark.parametrize(
@@ -967,22 +1007,40 @@ def test_api_hydrate_run_outputs_rejects_scalar_string_keys_before_delegation(
         ("db_fallback", "always"),
     ],
 )
-def test_api_materialize_run_outputs_rejects_invalid_runtime_options_before_delegation(
+def test_api_materialize_run_outputs_passes_invalid_runtime_options_to_tracker(
     monkeypatch: pytest.MonkeyPatch,
     field_name: str,
     field_value: str,
 ) -> None:
+    calls: dict[str, object] = {}
+
     class _FakeTracker:
         def materialize_run_outputs(self, run_id: str, **kwargs):
-            raise AssertionError("delegation should not happen for invalid options")
+            calls["run_id"] = run_id
+            calls["kwargs"] = kwargs
+            return "api-result"
 
     monkeypatch.setattr(
         "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
     )
     kwargs = {"target_root": "/tmp/restored", field_name: field_value}
 
-    with pytest.raises(ValueError, match=field_name):
-        materialize_run_outputs_api("run_1", **kwargs)
+    result = materialize_run_outputs_api("run_1", **kwargs)
+
+    assert result == "api-result"
+    assert calls == {
+        "run_id": "run_1",
+        "kwargs": {
+            "target_root": "/tmp/restored",
+            "source_root": None,
+            "keys": None,
+            "preserve_existing": True,
+            "on_missing": "warn" if field_name != "on_missing" else field_value,
+            "db_fallback": (
+                "if_ingested" if field_name != "db_fallback" else field_value
+            ),
+        },
+    }
 
 
 @pytest.mark.parametrize(
@@ -992,19 +1050,37 @@ def test_api_materialize_run_outputs_rejects_invalid_runtime_options_before_dele
         ("db_fallback", "always"),
     ],
 )
-def test_api_hydrate_run_outputs_rejects_invalid_runtime_options_before_delegation(
+def test_api_hydrate_run_outputs_passes_invalid_runtime_options_to_tracker(
     monkeypatch: pytest.MonkeyPatch,
     field_name: str,
     field_value: str,
 ) -> None:
+    calls: dict[str, object] = {}
+
     class _FakeTracker:
         def hydrate_run_outputs(self, run_id: str, **kwargs):
-            raise AssertionError("delegation should not happen for invalid options")
+            calls["run_id"] = run_id
+            calls["kwargs"] = kwargs
+            return "hydrated-api-result"
 
     monkeypatch.setattr(
         "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
     )
     kwargs = {"target_root": "/tmp/restored", field_name: field_value}
 
-    with pytest.raises(ValueError, match=field_name):
-        hydrate_run_outputs_api("run_1", **kwargs)
+    result = hydrate_run_outputs_api("run_1", **kwargs)
+
+    assert result == "hydrated-api-result"
+    assert calls == {
+        "run_id": "run_1",
+        "kwargs": {
+            "target_root": "/tmp/restored",
+            "source_root": None,
+            "keys": None,
+            "preserve_existing": True,
+            "on_missing": "warn" if field_name != "on_missing" else field_value,
+            "db_fallback": (
+                "if_ingested" if field_name != "db_fallback" else field_value
+            ),
+        },
+    }

--- a/tests/unit/core/test_input_staging.py
+++ b/tests/unit/core/test_input_staging.py
@@ -4,8 +4,6 @@ import hashlib
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 import consist.api as consist_api
 from consist.core.fs import FileSystemManager
 from consist.core.materialize import (
@@ -271,17 +269,16 @@ def test_stage_inputs_returns_ordered_keyed_results(tmp_path: Path) -> None:
     assert result.paths["b"] == dest_b.resolve()
 
 
-def test_api_stage_artifact_delegates_to_core(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_api_stage_artifact_delegates_to_tracker_method() -> None:
     sentinel = object()
     calls: dict[str, object] = {}
-    tracker = SimpleNamespace()
     artifact = _artifact("source", "./inputs/source.csv")
 
-    def _fake_stage(tr, art, destination, **kwargs):
-        calls.update(tr=tr, art=art, destination=destination, kwargs=kwargs)
+    def _fake_stage(art, **kwargs):
+        calls.update(art=art, kwargs=kwargs)
         return sentinel
 
-    monkeypatch.setattr(consist_api, "stage_artifact_core", _fake_stage)
+    tracker = SimpleNamespace(stage_artifact=_fake_stage)
 
     result = consist_api.stage_artifact(
         artifact,
@@ -292,28 +289,25 @@ def test_api_stage_artifact_delegates_to_core(monkeypatch: pytest.MonkeyPatch) -
     )
 
     assert result is sentinel
-    assert calls["tr"] is tracker
     assert calls["art"] is artifact
-    assert calls["destination"] == Path("/tmp/staged.csv")
     assert calls["kwargs"]["overwrite"] is True
+    assert calls["kwargs"]["destination"] == "/tmp/staged.csv"
+    assert calls["kwargs"]["mode"] == "copy"
 
 
-def test_api_stage_inputs_delegates_to_core(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_api_stage_inputs_delegates_to_tracker_method() -> None:
     sentinel = object()
     calls: dict[str, object] = {}
-    tracker = SimpleNamespace()
     artifact = _artifact("source", "./inputs/source.csv")
 
-    def _fake_stage(tr, inputs_by_key, destinations_by_key, **kwargs):
+    def _fake_stage(inputs_by_key, **kwargs):
         calls.update(
-            tr=tr,
             inputs_by_key=inputs_by_key,
-            destinations_by_key=destinations_by_key,
             kwargs=kwargs,
         )
         return sentinel
 
-    monkeypatch.setattr(consist_api, "stage_inputs_core", _fake_stage)
+    tracker = SimpleNamespace(stage_inputs=_fake_stage)
 
     result = consist_api.stage_inputs(
         {"source": artifact},
@@ -324,7 +318,7 @@ def test_api_stage_inputs_delegates_to_core(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
     assert result is sentinel
-    assert calls["tr"] is tracker
     assert calls["inputs_by_key"] == {"source": artifact}
-    assert calls["destinations_by_key"] == {"source": Path("/tmp/staged.csv")}
     assert calls["kwargs"]["overwrite"] is True
+    assert calls["kwargs"]["destinations_by_key"] == {"source": "/tmp/staged.csv"}
+    assert calls["kwargs"]["mode"] == "copy"

--- a/tests/unit/test_api_run_options.py
+++ b/tests/unit/test_api_run_options.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import consist
 import pytest
 from consist import use_tracker
+from consist.models.artifact import Artifact
 from consist.types import CacheOptions, ExecutionOptions
 
 
@@ -15,18 +16,20 @@ def test_consist_run_forwards_options_objects(tracker):
         (ctx.run_dir / "out.txt").write_text("ok")
 
     with use_tracker(tracker):
-        first = consist.run(
-            fn=step,
-            output_paths={"out": "out.txt"},
-            cache_options=CacheOptions(cache_mode="reuse"),
-            execution_options=ExecutionOptions(inject_context="ctx"),
-        )
-        second = consist.run(
-            fn=step,
-            output_paths={"out": "out.txt"},
-            cache_options=CacheOptions(cache_mode="reuse"),
-            execution_options=ExecutionOptions(inject_context="ctx"),
-        )
+        with pytest.warns(DeprecationWarning, match="consist.run"):
+            first = consist.run(
+                fn=step,
+                output_paths={"out": "out.txt"},
+                cache_options=CacheOptions(cache_mode="reuse"),
+                execution_options=ExecutionOptions(inject_context="ctx"),
+            )
+        with pytest.warns(DeprecationWarning, match="consist.run"):
+            second = consist.run(
+                fn=step,
+                output_paths={"out": "out.txt"},
+                cache_options=CacheOptions(cache_mode="reuse"),
+                execution_options=ExecutionOptions(inject_context="ctx"),
+            )
 
     assert first.cache_hit is False
     assert second.cache_hit is True
@@ -51,7 +54,7 @@ def test_consist_get_run_result_wrapper(tracker):
         (ctx.run_dir / "out.txt").write_text("ok")
 
     with use_tracker(tracker):
-        produced = consist.run(
+        produced = tracker.run(
             fn=step,
             output_paths={"out": "out.txt"},
             execution_options=ExecutionOptions(inject_context="ctx"),
@@ -67,20 +70,59 @@ def test_consist_trace_forwards_identity_kwargs(tracker, tmp_path):
     identity_dep.write_text("dep=true\n")
 
     with use_tracker(tracker):
-        with consist.trace(
-            "trace_identity_api",
-            identity_inputs=[identity_dep],
-            cache_version=5,
-            cache_epoch=4,
-            code_identity="repo_git",
-            code_identity_extra_deps=[str(identity_dep)],
-        ) as t:
-            out_path = t.run_dir / "out.txt"
-            out_path.write_text("ok")
-            t.log_artifact(out_path, key="out", direction="output")
+        with pytest.warns(DeprecationWarning, match="consist.trace"):
+            with consist.trace(
+                "trace_identity_api",
+                identity_inputs=[identity_dep],
+                cache_version=5,
+                cache_epoch=4,
+                code_identity="repo_git",
+                code_identity_extra_deps=[str(identity_dep)],
+            ) as t:
+                out_path = t.run_dir / "out.txt"
+                out_path.write_text("ok")
+                t.log_artifact(out_path, key="out", direction="output")
 
     run = tracker.last_run.run
     assert run.meta["cache_version"] == 5
     assert run.meta["cache_epoch"] == 4
     assert run.meta["code_identity"] == "repo_git"
     assert run.meta["code_identity_extra_deps"] == [str(identity_dep)]
+
+
+def test_consist_start_run_warns_and_delegates(tracker) -> None:
+    with use_tracker(tracker):
+        with pytest.warns(DeprecationWarning, match="consist.start_run"):
+            with consist.start_run("deprecated_start", "model") as active:
+                assert active is tracker
+                assert active.current_consist is not None
+                assert active.current_consist.run.id == "deprecated_start"
+
+
+def test_consist_ingest_delegates_without_warning(
+    tracker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: dict[str, object] = {}
+    artifact = Artifact(
+        key="table",
+        container_uri="./table.csv",
+        driver="csv",
+        meta={},
+    )
+
+    def _fake_ingest(*, artifact, data=None, schema=None, run=None):
+        calls.update(artifact=artifact, data=data, schema=schema, run=run)
+        return "ingested"
+
+    monkeypatch.setattr(tracker, "ingest", _fake_ingest)
+
+    with tracker.start_run("ingest_warn", "model"):
+        result = consist.ingest(artifact, data=[{"id": 1}])
+
+    assert result == "ingested"
+    assert calls == {
+        "artifact": artifact,
+        "data": [{"id": 1}],
+        "schema": None,
+        "run": None,
+    }


### PR DESCRIPTION
## Summary

This PR tightens the boundary between the top-level `consist.*` API and the explicit `Tracker` API.

It does two things:

1. Simplifies `src/consist/api.py` so it stops duplicating tracker/service behavior.
2. Clarifies which top-level helpers are worth keeping vs. which are redundant enough to deprecate.

## Motivation

`api.py` had become a parallel implementation surface for behavior that already exists on `Tracker` and its services. That creates drift risk and makes future refactors more expensive, since changes have to be maintained in two places.

The specific goal here is to preserve top-level helpers that add real ergonomic value, while deprecating top-level wrappers that only duplicate tracker-owned execution entry points.

The design line this PR adopts is:

- Keep top-level helpers that provide ambient run-scoped behavior.
- Keep pure/context utilities.
- Deprecate top-level helpers that are just duplicate execution entry points.

That means there is still clear value in things like `consist.log_artifact(...)` for orchestration-heavy workflows where threading a tracker through nested helper functions is undesirable, while `consist.run(...)` / `consist.trace(...)` / `consist.start_run(...)` do not provide enough distinct value to justify long-term parity maintenance.

## What changed

### API cleanup
- Converted the pure tracker-forwarding helpers in `src/consist/api.py` into direct delegates.
- Changed `stage_artifact(...)` and `stage_inputs(...)` to go through `Tracker` instead of calling `stage_*_core` directly.
- Removed duplicate validation from `materialize_run_outputs(...)` and `hydrate_run_outputs(...)` in `api.py`; validation now comes from the tracker/service layer only.
- Removed dead imports associated with the old API-layer implementations.

### Deprecation policy
Added `DeprecationWarning` for these top-level wrappers:
- `consist.run(...)`
- `consist.trace(...)`
- `consist.start_run(...)`

Kept these as supported top-level helpers:
- ambient run-scoped helpers such as `consist.log_artifact(...)`, `log_artifacts(...)`, `log_input(...)`, `log_output(...)`, `ingest(...)`, `log_meta(...)`, `capture_outputs(...)`
- pure/context utilities such as `ref(...)`, `refs(...)`, `output_path(...)`, `output_dir(...)`
- `consist.scenario(...)` as an intentional exception because it still provides meaningful API-level behavior, including `enabled=False`

### Docs
Updated docs to reflect the new API policy:
- prefer `tracker.run(...)` / `tracker.trace(...)` for explicit execution
- prefer `scenario.run(...)` / `scenario.trace(...)` inside scenarios
- document `consist.run(...)` / `consist.trace(...)` / `consist.start_run(...)` as deprecated compatibility wrappers
- explicitly document why logging/ingestion-style top-level helpers remain supported

## Why this is safe

This is intended to be a mechanical cleanup:
- no symbol removals
- no public API removals
- same tracker/service validation still exists, just in one place instead of two
- top-level helper behavior that provides real ergonomic value is preserved

## Follow-up ideas

- Decide whether more top-level helpers should be explicitly classified as “ambient helper” vs. “execution wrapper” in docs.
- Consider a longer-term deprecation/removal timeline for `consist.run(...)`, `consist.trace(...)`, and `consist.start_run(...)`.