### PR TITLE
Better h5 child-artifact support

### DIFF
--- a/docs/api/artifact.md
+++ b/docs/api/artifact.md
@@ -3,12 +3,26 @@
 `Artifact` represents a tracked input or output file with stable provenance
 metadata (`run_id`, `hash`, `container_uri`, driver, and custom metadata).
 
+Container-backed child artifacts, such as HDF5 tables discovered from a parent
+file, are still ordinary `Artifact` rows. Consist records their canonical
+parent-child relation on `artifact.parent_artifact_id`. Legacy metadata-based
+links in `artifact.meta["parent_id"]` remain for compatibility and debugging,
+but new code should treat `parent_artifact_id` as the source of truth.
+
 ## When to use `Artifact` directly
 
 - You want to pass outputs from one step to another (`inputs={...}` mappings).
 - You need a portable path via `artifact.path` rather than hard-coded file paths.
 - You need metadata checks (`artifact.get_meta(...)`, `artifact.is_tabular`,
   `artifact.is_matrix`) before loading.
+- You need to inspect or traverse container child-artifact relations after
+  logging, hydration, or query retrieval.
+
+## Container child artifacts
+
+Use `Tracker.get_child_artifacts(...)` and `Tracker.get_parent_artifact(...)`
+to navigate first-class parent-child artifact relations. This is the supported
+query surface for HDF5 container artifacts and other container-child patterns.
 
 ## Minimal runnable example
 
@@ -35,6 +49,8 @@ print(artifact.path.read_text().strip())
 
 See [API Helpers](api_helpers.md) for helper functions that return and consume
 artifacts (`consist.run`, `consist.ref`, `consist.refs`, `consist.load*`).
