### PR TITLE
formalize artifact hash

### DIFF
--- a/docs/api/materialize.md
+++ b/docs/api/materialize.md
@@ -114,7 +114,8 @@ In this flow:
   destination.
 - `hydrated["persons"].artifact` is a detached artifact view. When
   `resolvable` is `True`, `artifact.as_path()` points at the hydrated
-  destination in the new workspace.
+  destination in the new workspace. The detached artifact also preserves
+  `artifact.hash`, Consist's canonical artifact fingerprint surface.
 
 ## Requested Input Staging
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,14 +63,15 @@ Consist uses two core entities with a many-to-many relationship:
 | Entity | Purpose |
 |--------|---------|
 | `Run` | Execution context: model name, config, timestamps, status, parent linkage |
-| `Artifact` | File metadata: path (as URI), content hash, driver, schema reference |
+| `Artifact` | File metadata: path (as URI), canonical fingerprint (`artifact.hash`), driver, schema reference |
 | `RunArtifactLink` | Connects runs to their input and output artifacts with direction metadata |
 
 Key fields for workflow tracking:
 - `Run.parent_run_id` — Links scenario steps to their parent scenario; used as the scenario identifier in views (see `consist_scenario_id`)
 - `Run.year` — Simulation year for time-series workflows
 - `Run.tags` — String labels for filtering (stored as JSON array)
-- `Artifact.hash` — SHA256 content hash for deduplication and verification
+- `Artifact.hash` — Canonical portable artifact fingerprint for downstream provenance, verification, and deduplication
+- `Artifact.content_id` — DB-local dedupe identity; not the public fingerprint surface
 
 Consist provides three strategies for tracking configuration: `config=` (hashed into the cache key, stored as a JSON snapshot), `facet=` (queryable in DuckDB, does not affect the cache), and `identity_inputs=` (large external files hashed into the cache key but not stored as content). For full usage, guardrails, and query examples, see [Config, Facets, and Identity Inputs](concepts/config-management.md).
 