+For query helpers that traverse child artifacts, see
+[Tracker](tracker.md#tracker).
 
 ::: consist.models.artifact.Artifact
     options:

--- a/docs/api/public_api.md
+++ b/docs/api/public_api.md
@@ -115,6 +115,7 @@ with tracker.scenario("baseline") as sc:
 - [`consist.AlignedPair`](runset.md#consist.runset.AlignedPair)
 - `consist.CacheOptions`, `consist.OutputPolicyOptions`, `consist.ExecutionOptions`
 - `consist.BindingResult` (execution envelope for orchestrator-resolved scenario inputs)
+- `consist.H5ChildSpec` (typed child-artifact customization for HDF5 containers)
 
 ### Scenario / workflow helpers
 
@@ -182,6 +183,7 @@ Scenario defaults like `name_template` and `cache_epoch` are configured via `con
 - [`RunSet`](runset.md#consist.runset.RunSet) and [`AlignedPair`](runset.md#consist.runset.AlignedPair)
 - [`Tracker.find_latest_run(...)`](tracker.md#consist.core.tracker.Tracker.find_latest_run)
 - [`Tracker.diff_runs(...)`](tracker.md#consist.core.tracker.Tracker.diff_runs)
+- [`Tracker.get_child_artifacts(...)`](tracker.md#consist.core.tracker.Tracker.get_child_artifacts) / [`Tracker.get_parent_artifact(...)`](tracker.md#consist.core.tracker.Tracker.get_parent_artifact)
 - [`Tracker.get_run_inputs(...)`](tracker.md#consist.core.tracker.Tracker.get_run_inputs) / [`Tracker.get_run_outputs(...)`](tracker.md#consist.core.tracker.Tracker.get_run_outputs)
 - [`Tracker.get_run_config(...)`](tracker.md#consist.core.tracker.Tracker.get_run_config)
 - [`Tracker.print_lineage(...)`](tracker.md#consist.core.tracker.Tracker.print_lineage)
@@ -218,7 +220,7 @@ as needed.
 #### Querying and history
 
 - `find_runs`, `run_set`, `find_run`, `find_latest_run`, `get_latest_run_id`
-- `find_artifacts`, `get_artifact`, `get_artifacts_for_run`
+- `find_artifacts`, `get_artifact`, `get_child_artifacts`, `get_parent_artifact`, `get_artifacts_for_run`
 - `find_artifacts_by_params`, `get_artifact_kv`, `register_artifact_facet_parser`
 - `get_run`, `get_run_config`, `get_run_inputs`, `get_run_outputs`
 - `hydrate_run_outputs`, `materialize_run_outputs`
@@ -240,6 +242,13 @@ as needed.
 #### Format-specific logging
 
 - `log_h5_container`, `log_h5_table`, `log_netcdf_file`, `log_openmatrix_file`
+
+`log_h5_container(...)` now supports `child_specs={...}` and
+`child_selection="all" | "include_only"` so callers can either customize
+discovered child artifacts or log only a selected subset of HDF5 dataset paths.
+`log_h5_table(...)` accepts the same child-level semantic metadata surface as
+normal artifact logging: `description`, `facet`, `facet_schema_version`, and
+`facet_index`.
 
 ### Advanced (power-user / lower-level)
 

--- a/docs/api/tracker.md
+++ b/docs/api/tracker.md
@@ -16,6 +16,13 @@ Run lookup helpers expose workflow-aware filters such as `stage=` and
 `phase=`. Use those when you need to query by lifecycle step or pipeline stage
 instead of treating those values as opaque metadata.
 
+Tracker also exposes first-class container child-artifact queries.
+`get_child_artifacts(...)` returns children ordered by creation time ascending,
+and `get_parent_artifact(...)` resolves the canonical parent relation for a
+child artifact. These helpers prefer `Artifact.parent_artifact_id` and fall
+back to legacy `artifact.meta["parent_id"]` rows when older databases are
+opened.
+
 ## Minimal runnable example
 
 ```python
@@ -46,6 +53,25 @@ into `run.meta` for backward compatibility, but the canonical fields live on
 
 For top-level wrappers around these methods, see [API Helpers](api_helpers.md).
 For grouped workflows, see [Workflow Contexts](workflow.md).
+
+## Container child artifacts and HDF5 helpers
+
+Use `log_h5_container(...)` when you want to log an HDF5 file as one container
+artifact plus optional child `h5_table` artifacts. The HDF5 logging surface now
+supports:
+
+- `child_specs={...}` keyed by HDF5 dataset path for per-child semantic
+  customization
+- `child_selection="all" | "include_only"` to either customize discovered
+  children or restrict logging to the paths named in `child_specs`
+- child-spec fields that mirror normal artifact ergonomics: `key`,
+  `description`, `facet`, `facet_schema_version`, `facet_index`, and extra
+  metadata
+
+Use `log_h5_table(...)` when you want to register a single child artifact
+without scanning the whole container. It accepts the same semantic metadata
+surface (`description`, `facet`, `facet_schema_version`, `facet_index`) and can
+link the child to a parent container artifact.
 
 ## Constructing with `TrackerConfig`
 
@@ -150,6 +176,8 @@ and `digest`.
         - get_latest_run_id
         - find_artifacts
         - get_artifact
+        - get_child_artifacts
+        - get_parent_artifact
         - get_artifacts_for_run
         - get_run
         - get_run_config

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,6 +171,8 @@ DuckDB connection open until you close them.
 - `Artifact.uri` → `Artifact.container_uri`
 - `Artifact.table_path` added (nullable) for container formats (HDF5 tables)
 - `Artifact.array_path` added (nullable) for array formats
+- `Artifact.parent_artifact_id` added (nullable) as the canonical container
+  child-artifact relation
 - `meta["table_path"]` is no longer used
 
 **Solution:**
@@ -182,16 +184,27 @@ rm ./provenance.duckdb
 rm ./test_db.duckdb
 ```
 
-Then update any code that referenced `artifact.uri` or `artifact.meta["table_path"]`:
+Then update any code that referenced `artifact.uri`,
+`artifact.meta["table_path"]`, or relied on metadata-only parent-child links:
 
 ```python
 # Before
 artifact.uri
 artifact.meta.get("table_path")
+artifact.meta.get("parent_id")  # legacy compatibility mirror only
 
 # After
 artifact.container_uri
 artifact.table_path
+artifact.parent_artifact_id
+```
+
+If you need to traverse container child artifacts, prefer the first-class query
+helpers:
+
+```python
+children = tracker.get_child_artifacts(container_artifact)
+parent = tracker.get_parent_artifact(child_artifact)
 ```
 
 ---

--- a/src/consist/__init__.py
+++ b/src/consist/__init__.py
@@ -92,6 +92,7 @@ from consist.types import (
     CacheOptions,
     DriverType,
     ExecutionOptions,
+    H5ChildSpec,
     OutputPolicyOptions,
 )
 from consist.core.noop import (
@@ -132,6 +133,7 @@ __all__ = [
     "CacheOptions",
     "OutputPolicyOptions",
     "ExecutionOptions",
+    "H5ChildSpec",
     "NoopArtifact",
     "NoopCoupler",
     "NoopRunResult",

--- a/src/consist/core/artifacts.py
+++ b/src/consist/core/artifacts.py
@@ -1,14 +1,22 @@
 import hashlib
 import logging
+import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Any, Type, TYPE_CHECKING, Callable, Union, Literal
+from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Type, Union
 
 from sqlmodel import SQLModel
-from consist.models.artifact import Artifact
+
 from consist.core.drivers import ARRAY_DRIVERS, TABLE_DRIVERS
 from consist.core.validation import validate_artifact_key
-from consist.types import ArtifactRef
+from consist.models.artifact import Artifact
+from consist.types import (
+    ArtifactRef,
+    H5ChildSelectionMode,
+    H5ChildSpec,
+    FacetLike,
+)
 
 if TYPE_CHECKING:
     from consist.core.tracker import Tracker
@@ -115,6 +123,27 @@ def _hash_h5_dataset(
     return hasher.hexdigest()
 
 
+def _normalize_h5_child_path(path: str) -> str:
+    stripped = path.strip()
+    if not stripped:
+        return "/"
+    return f"/{stripped.lstrip('/')}"
+
+
+def _resolve_h5_child_spec(
+    child_specs: Optional[Mapping[str, H5ChildSpec]],
+    table_path: str,
+) -> Optional[H5ChildSpec]:
+    if not child_specs:
+        return None
+    normalized_path = _normalize_h5_child_path(table_path)
+    return (
+        child_specs.get(normalized_path)
+        or child_specs.get(normalized_path.lstrip("/"))
+        or child_specs.get(table_path)
+    )
+
+
 class ArtifactManager:
     """
     Manage the lifecycle, virtualization, and identity hashing of Consist Artifacts.
@@ -143,6 +172,7 @@ class ArtifactManager:
         validate_content_hash: bool = False,
         reuse_if_unchanged: bool = False,
         reuse_scope: Literal["same_uri", "any_uri"] = "same_uri",
+        parent_artifact_id: Optional[uuid.UUID] = None,
         **meta: Any,
     ) -> Artifact:
         """
@@ -191,6 +221,8 @@ class ArtifactManager:
             if the content hash is identical.
         reuse_scope : {"same_uri", "any_uri"}, default "same_uri"
             The breadth of the search for reusable artifacts.
+        parent_artifact_id : Optional[uuid.UUID], default None
+            Canonical parent artifact relation for container child artifacts.
         **meta : Any
             Flexible metadata payload stored within the artifact record.
 
@@ -236,6 +268,7 @@ class ArtifactManager:
             driver_override: Optional[str],
             table_path_override: Optional[str],
             array_path_override: Optional[str],
+            parent_artifact_id_override: Optional[uuid.UUID],
         ) -> Artifact:
             cloned = Artifact(
                 id=artifact.id,
@@ -254,6 +287,11 @@ class ArtifactManager:
                 driver=driver_override or artifact.driver,
                 hash=artifact.hash,
                 content_id=artifact.content_id,
+                parent_artifact_id=(
+                    parent_artifact_id_override
+                    if parent_artifact_id_override is not None
+                    else artifact.parent_artifact_id
+                ),
                 run_id=artifact.run_id,
                 meta=dict(artifact.meta or {}),
                 created_at=artifact.created_at,
@@ -364,6 +402,7 @@ class ArtifactManager:
                 driver_override=driver,
                 table_path_override=table_path,
                 array_path_override=array_path,
+                parent_artifact_id_override=parent_artifact_id,
             )
             _apply_content_hash_override(artifact_obj)
             if meta:
@@ -413,6 +452,7 @@ class ArtifactManager:
                             driver_override=driver,
                             table_path_override=table_path,
                             array_path_override=array_path,
+                            parent_artifact_id_override=parent_artifact_id,
                         )
                         _apply_content_hash_override(artifact_obj)
                         if meta:
@@ -432,6 +472,7 @@ class ArtifactManager:
                     array_path=array_path,
                     hash=hash_state.effective_hash,
                     run_id=run_id,
+                    parent_artifact_id=parent_artifact_id,
                     meta=meta,
                 )
 
@@ -464,7 +505,8 @@ class ArtifactManager:
         *,
         hash_tables: bool,
         table_hash_chunk_rows: Optional[int],
-    ) -> List[Artifact]:
+        child_specs: Optional[Mapping[str, H5ChildSpec]] = None,
+    ) -> List[tuple[Artifact, Any]]:
         """
         Discover and log HDF5 tables contained within an artifact.
 
@@ -487,8 +529,9 @@ class ArtifactManager:
 
         Returns
         -------
-        List[Artifact]
-            One artifact per selected dataset.
+        List[tuple[Artifact, Any]]
+            One tuple per selected dataset containing the child artifact and an
+            optional prepared facet bundle.
         """
         try:
             import h5py
@@ -498,7 +541,7 @@ class ArtifactManager:
             )
             return []
 
-        table_artifacts: List[Artifact] = []
+        table_artifacts: List[tuple[Artifact, Any]] = []
 
         try:
             with h5py.File(str(path_obj), "r") as f:
@@ -506,13 +549,22 @@ class ArtifactManager:
                 def visit_datasets(name: str, obj: Any) -> None:
                     if isinstance(obj, h5py.Dataset):
                         if filter_fn(name):
-                            table_key = f"{key}_{name.replace('/', '_')}"
+                            child_spec = _resolve_h5_child_spec(child_specs, name)
+                            table_key = (
+                                child_spec.key
+                                if child_spec and child_spec.key
+                                else f"{key}_{name.replace('/', '_')}"
+                            )
                             table_hash = None
                             table_meta: dict[str, Any] = {
                                 "parent_id": str(container.id),
                                 "shape": list(obj.shape),
                                 "dtype": str(obj.dtype),
                             }
+                            if child_spec and child_spec.description:
+                                table_meta["description"] = child_spec.description
+                            if child_spec and child_spec.metadata:
+                                table_meta.update(dict(child_spec.metadata))
                             if hash_tables:
                                 try:
                                     table_hash = _hash_h5_dataset(
@@ -539,9 +591,22 @@ class ArtifactManager:
                                 driver="h5_table",
                                 table_path=name,
                                 content_hash=table_hash,
+                                parent_artifact_id=container.id,
                                 **table_meta,
                             )
-                            table_artifacts.append(table_art)
+                            prepared_bundle = self.tracker._artifact_logging.prepare_artifact_facet_bundle(
+                                artifact=table_art,
+                                facet=child_spec.facet if child_spec else None,
+                                facet_schema_version=(
+                                    child_spec.facet_schema_version
+                                    if child_spec
+                                    else None
+                                ),
+                                facet_index=(
+                                    child_spec.facet_index if child_spec else False
+                                ),
+                            )
+                            table_artifacts.append((table_art, prepared_bundle))
 
                 f.visititems(visit_datasets)
         except Exception as e:
@@ -559,6 +624,8 @@ class ArtifactManager:
         table_filter: Optional[Union[Callable[[str], bool], List[str]]] = None,
         hash_tables: Literal["always", "if_unchanged", "never"] = "if_unchanged",
         table_hash_chunk_rows: Optional[int] = None,
+        child_specs: Optional[Mapping[str, H5ChildSpec]] = None,
+        child_selection: H5ChildSelectionMode = "all",
         **meta: Any,
     ) -> tuple[Artifact, List[Artifact]]:
         """
@@ -588,6 +655,12 @@ class ArtifactManager:
             legacy hash-based behavior is used as a fallback.
         table_hash_chunk_rows : Optional[int], optional
             Rows per chunk when hashing tables (defaults to dataset chunking or 1024).
+        child_specs : Optional[Mapping[str, H5ChildSpec]], optional
+            Optional per-dataset semantic customization keyed by HDF5 dataset path.
+            Keys may be written with or without a leading ``/``.
+        child_selection : {"all", "include_only"}, default "all"
+            Whether discovered tables are all eligible for logging or restricted
+            to the dataset paths listed in ``child_specs``.
         **meta : Any
             Additional metadata for the container artifact.
 
@@ -603,10 +676,20 @@ class ArtifactManager:
         """
         if not self.tracker.current_consist:
             raise RuntimeError("Cannot log artifact outside of a run context.")
+        if child_selection not in {"all", "include_only"}:
+            raise ValueError("child_selection must be 'all' or 'include_only'.")
 
         path_obj = Path(path)
         if key is None:
             key = path_obj.stem
+        normalized_child_specs = (
+            {
+                _normalize_h5_child_path(path_key): spec
+                for path_key, spec in child_specs.items()
+            }
+            if child_specs
+            else None
+        )
         prior_container = None
         if self.tracker.db:
             try:
@@ -670,22 +753,34 @@ class ArtifactManager:
                     container.meta["table_hashes_skip_reason"] = skip_reason
 
             if discover_tables:
+                include_only_paths = (
+                    set(normalized_child_specs.keys())
+                    if child_selection == "include_only" and normalized_child_specs
+                    else None
+                )
                 if table_filter is None:
 
-                    def filter_fn(name: str) -> bool:
+                    def base_filter_fn(name: str) -> bool:
                         return True
 
                 elif isinstance(table_filter, list):
                     filter_set = set(table_filter)
 
-                    def filter_fn(name: str) -> bool:
+                    def base_filter_fn(name: str) -> bool:
                         stripped = name.lstrip("/")
                         return name in filter_set or stripped in filter_set
 
                 else:
-                    filter_fn = table_filter
+                    base_filter_fn = table_filter
 
-                table_artifacts = self.scan_h5_container(
+                def filter_fn(name: str) -> bool:
+                    if not base_filter_fn(name):
+                        return False
+                    if include_only_paths is None:
+                        return True
+                    return _normalize_h5_child_path(name) in include_only_paths
+
+                scanned_children = self.scan_h5_container(
                     container,
                     path_obj,
                     key,
@@ -693,16 +788,32 @@ class ArtifactManager:
                     filter_fn,
                     hash_tables=should_hash_tables,
                     table_hash_chunk_rows=table_hash_chunk_rows,
+                    child_specs=normalized_child_specs,
                 )
 
-                target = (
-                    self.tracker.current_consist.inputs
-                    if direction == "input"
-                    else self.tracker.current_consist.outputs
-                )
-                for table_artifact in table_artifacts:
-                    target.append(table_artifact)
-                    self.tracker.persistence.sync_artifact(table_artifact, direction)
+                for table_artifact, prepared_bundle in scanned_children:
+                    self.tracker._artifact_logging.apply_inherited_run_metadata(
+                        table_artifact
+                    )
+                    self.tracker._artifact_logging.attach_logged_artifact(
+                        artifact=table_artifact,
+                        direction=direction,
+                        register_with_coupler=False,
+                    )
+                    if prepared_bundle is not None:
+                        self.tracker.persistence.sync_artifact_with_facet_bundle(
+                            table_artifact,
+                            direction,
+                            facet=prepared_bundle.facet,
+                            meta_updates=prepared_bundle.meta_updates,
+                            kv_rows=prepared_bundle.kv_rows,
+                        )
+                    else:
+                        self.tracker.persistence.sync_artifact(
+                            table_artifact,
+                            direction,
+                        )
+                    table_artifacts.append(table_artifact)
 
             container.meta["table_count"] = len(table_artifacts)
             container.meta["table_ids"] = [str(t.id) for t in table_artifacts]
@@ -724,6 +835,10 @@ class ArtifactManager:
         table_hash_chunk_rows: Optional[int] = None,
         profile_file_schema: bool | Literal["if_changed"] = False,
         file_schema_sample_rows: Optional[int] = None,
+        description: Optional[str] = None,
+        facet: Optional[FacetLike] = None,
+        facet_schema_version: Optional[Union[str, int]] = None,
+        facet_index: bool = False,
         **meta: Any,
     ) -> Artifact:
         """
@@ -751,6 +866,14 @@ class ArtifactManager:
             has a stored schema (prefers content_id; falls back to hash for legacy rows).
         file_schema_sample_rows : Optional[int], optional
             Maximum rows to sample when profiling the schema.
+        description : Optional[str], optional
+            Optional description stored in the child artifact metadata.
+        facet : Optional[Any], optional
+            Optional artifact facet payload for the child artifact.
+        facet_schema_version : Optional[Union[str, int]], optional
+            Optional artifact facet schema version.
+        facet_index : bool, default False
+            Whether to index scalar child artifact facet fields for querying.
         **meta : Any
             Additional metadata for the table artifact.
 
@@ -789,23 +912,87 @@ class ArtifactManager:
         table_meta: dict[str, Any] = {}
         if parent is not None:
             table_meta["parent_id"] = str(parent.id)
+            parent_artifact_id = parent.id
+        else:
+            parent_artifact_id = None
         if table_hash:
             table_meta["table_hash"] = table_hash
             table_meta["table_hash_algo"] = "sha256"
             if table_hash_chunk_rows is not None:
                 table_meta["table_hash_chunk_rows"] = table_hash_chunk_rows
+        if description is not None:
+            table_meta["description"] = description
 
         if meta:
             table_meta.update(meta)
 
-        return self.tracker.log_artifact(
+        artifact = self.create_artifact(
             str(path_obj),
+            run_id=(
+                self.tracker.current_consist.run.id if direction == "output" else None
+            ),
             key=key,
             direction=direction,
             driver="h5_table",
             table_path=table_path,
             content_hash=table_hash,
-            profile_file_schema=profile_file_schema,
-            file_schema_sample_rows=file_schema_sample_rows,
+            parent_artifact_id=parent_artifact_id,
             **table_meta,
         )
+        prepared_bundle = self.tracker._artifact_logging.prepare_artifact_facet_bundle(
+            artifact=artifact,
+            facet=facet,
+            facet_schema_version=facet_schema_version,
+            facet_index=facet_index,
+        )
+        self.tracker._artifact_logging.apply_inherited_run_metadata(artifact)
+        self.tracker._artifact_logging.attach_logged_artifact(
+            artifact=artifact,
+            direction=direction,
+            register_with_coupler=False,
+        )
+
+        self.tracker._flush_json()
+        if prepared_bundle is not None:
+            self.tracker.persistence.sync_artifact_with_facet_bundle(
+                artifact,
+                direction,
+                facet=prepared_bundle.facet,
+                meta_updates=prepared_bundle.meta_updates,
+                kv_rows=prepared_bundle.kv_rows,
+            )
+        else:
+            self.tracker.persistence.sync_artifact(artifact, direction)
+
+        if (
+            profile_file_schema
+            and artifact.is_tabular
+            and self.tracker.current_consist is not None
+        ):
+            try:
+                if isinstance(artifact.meta, dict) and artifact.meta.get("schema_id"):
+                    return artifact
+                resolved_path = artifact.abs_path or self.tracker.resolve_uri(
+                    artifact.container_uri
+                )
+                if resolved_path:
+                    self.tracker.artifact_schemas.profile_file_artifact(
+                        artifact=artifact,
+                        run=self.tracker.current_consist.run,
+                        resolved_path=str(resolved_path),
+                        driver="h5_table",
+                        sample_rows=(
+                            self.tracker.settings.schema_sample_rows
+                            if file_schema_sample_rows is None
+                            else file_schema_sample_rows
+                        ),
+                        source="file",
+                        reuse_if_unchanged=profile_file_schema == "if_changed",
+                    )
+            except FileNotFoundError:
+                logging.warning(
+                    "[Consist] File schema capture skipped; file not found: %s",
+                    artifact.container_uri,
+                )
+
+        return artifact

--- a/src/consist/core/artifacts.py
+++ b/src/consist/core/artifacts.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Type, 
 from sqlmodel import SQLModel
 
 from consist.core.drivers import ARRAY_DRIVERS, TABLE_DRIVERS
+from consist.core.cache_output_logging import _demote_cache_hit
 from consist.core.validation import validate_artifact_key
 from consist.models.artifact import Artifact
 from consist.types import (
@@ -142,6 +143,33 @@ def _resolve_h5_child_spec(
         or child_specs.get(normalized_path.lstrip("/"))
         or child_specs.get(table_path)
     )
+
+
+def _list_h5_dataset_names(
+    path_obj: Path,
+    *,
+    filter_fn: Callable[[str], bool],
+) -> list[str]:
+    try:
+        import h5py
+    except ImportError:
+        logging.warning("[Consist] h5py not installed. Cannot inspect HDF5 tables.")
+        return []
+
+    dataset_names: list[str] = []
+    try:
+        with h5py.File(str(path_obj), "r") as handle:
+
+            def visit_datasets(name: str, obj: Any) -> None:
+                if isinstance(obj, h5py.Dataset) and filter_fn(name):
+                    dataset_names.append(_normalize_h5_child_path(name))
+
+            handle.visititems(visit_datasets)
+    except Exception as exc:
+        logging.warning("[Consist] Failed to inspect HDF5 tables: %s", exc)
+        return []
+
+    return dataset_names
 
 
 class ArtifactManager:
@@ -687,7 +715,7 @@ class ArtifactManager:
                 _normalize_h5_child_path(path_key): spec
                 for path_key, spec in child_specs.items()
             }
-            if child_specs
+            if child_specs is not None
             else None
         )
         prior_container = None
@@ -714,6 +742,7 @@ class ArtifactManager:
             )
 
             table_artifacts: List[Artifact] = []
+            reusing_cached_children = False
             should_hash_tables = False
             skip_reason: Optional[str] = None
             if hash_tables not in {"always", "if_unchanged", "never"}:
@@ -754,8 +783,12 @@ class ArtifactManager:
 
             if discover_tables:
                 include_only_paths = (
-                    set(normalized_child_specs.keys())
-                    if child_selection == "include_only" and normalized_child_specs
+                    (
+                        set(normalized_child_specs.keys())
+                        if normalized_child_specs is not None
+                        else set()
+                    )
+                    if child_selection == "include_only"
                     else None
                 )
                 if table_filter is None:
@@ -780,40 +813,87 @@ class ArtifactManager:
                         return True
                     return _normalize_h5_child_path(name) in include_only_paths
 
-                scanned_children = self.scan_h5_container(
-                    container,
-                    path_obj,
-                    key,
-                    direction,
-                    filter_fn,
-                    hash_tables=should_hash_tables,
-                    table_hash_chunk_rows=table_hash_chunk_rows,
-                    child_specs=normalized_child_specs,
-                )
-
-                for table_artifact, prepared_bundle in scanned_children:
-                    self.tracker._artifact_logging.apply_inherited_run_metadata(
-                        table_artifact
-                    )
-                    self.tracker._artifact_logging.attach_logged_artifact(
-                        artifact=table_artifact,
-                        direction=direction,
-                        register_with_coupler=False,
-                    )
-                    if prepared_bundle is not None:
-                        self.tracker.persistence.sync_artifact_with_facet_bundle(
-                            table_artifact,
-                            direction,
-                            facet=prepared_bundle.facet,
-                            meta_updates=prepared_bundle.meta_updates,
-                            kv_rows=prepared_bundle.kv_rows,
+                if direction == "output" and self.tracker.is_cached:
+                    cached_children = [
+                        artifact
+                        for artifact in self.tracker.current_consist.outputs
+                        if artifact.id != container.id
+                        and (
+                            artifact.parent_artifact_id == container.id
+                            or (
+                                isinstance(artifact.meta, dict)
+                                and artifact.meta.get("parent_id") == str(container.id)
+                            )
                         )
+                        and artifact.table_path is not None
+                        and filter_fn(artifact.table_path)
+                    ]
+                    cached_child_paths = {
+                        _normalize_h5_child_path(artifact.table_path)
+                        for artifact in cached_children
+                        if artifact.table_path is not None
+                    }
+                    requested_child_paths = set(
+                        _list_h5_dataset_names(path_obj, filter_fn=filter_fn)
+                    )
+                    if cached_child_paths == requested_child_paths:
+                        table_artifacts = list(cached_children)
+                        reusing_cached_children = True
                     else:
-                        self.tracker.persistence.sync_artifact(
-                            table_artifact,
-                            direction,
+                        _demote_cache_hit(
+                            self.tracker.current_consist,
+                            reason=(
+                                "caller requested HDF5 child artifacts that do not "
+                                "match the cached output set"
+                            ),
                         )
-                    table_artifacts.append(table_artifact)
+                        container = self.tracker.log_artifact(
+                            str(path_obj),
+                            key=key,
+                            direction=direction,
+                            driver="h5",
+                            is_container=True,
+                            **meta,
+                        )
+
+                if not table_artifacts:
+                    scanned_children = self.scan_h5_container(
+                        container,
+                        path_obj,
+                        key,
+                        direction,
+                        filter_fn,
+                        hash_tables=should_hash_tables,
+                        table_hash_chunk_rows=table_hash_chunk_rows,
+                        child_specs=normalized_child_specs,
+                    )
+
+                    for table_artifact, prepared_bundle in scanned_children:
+                        self.tracker._artifact_logging.apply_inherited_run_metadata(
+                            table_artifact
+                        )
+                        self.tracker._artifact_logging.attach_logged_artifact(
+                            artifact=table_artifact,
+                            direction=direction,
+                            register_with_coupler=False,
+                        )
+                        if prepared_bundle is not None:
+                            self.tracker.persistence.sync_artifact_with_facet_bundle(
+                                table_artifact,
+                                direction,
+                                facet=prepared_bundle.facet,
+                                meta_updates=prepared_bundle.meta_updates,
+                                kv_rows=prepared_bundle.kv_rows,
+                            )
+                        else:
+                            self.tracker.persistence.sync_artifact(
+                                table_artifact,
+                                direction,
+                            )
+                        table_artifacts.append(table_artifact)
+
+                if reusing_cached_children:
+                    return container, table_artifacts
 
             container.meta["table_count"] = len(table_artifacts)
             container.meta["table_ids"] = [str(t.id) for t in table_artifacts]
@@ -949,7 +1029,7 @@ class ArtifactManager:
         self.tracker._artifact_logging.attach_logged_artifact(
             artifact=artifact,
             direction=direction,
-            register_with_coupler=False,
+            register_with_coupler=direction == "output",
         )
 
         self.tracker._flush_json()

--- a/src/consist/core/maintenance.py
+++ b/src/consist/core/maintenance.py
@@ -2283,6 +2283,7 @@ class DatabaseMaintenance:
                         array_path=artifact.array_path,
                         driver=artifact.driver,
                         hash=artifact.hash,
+                        parent_artifact_id=artifact.parent_artifact_id,
                         run_id=artifact.run_id,
                         meta=dict(artifact.meta)
                         if isinstance(artifact.meta, dict)

--- a/src/consist/core/persistence.py
+++ b/src/consist/core/persistence.py
@@ -35,6 +35,7 @@ from consist.core.db_runtime import DatabaseRuntimeOps
 from consist.core.db_snapshot import DatabaseSnapshotOps
 from consist.core.provenance_writer import ProvenanceWriter
 from consist.core.schema_compat import (
+    apply_artifact_parent_compatibility,
     apply_content_identity_compatibility,
     apply_run_stage_phase_compatibility,
     backfill_artifact_content_ids as compat_backfill_artifact_content_ids,
@@ -384,6 +385,7 @@ class DatabaseManager:
             # Lightweight compatibility hooks for older DBs. Keep these isolated so
             # they can be removed without changing steady-state persistence behavior.
             apply_content_identity_compatibility(self)
+            apply_artifact_parent_compatibility(self)
             apply_run_stage_phase_compatibility(self)
             self._ensure_artifact_schema_field_ordinal_position()
             self._ensure_schema_links_view()
@@ -2210,6 +2212,92 @@ class DatabaseManager:
 
         try:
             return self.execute_with_retry(_query)
+        except Exception:
+            return None
+
+    def get_child_artifacts(self, parent_id: uuid.UUID) -> List[Artifact]:
+        """
+        Return child artifacts for a parent, ordered by creation time ascending.
+
+        Prefers the canonical ``artifact.parent_artifact_id`` column and falls
+        back to legacy ``artifact.meta["parent_id"]`` values for older rows.
+        """
+
+        def _query() -> List[Artifact]:
+            with self.session_scope() as session:
+                statement = (
+                    select(Artifact)
+                    .where(Artifact.parent_artifact_id == parent_id)
+                    .order_by(
+                        col(Artifact.created_at), col(Artifact.key), col(Artifact.id)
+                    )
+                )
+                results = list(session.exec(statement).all())
+
+                legacy_results = []
+                for artifact in session.exec(select(Artifact)).all():
+                    if artifact.parent_artifact_id is not None:
+                        continue
+                    meta = artifact.meta if isinstance(artifact.meta, dict) else {}
+                    if meta.get("parent_id") == str(parent_id):
+                        legacy_results.append(artifact)
+
+                combined = {artifact.id: artifact for artifact in results}
+                for artifact in legacy_results:
+                    combined.setdefault(artifact.id, artifact)
+
+                ordered = sorted(
+                    combined.values(),
+                    key=lambda artifact: (
+                        artifact.created_at,
+                        artifact.key,
+                        artifact.id,
+                    ),
+                )
+                for artifact in ordered:
+                    _ = artifact.meta
+                    session.expunge(artifact)
+                return ordered
+
+        try:
+            return self.execute_with_retry(_query, operation_name="get_child_artifacts")
+        except Exception:
+            return []
+
+    def get_parent_artifact(self, child_id: uuid.UUID) -> Optional[Artifact]:
+        """
+        Return the parent artifact for a child artifact when one is recorded.
+
+        Prefers the canonical ``artifact.parent_artifact_id`` column and falls
+        back to legacy ``artifact.meta["parent_id"]`` values for older rows.
+        """
+
+        def _query() -> Optional[Artifact]:
+            with self.session_scope() as session:
+                child = session.get(Artifact, child_id)
+                if child is None:
+                    return None
+
+                parent_id = child.parent_artifact_id
+                if parent_id is None:
+                    meta = child.meta if isinstance(child.meta, dict) else {}
+                    raw_parent_id = meta.get("parent_id")
+                    if isinstance(raw_parent_id, str):
+                        try:
+                            parent_id = uuid.UUID(raw_parent_id)
+                        except ValueError:
+                            parent_id = None
+                if parent_id is None:
+                    return None
+
+                parent = session.get(Artifact, parent_id)
+                if parent is not None:
+                    _ = parent.meta
+                    session.expunge(parent)
+                return parent
+
+        try:
+            return self.execute_with_retry(_query, operation_name="get_parent_artifact")
         except Exception:
             return None
 

--- a/src/consist/core/schema_compat.py
+++ b/src/consist/core/schema_compat.py
@@ -24,6 +24,17 @@ def apply_content_identity_compatibility(db: DatabaseManager) -> None:
     _ensure_artifact_content_id_index(db)
 
 
+def apply_artifact_parent_compatibility(db: DatabaseManager) -> None:
+    """
+    Apply additive schema compatibility for artifact parent-child relations.
+
+    This adds the canonical ``artifact.parent_artifact_id`` column and index for
+    older databases without requiring row backfills.
+    """
+    _ensure_artifact_parent_artifact_id_column(db)
+    _ensure_artifact_parent_artifact_id_index(db)
+
+
 def apply_run_stage_phase_compatibility(db: DatabaseManager) -> None:
     """
     Apply additive schema compatibility for run stage/phase support.
@@ -157,6 +168,39 @@ def _ensure_artifact_content_id_index(db: DatabaseManager) -> None:
             )
     except Exception as exc:
         logging.warning("Failed to create artifact.content_id index: %s", exc)
+
+
+def _ensure_artifact_parent_artifact_id_column(db: DatabaseManager) -> None:
+    """Ensure ``artifact.parent_artifact_id`` exists for container child relations."""
+    if db._table_has_column(table_name="artifact", column_name="parent_artifact_id"):
+        return
+    try:
+        with db.engine.begin() as conn:
+            conn.exec_driver_sql(
+                "ALTER TABLE artifact ADD COLUMN parent_artifact_id CHAR(36)"
+            )
+    except Exception as exc:
+        logging.warning("Failed to add artifact.parent_artifact_id column: %s", exc)
+
+
+def _ensure_artifact_parent_artifact_id_index(db: DatabaseManager) -> None:
+    """Ensure upgraded databases also index ``artifact.parent_artifact_id``."""
+    if not db._table_has_column(
+        table_name="artifact", column_name="parent_artifact_id"
+    ):
+        return
+    if db._table_has_index_on_column(
+        table_name="artifact", column_name="parent_artifact_id"
+    ):
+        return
+    try:
+        with db.engine.begin() as conn:
+            conn.exec_driver_sql(
+                "CREATE INDEX idx_artifact_parent_artifact_id "
+                "ON artifact(parent_artifact_id)"
+            )
+    except Exception as exc:
+        logging.warning("Failed to create artifact.parent_artifact_id index: %s", exc)
 
 
 def _ensure_run_stage_phase_columns(db: DatabaseManager) -> None:

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -104,6 +104,8 @@ from consist.types import (
     CodeIdentityMode,
     ExecutionOptions,
     FacetLike,
+    H5ChildSelectionMode,
+    H5ChildSpec,
     HashInputs,
     IdentityInputs,
     OutputPolicyOptions,
@@ -2787,6 +2789,8 @@ class Tracker:
         table_filter: Optional[Union[Callable[[str], bool], List[str]]] = None,
         hash_tables: Literal["always", "if_unchanged", "never"] = "if_unchanged",
         table_hash_chunk_rows: Optional[int] = None,
+        child_specs: Optional[Mapping[str, H5ChildSpec]] = None,
+        child_selection: H5ChildSelectionMode = "all",
         **meta: Any,
     ) -> Tuple[Artifact, List[Artifact]]:
         """
@@ -2817,6 +2821,12 @@ class Tracker:
             skips hashing when a table appears unchanged based on lightweight checks.
         table_hash_chunk_rows : Optional[int], optional
             Row chunk size to use when hashing large tables.
+        child_specs : Optional[Mapping[str, H5ChildSpec]], optional
+            Optional per-dataset semantic customization keyed by HDF5 dataset path.
+            Keys may be written with or without a leading ``/``.
+        child_selection : {"all", "include_only"}, default "all"
+            Whether all discovered datasets are eligible for logging or only the
+            dataset paths named in ``child_specs``.
         **meta : Any
             Additional metadata for the container artifact.
 
@@ -2862,6 +2872,8 @@ class Tracker:
             table_filter=table_filter,
             hash_tables=hash_tables,
             table_hash_chunk_rows=table_hash_chunk_rows,
+            child_specs=child_specs,
+            child_selection=child_selection,
             **meta,
         )
 
@@ -2877,6 +2889,10 @@ class Tracker:
         table_hash_chunk_rows: Optional[int] = None,
         profile_file_schema: bool | Literal["if_changed"] = False,
         file_schema_sample_rows: Optional[int] = None,
+        description: Optional[str] = None,
+        facet: Optional[FacetLike] = None,
+        facet_schema_version: Optional[Union[str, int]] = None,
+        facet_index: bool = False,
         **meta: Any,
     ) -> Artifact:
         """
@@ -2905,6 +2921,14 @@ class Tracker:
             for legacy rows).
         file_schema_sample_rows : Optional[int], optional
             Number of rows to sample when profiling schema.
+        description : Optional[str], optional
+            Optional description stored in the child artifact metadata.
+        facet : Optional[FacetLike], optional
+            Optional artifact-level facet payload for this child artifact.
+        facet_schema_version : Optional[Union[str, int]], optional
+            Optional facet schema version.
+        facet_index : bool, default False
+            Whether to index scalar facet fields for querying.
         **meta : Any
             Additional metadata to store on the artifact.
 
@@ -2923,6 +2947,10 @@ class Tracker:
             table_hash_chunk_rows=table_hash_chunk_rows,
             profile_file_schema=profile_file_schema,
             file_schema_sample_rows=file_schema_sample_rows,
+            description=description,
+            facet=facet,
+            facet_schema_version=facet_schema_version,
+            facet_index=facet_index,
             **meta,
         )
 
@@ -3857,6 +3885,16 @@ class Tracker:
         self, artifact: Union[Artifact, str, uuid.UUID]
     ) -> List[str]:
         return self._artifact_queries.find_runs_producing_same_content(artifact)
+
+    def get_child_artifacts(
+        self, parent: Union[Artifact, str, uuid.UUID]
+    ) -> List[Artifact]:
+        return self._artifact_queries.get_child_artifacts(parent)
+
+    def get_parent_artifact(
+        self, child: Union[Artifact, str, uuid.UUID]
+    ) -> Optional[Artifact]:
+        return self._artifact_queries.get_parent_artifact(child)
 
     def select_artifact_schema_for_artifact(
         self,
@@ -4974,6 +5012,8 @@ _TRACKER_WRAPPER_DOCS = {
     "find_runs_producing_same_content": (
         TrackerArtifactQueryService.find_runs_producing_same_content
     ),
+    "get_child_artifacts": TrackerArtifactQueryService.get_child_artifacts,
+    "get_parent_artifact": TrackerArtifactQueryService.get_parent_artifact,
     "select_artifact_schema_for_artifact": (
         TrackerArtifactQueryService.select_artifact_schema_for_artifact
     ),

--- a/src/consist/core/tracker_artifact_logging.py
+++ b/src/consist/core/tracker_artifact_logging.py
@@ -38,6 +38,87 @@ class ArtifactLoggingCoordinator:
             return f"log_artifact:h5_table:{direction}"
         return f"log_artifact:{direction}"
 
+    def prepare_artifact_facet_bundle(
+        self,
+        *,
+        artifact: Artifact,
+        facet: Optional[FacetLike],
+        facet_schema_version: Optional[Union[str, int]],
+        facet_index: bool,
+    ) -> Any:
+        """Prepare a persistable artifact facet bundle without mutating run state."""
+        tracker = self._tracker
+        resolved_artifact_facet: Optional[Dict[str, Any]] = None
+        artifact_facet_payload: Optional[FacetLike] = facet
+        if artifact_facet_payload is None and artifact.key:
+            artifact_facet_payload = (
+                tracker._parse_artifact_facet_from_registered_parsers(artifact.key)
+            )
+        if artifact_facet_payload is not None:
+            resolved_artifact_facet = tracker.artifact_facets.resolve_facet_dict(
+                artifact_facet_payload
+            )
+        if resolved_artifact_facet is None:
+            return None
+
+        schema_version = facet_schema_version
+        if schema_version is None and isinstance(
+            artifact_facet_payload, HasFacetSchemaVersion
+        ):
+            schema_version = artifact_facet_payload.facet_schema_version
+        return tracker.artifact_facets.prepare_facet_bundle(
+            artifact=artifact,
+            namespace=tracker.current_consist.run.model_name
+            if tracker.current_consist
+            else None,
+            facet_dict=resolved_artifact_facet,
+            schema_name=tracker.artifact_facets.infer_schema_name(
+                artifact_facet_payload
+            ),
+            schema_version=schema_version,
+            index_kv=facet_index,
+        )
+
+    def apply_inherited_run_metadata(self, artifact: Artifact) -> None:
+        """Mirror standard run metadata onto a newly logged artifact."""
+        tracker = self._tracker
+        if tracker.current_consist is None:
+            return
+        run_ctx = tracker.current_consist.run
+        inherited_fields = {
+            "year": run_ctx.year,
+            "iteration": run_ctx.iteration,
+            "tags": run_ctx.tags or [],
+        }
+        if artifact.meta is None:
+            artifact.meta = {}
+        for inherited_key, inherited_value in inherited_fields.items():
+            if inherited_value is not None and inherited_key not in artifact.meta:
+                artifact.meta[inherited_key] = inherited_value
+
+    def attach_logged_artifact(
+        self,
+        *,
+        artifact: Artifact,
+        direction: str,
+        register_with_coupler: bool,
+    ) -> None:
+        """Attach a logged artifact to the active run state and optional coupler."""
+        tracker = self._tracker
+        set_tracker_ref(artifact, tracker)
+        if tracker.current_consist is None:
+            return
+        if direction == "input":
+            tracker.current_consist.inputs.append(artifact)
+            return
+        tracker.current_consist.outputs.append(artifact)
+        if (
+            register_with_coupler
+            and tracker._active_coupler is not None
+            and artifact.key
+        ):
+            tracker._active_coupler.set(artifact.key, artifact)
+
     def log_artifact(
         self,
         path: ArtifactRef,
@@ -147,36 +228,12 @@ class ArtifactLoggingCoordinator:
             reuse_scope=reuse_scope,
             **meta,
         )
-
-        resolved_artifact_facet: Optional[Dict[str, Any]] = None
-        prepared_artifact_facet_bundle = None
-        artifact_facet_payload: Optional[FacetLike] = facet
-        if artifact_facet_payload is None and artifact_obj.key:
-            artifact_facet_payload = (
-                tracker._parse_artifact_facet_from_registered_parsers(artifact_obj.key)
-            )
-        if artifact_facet_payload is not None:
-            resolved_artifact_facet = tracker.artifact_facets.resolve_facet_dict(
-                artifact_facet_payload
-            )
-        if resolved_artifact_facet is not None:
-            schema_version = facet_schema_version
-            if schema_version is None and isinstance(
-                artifact_facet_payload, HasFacetSchemaVersion
-            ):
-                schema_version = artifact_facet_payload.facet_schema_version
-            prepared_artifact_facet_bundle = (
-                tracker.artifact_facets.prepare_facet_bundle(
-                    artifact=artifact_obj,
-                    namespace=tracker.current_consist.run.model_name,
-                    facet_dict=resolved_artifact_facet,
-                    schema_name=tracker.artifact_facets.infer_schema_name(
-                        artifact_facet_payload
-                    ),
-                    schema_version=schema_version,
-                    index_kv=facet_index,
-                )
-            )
+        prepared_artifact_facet_bundle = self.prepare_artifact_facet_bundle(
+            artifact=artifact_obj,
+            facet=facet,
+            facet_schema_version=facet_schema_version,
+            facet_index=facet_index,
+        )
 
         if isinstance(path, Artifact) and direction == "output":
             producing_run_id = artifact_obj.run_id
@@ -190,26 +247,12 @@ class ArtifactLoggingCoordinator:
                     getattr(artifact_obj, "key", None),
                     getattr(artifact_obj, "id", None),
                 )
-
-        run_ctx = tracker.current_consist.run
-        inherited_fields = {
-            "year": run_ctx.year,
-            "iteration": run_ctx.iteration,
-            "tags": run_ctx.tags or [],
-        }
-        if artifact_obj.meta is None:
-            artifact_obj.meta = {}
-        for inherited_key, inherited_value in inherited_fields.items():
-            if inherited_value is not None and inherited_key not in artifact_obj.meta:
-                artifact_obj.meta[inherited_key] = inherited_value
-
-        set_tracker_ref(artifact_obj, tracker)
-        if direction == "input":
-            tracker.current_consist.inputs.append(artifact_obj)
-        else:
-            tracker.current_consist.outputs.append(artifact_obj)
-            if tracker._active_coupler is not None and artifact_obj.key:
-                tracker._active_coupler.set(artifact_obj.key, artifact_obj)
+        self.apply_inherited_run_metadata(artifact_obj)
+        self.attach_logged_artifact(
+            artifact=artifact_obj,
+            direction=direction,
+            register_with_coupler=True,
+        )
 
         # Preserve dual-write ordering so snapshot state reflects artifact links
         # before DB synchronization side effects occur.

--- a/src/consist/core/tracker_artifact_queries.py
+++ b/src/consist/core/tracker_artifact_queries.py
@@ -12,6 +12,13 @@ if TYPE_CHECKING:
 
 
 class TrackerArtifactQueryService(_TrackerServiceBase):
+    def _resolve_artifact_ref(
+        self, artifact: Union[Artifact, str, uuid.UUID]
+    ) -> Optional[Artifact]:
+        return (
+            artifact if isinstance(artifact, Artifact) else self.get_artifact(artifact)
+        )
+
     def get_artifact(
         self,
         key_or_id: Union[str, uuid.UUID],
@@ -58,9 +65,7 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         """
         if not self.db:
             return []
-        target = (
-            artifact if isinstance(artifact, Artifact) else self.get_artifact(artifact)
-        )
+        target = self._resolve_artifact_ref(artifact)
         if target is None or target.content_id is None:
             return []
         artifacts = self.db.find_artifacts_by_content_id(target.content_id)
@@ -86,12 +91,62 @@ class TrackerArtifactQueryService(_TrackerServiceBase):
         """
         if not self.db:
             return []
-        target = (
-            artifact if isinstance(artifact, Artifact) else self.get_artifact(artifact)
-        )
+        target = self._resolve_artifact_ref(artifact)
         if target is None or target.content_id is None:
             return []
         return self.db.find_runs_producing_content(target.content_id)
+
+    def get_child_artifacts(
+        self, parent: Union[Artifact, str, uuid.UUID]
+    ) -> List[Artifact]:
+        """
+        Return child artifacts for a parent artifact, ordered by creation time.
+
+        Parameters
+        ----------
+        parent : Artifact | str | uuid.UUID
+            Parent artifact instance or identifier to resolve first.
+
+        Returns
+        -------
+        List[Artifact]
+            Child artifacts linked to the resolved parent.
+        """
+        if not self.db:
+            return []
+        target = self._resolve_artifact_ref(parent)
+        if target is None:
+            return []
+        artifacts = self.db.get_child_artifacts(target.id)
+        for artifact in artifacts:
+            set_tracker_ref(artifact, self._tracker)
+        return artifacts
+
+    def get_parent_artifact(
+        self, child: Union[Artifact, str, uuid.UUID]
+    ) -> Optional[Artifact]:
+        """
+        Return the parent artifact for a child artifact when one is recorded.
+
+        Parameters
+        ----------
+        child : Artifact | str | uuid.UUID
+            Child artifact instance or identifier to resolve first.
+
+        Returns
+        -------
+        Optional[Artifact]
+            Parent artifact, or ``None`` if the child has no recorded parent.
+        """
+        if not self.db:
+            return None
+        target = self._resolve_artifact_ref(child)
+        if target is None:
+            return None
+        artifact = self.db.get_parent_artifact(target.id)
+        if artifact is not None:
+            set_tracker_ref(artifact, self._tracker)
+        return artifact
 
     def select_artifact_schema_for_artifact(
         self,

--- a/src/consist/models/artifact.py
+++ b/src/consist/models/artifact.py
@@ -162,6 +162,8 @@ class Artifact(SQLModel, table=True):
                       (e.g., "parquet", "csv", "zarr").
         hash (Optional[str]): SHA256 content hash of the artifact's data, enabling content-addressable
                               lookups and deduplication.
+        parent_artifact_id (Optional[uuid.UUID]): Canonical parent artifact relation for
+                              container child artifacts. Null for standalone artifacts.
         run_id (Optional[str]): The ID of the run that generated this artifact. Null for inputs.
         meta (dict[str, object]): A flexible JSON field for storing arbitrary metadata, such as
                                schema signatures, or data dimensions.
@@ -210,6 +212,14 @@ class Artifact(SQLModel, table=True):
         index=True,
         sa_type=UUIDType,
         description="Pointer to shared ArtifactContent metadata when available",
+    )
+    parent_artifact_id: Optional[uuid.UUID] = Field(
+        default=None,
+        index=True,
+        sa_type=UUIDType,
+        description=(
+            "Canonical parent artifact relation for container child artifacts."
+        ),
     )
 
     # Lineage

--- a/src/consist/types.py
+++ b/src/consist/types.py
@@ -49,6 +49,7 @@ CodeIdentityMode: TypeAlias = Literal[
     "callable_source",
 ]
 InputBindingMode: TypeAlias = Literal["loaded", "paths", "none"]
+H5ChildSelectionMode: TypeAlias = Literal["all", "include_only"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,6 +142,24 @@ class ExecutionOptions:
     container: Optional[Mapping[str, Any]] = None
     runtime_kwargs: Optional[Mapping[str, Any]] = None
     inject_context: Optional[Union[bool, str]] = None
+
+
+@dataclass(frozen=True, slots=True)
+class H5ChildSpec:
+    """
+    Semantic customization for one discovered child artifact inside an HDF5 container.
+
+    The spec is keyed by HDF5 dataset path and only affects how an already-selected
+    child artifact is logged; it does not change dataset discovery behavior unless
+    paired with ``child_selection="include_only"``.
+    """
+
+    key: Optional[str] = None
+    description: Optional[str] = None
+    facet: Optional[FacetLike] = None
+    facet_schema_version: Optional[Union[str, int]] = None
+    facet_index: bool = False
+    metadata: Optional[Mapping[str, Any]] = None
 
 
 # Known artifact drivers used by Consist loaders.

--- a/tests/integration/artifacts/test_h5_support.py
+++ b/tests/integration/artifacts/test_h5_support.py
@@ -1,4 +1,5 @@
 import pytest
+from consist.core.coupler import Coupler
 from consist.core.tracker import Tracker
 from consist.types import H5ChildSpec
 
@@ -116,6 +117,28 @@ def test_h5_child_specs_include_only_and_semantic_overrides(tracker: Tracker):
     assert [artifact.id for artifact in children_from_query] == [child.id]
 
 
+def test_h5_child_specs_include_only_with_empty_specs_logs_no_children(
+    tracker: Tracker,
+):
+    h5_path = tracker.run_dir / "customized_empty.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        year_2020 = f.create_group("year_2020")
+        year_2020.create_dataset("households", data=[1, 2, 3])
+
+    with tracker.start_run("run_child_specs_empty", model="test_model"):
+        container, children = tracker.log_h5_container(
+            h5_path,
+            key="simulation_data",
+            child_selection="include_only",
+            child_specs={},
+        )
+
+    assert container.meta["table_count"] == 0
+    assert children == []
+
+
 def test_h5_child_specs_customize_without_filtering_all_children(tracker: Tracker):
     h5_path = tracker.run_dir / "customized_all.h5"
     h5_path.parent.mkdir(parents=True, exist_ok=True)
@@ -167,6 +190,7 @@ def test_log_h5_table_supports_semantic_metadata_and_parent_queries(tracker: Tra
             key="single_table_container",
             discover_tables=False,
         )
+        tracker._active_coupler = Coupler(tracker)
         table = tracker.log_h5_table(
             h5_path,
             table_path="/year_2030/households",
@@ -178,6 +202,8 @@ def test_log_h5_table_supports_semantic_metadata_and_parent_queries(tracker: Tra
             facet_index=True,
             semantic_group="population",
         )
+        assert tracker._active_coupler.get("households_2030") is table
+        tracker._active_coupler = None
 
     assert table.parent_artifact_id == container.id
     assert table.meta["parent_id"] == str(container.id)
@@ -188,3 +214,81 @@ def test_log_h5_table_supports_semantic_metadata_and_parent_queries(tracker: Tra
     parent = tracker.get_parent_artifact(table)
     assert parent is not None
     assert parent.id == container.id
+
+
+def test_h5_container_cache_hit_reuses_cached_children(tracker: Tracker):
+    h5_path = tracker.run_dir / "cache_reuse.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        f.create_dataset("households", data=[1, 2, 3])
+        f.create_dataset("persons", data=[4, 5, 6])
+
+    with tracker.start_run(
+        "run_h5_cache_seed",
+        model="test_model",
+        cache_mode="overwrite",
+        config={"cache_demo": True},
+    ) as t:
+        container_seed, children_seed = t.log_h5_container(
+            h5_path,
+            key="cached_h5",
+            discover_tables=True,
+        )
+        assert not t.is_cached
+
+    with tracker.start_run(
+        "run_h5_cache_hit",
+        model="test_model",
+        cache_mode="reuse",
+        config={"cache_demo": True},
+    ) as t:
+        container_hit, children_hit = t.log_h5_container(
+            h5_path,
+            key="cached_h5",
+            discover_tables=True,
+        )
+        assert t.is_cached
+
+    assert container_hit.id == container_seed.id
+    assert [child.id for child in children_hit] == [child.id for child in children_seed]
+
+
+def test_h5_container_cache_hit_demotes_when_children_were_not_cached(
+    tracker: Tracker,
+):
+    h5_path = tracker.run_dir / "cache_demote.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        f.create_dataset("households", data=[1, 2, 3])
+
+    with tracker.start_run(
+        "run_h5_cache_demote_seed",
+        model="test_model",
+        cache_mode="overwrite",
+        config={"cache_demo": "demote"},
+    ) as t:
+        t.log_h5_container(
+            h5_path,
+            key="cached_h5",
+            discover_tables=False,
+        )
+        assert not t.is_cached
+
+    with tracker.start_run(
+        "run_h5_cache_demote_hit",
+        model="test_model",
+        cache_mode="reuse",
+        config={"cache_demo": "demote"},
+    ) as t:
+        assert t.is_cached
+        container, children = t.log_h5_container(
+            h5_path,
+            key="cached_h5",
+            discover_tables=True,
+        )
+        assert not t.is_cached
+
+    assert container.key == "cached_h5"
+    assert len(children) == 1

--- a/tests/integration/artifacts/test_h5_support.py
+++ b/tests/integration/artifacts/test_h5_support.py
@@ -1,5 +1,6 @@
 import pytest
 from consist.core.tracker import Tracker
+from consist.types import H5ChildSpec
 
 pytest.importorskip("tables")
 h5py = pytest.importorskip("h5py")
@@ -57,6 +58,7 @@ def test_h5_auto_discovery(tracker: Tracker):
             assert child.run_id == container.run_id, (
                 "Child artifact must inherit Run ID"
             )
+            assert child.parent_artifact_id == container.id
             assert child.meta["parent_id"] == str(container.id)
             assert child.driver == "h5_table"
 
@@ -64,3 +66,125 @@ def test_h5_auto_discovery(tracker: Tracker):
     saved_children = tracker.get_artifacts_for_run(container.run_id).outputs
     # +1 for the container itself
     assert len(saved_children) == 3
+
+
+def test_h5_child_specs_include_only_and_semantic_overrides(tracker: Tracker):
+    h5_path = tracker.run_dir / "customized.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        year_2020 = f.create_group("year_2020")
+        year_2020.create_dataset("households", data=[1, 2, 3])
+        year_2020.create_dataset("persons", data=[4, 5, 6])
+
+    with tracker.start_run("run_child_specs", model="test_model"):
+        container, children = tracker.log_h5_container(
+            h5_path,
+            key="simulation_data",
+            child_selection="include_only",
+            child_specs={
+                "/year_2020/households": H5ChildSpec(
+                    key="households_2020",
+                    description="Selected households table",
+                    facet={"artifact_family": "urbansim", "dataset": "households"},
+                    facet_schema_version="1",
+                    facet_index=True,
+                    metadata={"semantic_group": "population"},
+                )
+            },
+        )
+
+    assert container.meta["table_count"] == 1
+    assert [child.key for child in children] == ["households_2020"]
+
+    child = children[0]
+    assert child.parent_artifact_id == container.id
+    assert child.meta["parent_id"] == str(container.id)
+    assert child.meta["description"] == "Selected households table"
+    assert child.meta["semantic_group"] == "population"
+    assert child.meta["artifact_facet_schema_version"] == "1"
+
+    reloaded_child = tracker.get_artifact(child.id)
+    assert reloaded_child is not None
+    assert reloaded_child.parent_artifact_id == container.id
+
+    resolved_parent = tracker.get_parent_artifact(reloaded_child)
+    assert resolved_parent is not None
+    assert resolved_parent.id == container.id
+
+    children_from_query = tracker.get_child_artifacts(container)
+    assert [artifact.id for artifact in children_from_query] == [child.id]
+
+
+def test_h5_child_specs_customize_without_filtering_all_children(tracker: Tracker):
+    h5_path = tracker.run_dir / "customized_all.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        year_2020 = f.create_group("year_2020")
+        year_2020.create_dataset("households", data=[1, 2, 3])
+        year_2020.create_dataset("persons", data=[4, 5, 6])
+
+    with tracker.start_run("run_child_specs_all", model="test_model"):
+        container, children = tracker.log_h5_container(
+            h5_path,
+            key="simulation_data",
+            child_specs={
+                "year_2020/households": H5ChildSpec(
+                    key="households_2020",
+                    description="Customized households table",
+                    metadata={"semantic_group": "population"},
+                )
+            },
+        )
+
+    assert container.meta["table_count"] == 2
+    assert sorted(child.key for child in children) == [
+        "households_2020",
+        "simulation_data_year_2020_persons",
+    ]
+
+    customized = next(child for child in children if child.key == "households_2020")
+    default_child = next(
+        child for child in children if child.key == "simulation_data_year_2020_persons"
+    )
+
+    assert customized.meta["description"] == "Customized households table"
+    assert customized.meta["semantic_group"] == "population"
+    assert default_child.meta.get("description") is None
+
+
+def test_log_h5_table_supports_semantic_metadata_and_parent_queries(tracker: Tracker):
+    h5_path = tracker.run_dir / "single_table.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        f.create_group("year_2030").create_dataset("households", data=[1, 2, 3])
+
+    with tracker.start_run("run_single_table", model="test_model"):
+        container, _ = tracker.log_h5_container(
+            h5_path,
+            key="single_table_container",
+            discover_tables=False,
+        )
+        table = tracker.log_h5_table(
+            h5_path,
+            table_path="/year_2030/households",
+            key="households_2030",
+            parent=container,
+            description="Standalone child artifact",
+            facet={"artifact_family": "urbansim", "dataset": "households"},
+            facet_schema_version=2,
+            facet_index=True,
+            semantic_group="population",
+        )
+
+    assert table.parent_artifact_id == container.id
+    assert table.meta["parent_id"] == str(container.id)
+    assert table.meta["description"] == "Standalone child artifact"
+    assert table.meta["semantic_group"] == "population"
+    assert table.meta["artifact_facet_schema_version"] == 2
+
+    parent = tracker.get_parent_artifact(table)
+    assert parent is not None
+    assert parent.id == container.id

--- a/tests/integration/workflow/test_tracker_artifact_helpers.py
+++ b/tests/integration/workflow/test_tracker_artifact_helpers.py
@@ -336,3 +336,35 @@ class TestLogH5Container:
 
         assert container.key == "discovered_data"
         assert isinstance(tables, list)
+
+
+def test_tracker_parent_child_artifact_queries(tracker, run_dir: Path):
+    h5py = pytest.importorskip("h5py")
+
+    h5_file = run_dir / "query_helpers.h5"
+    with h5py.File(h5_file, "w") as handle:
+        handle.create_dataset("a", data=[1, 2, 3])
+        handle.create_dataset("b", data=[4, 5, 6])
+
+    with tracker.start_run("run_h5_queries", "test_model"):
+        container, tables = tracker.log_h5_container(
+            h5_file,
+            key="query_helpers",
+            discover_tables=True,
+        )
+
+    assert len(tables) == 2
+
+    children_by_artifact = tracker.get_child_artifacts(container)
+    children_by_id = tracker.get_child_artifacts(container.id)
+
+    assert [artifact.id for artifact in children_by_artifact] == [
+        artifact.id for artifact in children_by_id
+    ]
+    assert [artifact.id for artifact in children_by_artifact] == [
+        artifact.id for artifact in tables
+    ]
+
+    parent = tracker.get_parent_artifact(tables[0].id)
+    assert parent is not None
+    assert parent.id == container.id

--- a/tests/unit/core/test_artifacts.py
+++ b/tests/unit/core/test_artifacts.py
@@ -209,6 +209,7 @@ def test_attach_content_id_handles_deepcopied_detached_artifact(tmp_path, caplog
     assert content is not None
     assert out.content_id == content.id
     assert "Failed to record artifact content identity" not in caplog.text
+    assert out.parent_artifact_id is None
 
 
 def test_create_artifact_handles_driver_override_on_deepcopied_detached_artifact(
@@ -259,6 +260,47 @@ def test_create_artifact_handles_driver_override_on_deepcopied_detached_artifact
     assert persisted.content_id == content.id
     assert replayed.content_id != content.id
     assert "Failed to record artifact content identity" not in caplog.text
+
+
+def test_create_artifact_preserves_parent_artifact_id_on_detached_clone(tmp_path):
+    db = DatabaseManager(str(tmp_path / "artifact_parent_clone.db"))
+    parent_id = Artifact(
+        key="container",
+        container_uri="outputs://container.h5",
+        driver="h5",
+        run_id="run_parent",
+    ).id
+
+    with db.session_scope() as session:
+        original = Artifact(
+            key="geoid_to_zone",
+            container_uri="outputs://zones.h5",
+            table_path="/zones",
+            driver="h5_table",
+            hash="shared_hash",
+            parent_artifact_id=parent_id,
+            run_id="run_a",
+            meta={"parent_id": str(parent_id)},
+        )
+        session.add(original)
+        session.commit()
+        artifact_id = original.id
+
+    detached = db.get_artifact(artifact_id)
+    assert detached is not None
+    replayed = deepcopy(detached)
+
+    tracker = MagicMock()
+    tracker.resolve_uri = lambda uri: f"/abs/{uri}"
+    tracker.fs.virtualize_path = lambda path: f"inputs://{Path(path).name}"
+    tracker.identity.compute_file_checksum.return_value = "shared_hash"
+    tracker.db = db
+
+    manager = ArtifactManager(tracker)
+    out = manager.create_artifact(path=replayed, run_id="run_b")
+
+    assert out.parent_artifact_id == parent_id
+    assert out.meta["parent_id"] == str(parent_id)
 
 
 def test_create_artifact_clones_reused_input_artifact_before_mutation(tmp_path, caplog):

--- a/tests/unit/core/test_persistence.py
+++ b/tests/unit/core/test_persistence.py
@@ -1,7 +1,11 @@
 from pathlib import Path
+import uuid
 
 from consist.core.persistence import DatabaseManager
-from consist.core.schema_compat import apply_content_identity_compatibility
+from consist.core.schema_compat import (
+    apply_artifact_parent_compatibility,
+    apply_content_identity_compatibility,
+)
 from consist.models.artifact import Artifact
 from consist.models.artifact_schema import ArtifactSchemaObservation, ArtifactSchema
 
@@ -115,6 +119,53 @@ def test_content_identity_compatibility_recreates_index_idempotently(
     assert rows == [("idx_artifact_content_id",)]
 
 
+def test_artifact_parent_compatibility_recreates_index_idempotently(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "artifact_parent_index.db"
+    db = DatabaseManager(str(db_path))
+
+    with db.engine.begin() as conn:
+        initial_rows = conn.exec_driver_sql(
+            """
+            SELECT index_name
+            FROM duckdb_indexes()
+            WHERE table_name = 'artifact'
+              AND expressions = '[parent_artifact_id]'
+            """
+        ).fetchall()
+
+    assert len(initial_rows) == 1
+
+    with db.engine.begin() as conn:
+        for (index_name,) in conn.exec_driver_sql(
+            """
+            SELECT index_name
+            FROM duckdb_indexes()
+            WHERE table_name = 'artifact'
+              AND expressions = '[parent_artifact_id]'
+            """
+        ).fetchall():
+            conn.exec_driver_sql(f"DROP INDEX IF EXISTS {index_name}")
+
+    assert db._table_has_column(table_name="artifact", column_name="parent_artifact_id")
+
+    apply_artifact_parent_compatibility(db)
+    apply_artifact_parent_compatibility(db)
+
+    with db.engine.begin() as conn:
+        rows = conn.exec_driver_sql(
+            """
+            SELECT index_name
+            FROM duckdb_indexes()
+            WHERE table_name = 'artifact'
+              AND expressions = '[parent_artifact_id]'
+            """
+        ).fetchall()
+
+    assert rows == [("idx_artifact_parent_artifact_id",)]
+
+
 def test_content_id_backfill_is_explicit_not_automatic(tmp_path: Path) -> None:
     db_path = tmp_path / "content_backfill.db"
     db = DatabaseManager(str(db_path))
@@ -188,3 +239,53 @@ def test_find_schema_observation_for_content_id(tmp_path: Path) -> None:
     obs = db.find_schema_observation_for_content_id(content.id)
     assert obs is not None
     assert obs.schema_id == "sid"
+
+
+def test_parent_artifact_queries_support_canonical_and_legacy_rows(
+    tmp_path: Path,
+) -> None:
+    db = DatabaseManager(str(tmp_path / "artifact_parent_lookup.db"))
+
+    parent_id = uuid.uuid4()
+    with db.session_scope() as session:
+        parent = Artifact(
+            id=parent_id,
+            key="container",
+            container_uri="outputs://container.h5",
+            driver="h5",
+            run_id="run_a",
+        )
+        child = Artifact(
+            key="child",
+            container_uri="outputs://container.h5",
+            driver="h5_table",
+            table_path="/a",
+            parent_artifact_id=parent_id,
+            run_id="run_a",
+            meta={"parent_id": str(parent_id)},
+        )
+        legacy_child = Artifact(
+            key="legacy_child",
+            container_uri="outputs://legacy.h5",
+            driver="h5_table",
+            table_path="/legacy",
+            run_id="run_a",
+            meta={"parent_id": str(parent_id)},
+        )
+        session.add(parent)
+        session.add(child)
+        session.add(legacy_child)
+        session.commit()
+        child_id = child.id
+        legacy_child_id = legacy_child.id
+
+    children = db.get_child_artifacts(parent_id)
+    assert [artifact.key for artifact in children] == ["child", "legacy_child"]
+
+    resolved_parent = db.get_parent_artifact(child_id)
+    assert resolved_parent is not None
+    assert resolved_parent.id == parent_id
+
+    resolved_legacy_parent = db.get_parent_artifact(legacy_child_id)
+    assert resolved_legacy_parent is not None
+    assert resolved_legacy_parent.id == parent_id

--- a/tests/unit/core/test_run_materialize_outputs_core.py
+++ b/tests/unit/core/test_run_materialize_outputs_core.py
@@ -907,6 +907,45 @@ def test_hydrate_run_outputs_returns_detached_artifact_views(
     assert historical_artifact.as_path() == output_path
 
 
+def test_hydrate_run_outputs_preserves_parent_artifact_id(
+    tracker, run_dir: Path
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    output_path = run_dir / "outputs" / "tables.h5"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(output_path, "w") as handle:
+        handle.create_dataset("households", data=[1, 2, 3])
+
+    with tracker.start_run(
+        "producer_h5_hydrate", model="producer", cache_mode="overwrite"
+    ):
+        container, _ = tracker.log_h5_container(
+            output_path,
+            key="tables",
+            discover_tables=False,
+        )
+        tracker.log_h5_table(
+            output_path,
+            table_path="/households",
+            key="households",
+            parent=container,
+        )
+
+    historical_artifact = tracker.get_run_outputs("producer_h5_hydrate")["households"]
+
+    hydrated = tracker.hydrate_run_outputs(
+        "producer_h5_hydrate",
+        target_root=run_dir / "restored_h5_hydrate",
+        keys=["households"],
+    )
+
+    result = hydrated["households"]
+    assert result.artifact is not historical_artifact
+    assert result.artifact.parent_artifact_id == historical_artifact.parent_artifact_id
+    assert result.artifact.meta["parent_id"] == historical_artifact.meta["parent_id"]
+
+
 def test_hydrate_run_outputs_warn_mode_returns_mixed_keyed_statuses(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Formalizes container child-artifact semantics in Consist, using HDF5 as the first concrete implementation.

This PR does not introduce a new HDF5 subsystem or change hashing behavior. It promotes the existing `log_h5_container(...)` / `log_h5_table(...)` pattern into a more explicit public model by:

- making parent/child artifact relations canonical and queryable
- making HDF5 child selection/customization usable without local helper loops
- ensuring the relation survives logging, DB round-trip, replay/clone, cache-hit reuse, and hydration/materialization flows
- documenting the new public surface in the API and troubleshooting docs

The downstream goal is to let PILATES remove generic HDF5 child-artifact logging ceremony while keeping only workflow-specific table-selection logic.

## What Changed

### Canonical parent/child artifact relation

- Added `Artifact.parent_artifact_id` as the canonical persisted parent-child relation.
- Added additive DB compatibility for older databases:
  - lazily adds `artifact.parent_artifact_id`
  - lazily adds an index on that column
  - does not require backfill
- Continued writing `meta["parent_id"]` on new child rows as a compatibility/debug mirror.

### First-class query helpers

- Added `Tracker.get_child_artifacts(parent)`
- Added `Tracker.get_parent_artifact(child)`
- These accept artifact objects or identifiers and return normal `Artifact` objects.
- Child ordering is deterministic: creation time ascending.
- Queries prefer `parent_artifact_id` and fall back to legacy `meta["parent_id"]` rows.

### HDF5 child-artifact ergonomics

- Added `H5ChildSpec` as a typed child customization surface.
- Extended `log_h5_container(...)` with:
  - `child_specs={dataset_path: H5ChildSpec(...)}`
  - `child_selection="all" | "include_only"`
- Child specs support:
  - `key`
  - `description`
  - `facet`
  - `facet_schema_version`
  - `facet_index`
  - extra metadata
- Extended `log_h5_table(...)` to support:
  - `description`
  - `facet`
  - `facet_schema_version`
  - `facet_index`

### Lifecycle behavior

- Parent-child relations now persist through:
  - logging
  - DB round-trip
  - detached clone/replay flows
  - hydration/materialization detached artifact views
- HDF5 cache-hit behavior is now explicit:
  - if cached child artifacts match the requested child set, they are reused
  - if the cached run did not log the requested children, the cache hit is demoted and fresh child artifacts are logged
- Explicit `log_h5_table(...)` outputs now populate the active coupler again, matching normal output logging behavior.

### Docs

Updated:

- `docs/api/artifact.md`
- `docs/api/tracker.md`
- `docs/api/public_api.md`
- `docs/troubleshooting.md`

These now document:
- `Artifact.parent_artifact_id` as the canonical relation
- legacy `meta["parent_id"]` as compatibility-only
- `get_child_artifacts(...)` / `get_parent_artifact(...)`
- `H5ChildSpec`
- `child_specs` / `child_selection`
- the artifact schema compatibility note for older DBs

## Why

Consist already had the primitives for HDF5 child artifacts, but the abstraction was weakly modeled and awkward to use:

- parent/child relation lived only in metadata
- no first-class parent/child query helpers
- no bulk semantic customization for discovered children
- poor ergonomics for selecting only a subset of children

This PR makes container child artifacts a first-class concept without broadening the design beyond HDF5 yet.

## Non-Goals

- No hashing redesign
- No migration/backfill requirement
- No broader container-child implementation for NetCDF/OpenMatrix yet
- No UI work beyond API/docs discoverability
- No attempt to remove all PILATES HDF5 logic; only the generic logging ceremony is targeted here

## Downstream Payoff

This should let PILATES delete most or all of its generic HDF5 child-artifact logging helper ceremony while preserving:

- semantic per-table keys/descriptions/facets
- selected-subset child logging
- clear parent-child lineage
- stable provenance/query ergonomics for ActivitySim bookkeeping