--- a/docs/concepts/caching-and-hydration.md
+++ b/docs/concepts/caching-and-hydration.md
@@ -333,7 +333,13 @@ Consist distinguishes **provenance identity** (where an artifact came from, via 
 
 For Consist-produced artifacts, inputs are hashed by linking to the producing run's signature (Merkle-style). For raw files (no `run_id`), Consist hashes file contents or metadata depending on configuration.
 
-To skip hashing when you know the content hash (e.g., after copying a file), pass `content_hash=` to `log_artifact`. Consist ignores mismatched overrides unless `force_hash_override=True`. Use `validate_content_hash=True` to verify the override against on-disk data.
+To skip hashing when you already know the artifact fingerprint (for example
+after copying a file), pass `content_hash=` to `log_artifact`. Consist stores
+that value on `artifact.hash`, the canonical public fingerprint field. Consist
+ignores mismatched overrides unless `force_hash_override=True`. Use
+`validate_content_hash=True` to verify the override against on-disk data. Under
+`fast` hashing, the fingerprint may be metadata-based rather than a strict
+byte-content digest.
 
 ### Portability and Path Resolution
 
@@ -549,7 +555,13 @@ features = hydrated["features"]
 assert features.resolvable
 print(features.status)
 print(features.artifact.as_path())
+print(features.artifact.hash)
 ```
+
+`features.artifact.hash` remains the canonical artifact fingerprint after
+hydration. Downstream provenance code should read that field rather than
+guessing among wrapper-specific names. Fingerprint semantics follow the active
+hashing strategy, so under `fast` hashing the value may be metadata-based.
 
 Cache hydration exposes an archive-mirror override via
 `materialize_cached_outputs_source_root=...` for `outputs-requested` and

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -6,7 +6,10 @@ This section establishes the mental model for Consist before covering API detail
 
 ## Core Abstractions
 
-**Artifact**: A file with provenance metadata—its path, format, content hash (SHA256), producing run, and ingestion status.
+**Artifact**: A file with provenance metadata: path, format, canonical
+fingerprint (`artifact.hash`), producing run, and ingestion status. Fingerprint
+semantics follow the active hashing strategy, so under `fast` hashing the value
+may be metadata-based rather than a strict byte-content digest.
 
 **Run**: A single execution with tracked inputs, configuration, outputs, status, and timing. Each run has a signature computed from code, config, and inputs that enables cache reuse.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -369,7 +369,7 @@ cache miss explanation tells you which part of that key likely drifted.
 **Common causes:**
 - **Code changed:** Check git status, function definitions
 - **Config changed:** Check parameter types (0 vs 0.0, "0" vs 0)
-- **Input file changed:** Check file modification time, content hash
+- **Input file changed:** Check file modification time and artifact fingerprint
 - **Run fields changed:** `model`, `year`, or `iteration` are folded into the config hash
 - **Dependencies changed:** Installed package versions can affect behavior
 
@@ -935,7 +935,7 @@ from pathlib import Path
 with tracker.start_run("hash_input", model="example"):
     artifact = tracker.log_artifact(Path("input.csv"), key="input", direction="input")
     print(f"Path: {artifact.path}")
-    print(f"Hash: {artifact.hash}")
+    print(f"Artifact Fingerprint: {artifact.hash}")
     print(f"Size: {artifact.path.stat().st_size}")
 ```
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1198,7 +1198,16 @@ result = hydrated["results"]
 print(result.status)
 if result.resolvable:
     print(result.artifact.as_path())
+    print(result.artifact.hash)
 ```
+
+The detached artifact returned by `hydrate_run_outputs(...)` preserves
+`artifact.hash` as Consist's canonical artifact fingerprint. This is the field
+downstream provenance code should read after logging, querying, replay, staging,
+or hydration. Fingerprint semantics follow the active hashing strategy, so under
+`fast` hashing the value may be metadata-based rather than a byte-for-byte
+content digest. By contrast, `artifact.content_id` is a DB-local dedupe key and
+is not the public fingerprint surface.
 
 Set per-run via `cache_options=CacheOptions(cache_hydration=...)` (for `run(...)`)
 or for scenario defaults via `step_cache_hydration=...`:
@@ -1517,7 +1526,15 @@ For more on ingestion and hybrid views, see [Data Materialization Strategy](conc
 If you ingest tabular data into DuckDB, Consist can capture the observed schema and export an **editable SQLModel stub** so you can curate PK/FK constraints and then register the model for views. This is useful when you want a stable, documented schema for downstream analysis or audits.
 
 You can also opt into lightweight file schema capture when logging CSV/Parquet artifacts by passing `profile_file_schema=True` (and optionally `file_schema_sample_rows=`) to `log_artifact`. These captured schemas are stored in the provenance DB and remain available even if the original files move or are deleted.
-If you already have a content hash (e.g., after copying or moving a file), pass `content_hash=` to `log_artifact` to reuse it without re-hashing the file. For safety, Consist will not overwrite an existing, different hash unless you pass `force_hash_override=True`. To verify the hash against disk, use `validate_content_hash=True`.
+If you already have an artifact fingerprint (for example after copying or moving
+a file), pass `content_hash=` to `log_artifact` to reuse it without re-hashing
+the path. Consist stores that value on `artifact.hash`, the canonical public
+fingerprint surface for downstream provenance/bookkeeping code. For safety,
+Consist will not overwrite an existing, different fingerprint unless you pass
+`force_hash_override=True`. To verify the supplied fingerprint against disk, use
+`validate_content_hash=True`. Fingerprint semantics follow the active hashing
+strategy, so under `fast` hashing the value may be metadata-based for files or
+directories.
 
 See [Schema Export](schema-export.md) for the full workflow (CLI + Python) and column-name/`__tablename__` guidelines.
 See [Data Materialization Strategy](concepts/data-materialization.md) for ingestion tradeoffs and DB fallback behavior.

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -1165,7 +1165,9 @@ def hydrate_run_outputs(
     Returns
     -------
     HydratedRunOutputsResult
-        Keyed hydration outcome for the selected run outputs.
+        Keyed hydration outcome for the selected run outputs. Each detached
+        returned artifact preserves the canonical fingerprint surface on
+        ``artifact.hash``.
 
     Examples
     --------
@@ -1448,8 +1450,9 @@ def log_artifact(
         Explicitly specify the driver (e.g., 'h5_table').
         If None, the driver is inferred from the file extension.
     content_hash : Optional[str], optional
-        Precomputed content hash to use for the artifact instead of hashing
-        the path on disk.
+        Precomputed artifact fingerprint to use instead of hashing the path on
+        disk. When provided, Consist stores it on the canonical public
+        fingerprint field, ``artifact.hash``.
     force_hash_override : bool, default False
         If True, overwrite an existing artifact hash when it differs from
         `content_hash`. By default, mismatched overrides are ignored with a warning.
@@ -1695,7 +1698,9 @@ def log_input(
     driver : Optional[str]
         Explicit format driver (e.g. "parquet"). Inferred from extension if None.
     content_hash : Optional[str]
-        Precomputed hash to avoid re-hashing large files.
+        Precomputed artifact fingerprint to avoid re-hashing large files. When
+        provided, Consist stores it on the canonical public fingerprint field,
+        ``artifact.hash``.
     force_hash_override : bool, default False
         Overwrite existing hash in the database if different from `content_hash`.
     validate_content_hash : bool, default False
@@ -1765,7 +1770,9 @@ def log_output(
     driver : Optional[str]
         Explicit format driver (e.g. "parquet"). Inferred from extension if None.
     content_hash : Optional[str]
-        Precomputed hash to avoid re-hashing large files.
+        Precomputed artifact fingerprint to avoid re-hashing large files. When
+        provided, Consist stores it on the canonical public fingerprint field,
+        ``artifact.hash``.
     force_hash_override : bool, default False
         Overwrite existing hash in the database if different from `content_hash`.
     validate_content_hash : bool, default False

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -130,7 +130,8 @@ class HydratedRunOutput:
         Detached copy of the historical artifact record. When ``resolvable`` is
         ``True``, the detached artifact's runtime ``abs_path`` points at the
         hydrated destination so helpers like ``artifact.as_path()`` can be used
-        directly in the new workspace.
+        directly in the new workspace. The detached artifact preserves the
+        canonical fingerprint surface on ``artifact.hash``.
     path : Path | None
         Destination path under the requested target root, when one is known.
         This can be populated even for non-resolvable outcomes to show the
@@ -272,7 +273,8 @@ class StagedInput:
         Detached copy of the input artifact. When ``resolvable`` is ``True``,
         the detached artifact's runtime ``abs_path`` points at the staged
         destination so helpers like ``artifact.as_path()`` can be used
-        directly.
+        directly. The detached artifact preserves the canonical fingerprint
+        surface on ``artifact.hash``.
     path : Path | None
         Explicit staging destination, when one was known.
     status : StagingStatus

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -2347,8 +2347,9 @@ class Tracker:
         array_path : Optional[str], optional
             Optional array path inside a container (e.g., Zarr group).
         content_hash : Optional[str], optional
-            Precomputed content hash to use for the artifact instead of hashing
-            the path on disk.
+            Precomputed artifact fingerprint to use instead of hashing the path
+            on disk. When provided, Consist stores it on the canonical public
+            fingerprint field, ``artifact.hash``.
         force_hash_override : bool, default False
             If True, overwrite an existing artifact hash when it differs from
             `content_hash`. By default, mismatched overrides are ignored with a warning.
@@ -2656,8 +2657,9 @@ class Tracker:
         key : Optional[str], optional
             A semantic, human-readable name for the artifact.
         content_hash : Optional[str], optional
-            Precomputed content hash to use for the artifact instead of hashing
-            the path on disk.
+            Precomputed artifact fingerprint to use instead of hashing the path
+            on disk. When provided, Consist stores it on the canonical public
+            fingerprint field, ``artifact.hash``.
         force_hash_override : bool, default False
             If True, overwrite an existing artifact hash when it differs from
             `content_hash`. By default, mismatched overrides are ignored with a warning.
@@ -2714,8 +2716,9 @@ class Tracker:
         key : Optional[str], optional
             A semantic, human-readable name for the artifact.
         content_hash : Optional[str], optional
-            Precomputed content hash to use for the artifact instead of hashing
-            the path on disk.
+            Precomputed artifact fingerprint to use instead of hashing the path
+            on disk. When provided, Consist stores it on the canonical public
+            fingerprint field, ``artifact.hash``.
         force_hash_override : bool, default False
             If True, overwrite an existing artifact hash when it differs from
             `content_hash`. By default, mismatched overrides are ignored with a warning.

--- a/src/consist/core/tracker_artifact_logging.py
+++ b/src/consist/core/tracker_artifact_logging.py
@@ -78,7 +78,9 @@ class ArtifactLoggingCoordinator:
         array_path : str | None, optional
             Optional array path for array/container-backed artifacts.
         content_hash : str | None, optional
-            Optional precomputed content hash override.
+            Optional precomputed artifact fingerprint override. When provided,
+            it becomes the artifact's canonical public fingerprint on
+            ``artifact.hash``.
         force_hash_override : bool, default False
             Whether mismatched content hash overrides are forced.
         validate_content_hash : bool, default False

--- a/src/consist/models/artifact.py
+++ b/src/consist/models/artifact.py
@@ -151,6 +151,15 @@ class Artifact(SQLModel, table=True):
     has a unique identity, a virtualized location, and rich metadata, supporting
     both "hot" (ingested) and "cold" (file-based) data strategies.
 
+    The public fingerprint surface for downstream consumers is ``Artifact.hash``.
+    Consist preserves that field across logging, querying, replay, staging, and
+    hydration so external provenance/bookkeeping code can read one stable
+    fingerprint without probing wrapper-specific fields. Fingerprint semantics
+    follow the configured hashing strategy: ``full`` is generally content-based,
+    while ``fast`` may use metadata-based hashing for files or directories.
+    ``Artifact.content_id`` is a database-local deduplication key and is not the
+    public fingerprint contract.
+
     Attributes:
         id (uuid.UUID): A unique identifier for the artifact.
         key (str): A semantic, human-readable name for the artifact (e.g., "households", "parcels").
@@ -160,8 +169,9 @@ class Artifact(SQLModel, table=True):
         array_path (Optional[str]): Optional path inside a container for array artifacts.
         driver (str): The name of the format handler used to read or write the artifact
                       (e.g., "parquet", "csv", "zarr").
-        hash (Optional[str]): SHA256 content hash of the artifact's data, enabling content-addressable
-                              lookups and deduplication.
+        hash (Optional[str]): Canonical portable artifact fingerprint. This is usually a SHA256
+                              digest and remains the stable public identity field across logging,
+                              replay, staging, and hydration.
         run_id (Optional[str]): The ID of the run that generated this artifact. Null for inputs.
         meta (dict[str, object]): A flexible JSON field for storing arbitrary metadata, such as
                                schema signatures, or data dimensions.
@@ -199,17 +209,23 @@ class Artifact(SQLModel, table=True):
         description="Format handler: parquet, csv, zarr, json, h5_table, h5, hdf5, geojson, shapefile, geopackage, or other"
     )
 
-    # Content Hash (for deduplication and content-addressable lookups)
+    # Canonical artifact fingerprint (portable) plus DB-local content identity.
     hash: Optional[str] = Field(
         default=None,
         index=True,
-        description="SHA256 content hash of the artifact's data",
+        description=(
+            "Canonical portable artifact fingerprint. Semantics follow the active "
+            "hashing strategy and may be content- or metadata-based."
+        ),
     )
     content_id: Optional[uuid.UUID] = Field(
         default=None,
         index=True,
         sa_type=UUIDType,
-        description="Pointer to shared ArtifactContent metadata when available",
+        description=(
+            "Database-local pointer to shared ArtifactContent metadata used for "
+            "deduplication; not the public artifact fingerprint surface."
+        ),
     )
 
     # Lineage

--- a/tests/unit/core/test_artifacts.py
+++ b/tests/unit/core/test_artifacts.py
@@ -206,6 +206,7 @@ def test_attach_content_id_handles_deepcopied_detached_artifact(tmp_path, caplog
 
     assert out is not replayed
     assert out.id == replayed.id
+    assert out.hash == replayed.hash == "shared_hash"
     assert content is not None
     assert out.content_id == content.id
     assert "Failed to record artifact content identity" not in caplog.text

--- a/tests/unit/core/test_input_staging.py
+++ b/tests/unit/core/test_input_staging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -18,11 +19,22 @@ from consist.models.artifact import Artifact
 def _checksum(path: Path) -> str:
     if path.is_dir():
         digest = hashlib.sha256()
-        for child in sorted(path.rglob("*")):
-            if child.is_file():
-                digest.update(child.relative_to(path).as_posix().encode("utf-8"))
-                digest.update(b"\0")
-                digest.update(child.read_bytes())
+        base = path.resolve()
+        for root, dirnames, filenames in os.walk(base):
+            dirnames.sort()
+            filenames.sort()
+            rel_root = Path(root).resolve().relative_to(base).as_posix()
+            digest.update(f"dir:{rel_root}".encode("utf-8"))
+            for dirname in dirnames:
+                rel_dir = Path(root, dirname).resolve().relative_to(base).as_posix()
+                digest.update(f"subdir:{rel_dir}".encode("utf-8"))
+            for filename in filenames:
+                file_path = Path(root, filename).resolve()
+                rel_file = file_path.relative_to(base).as_posix()
+                digest.update(f"file:{rel_file}".encode("utf-8"))
+                digest.update(
+                    hashlib.sha256(file_path.read_bytes()).hexdigest().encode("utf-8")
+                )
         return digest.hexdigest()
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -78,6 +90,7 @@ def test_stage_artifact_copies_file_and_detaches_artifact(tmp_path: Path) -> Non
     assert result.status == "staged"
     assert result.resolvable is True
     assert result.path == destination.resolve()
+    assert result.artifact.hash == artifact.hash
     assert result.artifact.as_path() == destination.resolve()
     assert destination.read_text(encoding="utf-8") == "value\n1\n"
 
@@ -112,14 +125,32 @@ def test_stage_artifact_stages_directories(tmp_path: Path) -> None:
         "bundle",
         "./inputs/bundle",
         driver="zarr",
+        hash_value=_checksum(source),
     )
 
     result = stage_artifact(tracker, artifact, destination)
 
     assert result.status == "staged"
+    assert result.artifact.hash == artifact.hash
     assert (destination / "nested" / "data.txt").read_text(
         encoding="utf-8"
     ) == "payload"
+
+
+def test_stage_artifact_preserves_missing_hash_on_detached_artifact(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "inputs" / "source.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+    destination = tmp_path / "runs" / "staged" / "source.csv"
+    tracker = _tracker(tmp_path / "runs", resolve_uri=lambda _uri: str(source))
+    artifact = _artifact("source", "./inputs/source.csv")
+
+    result = stage_artifact(tracker, artifact, destination)
+
+    assert result.status == "staged"
+    assert result.artifact.hash is None
 
 
 def test_stage_artifact_uses_runtime_abs_path_when_canonical_resolution_missing(

--- a/tests/unit/core/test_run_materialize_outputs_core.py
+++ b/tests/unit/core/test_run_materialize_outputs_core.py
@@ -51,6 +51,7 @@ def _artifact(
     *,
     run_id: str | None = None,
     driver: str = "csv",
+    hash_value: str | None = None,
     meta: dict | None = None,
 ) -> Artifact:
     return Artifact(
@@ -58,6 +59,7 @@ def _artifact(
         key=key,
         container_uri=uri,
         driver=driver,
+        hash=hash_value,
         run_id=run_id,
         meta=dict(meta or {}),
     )
@@ -881,7 +883,7 @@ def test_hydrate_run_outputs_returns_detached_artifact_views(
     with tracker.start_run(
         "producer_hydrate", model="producer", cache_mode="overwrite"
     ):
-        tracker.log_artifact(output_path, key="table", direction="output")
+        logged = tracker.log_artifact(output_path, key="table", direction="output")
 
     historical_artifact = tracker.get_run_outputs("producer_hydrate")["table"]
 
@@ -897,6 +899,7 @@ def test_hydrate_run_outputs_returns_detached_artifact_views(
     assert result.resolvable is True
     assert result.path == restored_path
     assert result.artifact is not historical_artifact
+    assert result.artifact.hash == historical_artifact.hash == logged.hash
     assert result.artifact.container_uri == historical_artifact.container_uri
     assert result.artifact.path == restored_path
     assert result.artifact.as_path() == restored_path
@@ -905,6 +908,39 @@ def test_hydrate_run_outputs_returns_detached_artifact_views(
     assert list(hydrated.resolvable) == ["table"]
     assert hydrated.complete is True
     assert historical_artifact.as_path() == output_path
+
+
+def test_hydrate_run_outputs_preserves_unhashed_artifacts(tmp_path: Path) -> None:
+    producer_dir = tmp_path / "producer"
+    source = producer_dir / "outputs" / "table.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+
+    selected_run = _run("consumer", run_dir=tmp_path / "consumer")
+    producing_run = _run("producer", run_dir=producer_dir)
+    outputs = [_artifact("table", "./outputs/table.csv", run_id="producer")]
+    tracker = _stub_tracker(
+        run_dir=tmp_path / "workspace",
+        outputs_by_run={"consumer": outputs},
+        runs={"consumer": selected_run, "producer": producing_run},
+    )
+
+    hydrated = hydrate_run_outputs(
+        tracker,
+        selected_run,
+        target_root=tmp_path / "restored",
+        source_root=None,
+        keys=["table"],
+        allowed_base=tmp_path,
+        preserve_existing=True,
+        on_missing="raise",
+        db_fallback="never",
+    )
+
+    result = hydrated["table"]
+    assert result.status == "materialized_from_filesystem"
+    assert result.resolvable is True
+    assert result.artifact.hash is None
 
 
 def test_hydrate_run_outputs_warn_mode_returns_mixed_keyed_statuses(


### PR DESCRIPTION
## Summary

Formalizes `Artifact.hash` as Consist’s canonical public artifact fingerprint surface.

This PR does not change hashing behavior, persistence, or introduce new identity objects. It makes the existing contract explicit so downstream code can rely on one stable fingerprint field across logging, replay, staging, and hydration.

This is intended to support downstream provenance consumers like PILATES, which currently need local helper logic to probe multiple possible hash/fingerprint surfaces.

## What Changed

- Documented `Artifact.hash` as the canonical portable artifact fingerprint in the artifact model docs.
- Clarified that `Artifact.content_id` is a DB-local dedupe identity, not the public fingerprint surface.
- Updated `log_artifact`, `log_input`, and `log_output` docstrings to describe `content_hash=` as populating the canonical public fingerprint field, `artifact.hash`.
- Updated hydration/staging docs to explicitly state that detached artifacts preserve `artifact.hash`.
- Tightened user-facing docs to use “artifact fingerprint” where appropriate, especially where `fast` hashing means the value may be metadata-based rather than a strict byte-content digest.
- Added lifecycle-focused tests asserting that `artifact.hash` is preserved through:
  - logging/replay
  - input staging
  - historical output hydration
  - directory-backed staging
  - unhashed artifact round-trips

## Why

Downstream code should not need to guess among `hash`, `content_hash`, or wrapper-specific fields when it needs an artifact fingerprint after logging or hydration.

This PR makes the v1 contract explicit:

- `artifact.hash` is the canonical public fingerprint field
- `artifact.content_id` is internal/DB-local
- fingerprint semantics follow the active hashing strategy

That gives downstreams a stable surface now without waiting for a broader artifact identity redesign.

## Non-Goals

- No hashing behavior changes
- No schema or migration changes
- No new `artifact.fingerprint` alias or helper API
- No backfill for historical artifacts missing `hash`


## Downstream Payoff

This should let PILATES simplify its provenance bookkeeping by treating `artifact.hash` as the one authoritative artifact fingerprint surface, including for ActivitySim-related logging and hydration flows.