### PR TITLE
Register recovery copy

### DIFF
--- a/docs/api/api_helpers.md
+++ b/docs/api/api_helpers.md
@@ -23,8 +23,9 @@ a tracker object to every call.
 - Recovery/staging/archive: `consist.hydrate_run_outputs`,
   `consist.materialize_run_outputs`, `consist.stage_artifact`,
   `consist.stage_inputs`, `consist.set_artifact_recovery_roots`,
-  `consist.archive_artifact`, `consist.archive_run_outputs`,
-  `consist.archive_current_run_outputs`
+  `consist.register_artifact_recovery_copy`,
+  `consist.register_run_output_recovery_copies`, `consist.archive_artifact`,
+  `consist.archive_run_outputs`, `consist.archive_current_run_outputs`
 - Querying: `consist.find_run`, `consist.find_runs`,
   `consist.find_latest_run`, `consist.run_query`, `consist.run_set`,
   `consist.get_run_result`, `consist.config_run_query`,
@@ -112,6 +113,8 @@ For class-level equivalents, see [Tracker](tracker.md) and
         - stage_artifact
         - stage_inputs
         - set_artifact_recovery_roots
+        - register_artifact_recovery_copy
+        - register_run_output_recovery_copies
         - archive_artifact
         - archive_run_outputs
         - archive_current_run_outputs

--- a/docs/api/materialize.md
+++ b/docs/api/materialize.md
@@ -67,7 +67,11 @@ hydrated = tracker.hydrate_run_outputs(
 Use the lower-level helpers when you want to manage archival yourself:
 
 - `tracker.set_artifact_recovery_roots(...)` records one or more archive roots
-  without copying bytes.
+  without copying bytes or verifying the archive-side files.
+- `tracker.register_artifact_recovery_copy(...)` verifies an externally copied
+  artifact file before recording the recovery root.
+- `tracker.register_run_output_recovery_copies(...)` applies verified
+  external-copy adoption to all or selected outputs for a run.
 - `tracker.archive_current_run_outputs(...)` archives the outputs of the active
   run without manually extracting the run ID first.
 - `tracker.archive_artifact(...)` copies or moves a single artifact into an
@@ -203,6 +207,8 @@ signatures and attribute details, use the generated reference below.
         - stage_inputs
         - StagedInput
         - StagedInputsResult
+        - ArtifactRecoveryCopyRegistration
+        - RunOutputRecoveryCopiesRegistration
         - HydratedRunOutput
         - HydratedRunOutputsResult
         - MaterializationResult

--- a/docs/api/public_api.md
+++ b/docs/api/public_api.md
@@ -108,6 +108,8 @@ with tracker.scenario("baseline") as sc:
 - [`consist.Artifact`](artifact.md)
 - [`consist.HydratedRunOutput`](materialize.md#consist.core.materialize.HydratedRunOutput)
 - [`consist.HydratedRunOutputsResult`](materialize.md#consist.core.materialize.HydratedRunOutputsResult)
+- [`consist.ArtifactRecoveryCopyRegistration`](materialize.md#consist.core.materialize.ArtifactRecoveryCopyRegistration)
+- [`consist.RunOutputRecoveryCopiesRegistration`](materialize.md#consist.core.materialize.RunOutputRecoveryCopiesRegistration)
 - [`consist.MaterializationResult`](materialize.md#consist.core.materialize.MaterializationResult)
 - [`consist.StagedInput`](materialize.md#consist.core.materialize.StagedInput)
 - [`consist.StagedInputsResult`](materialize.md#consist.core.materialize.StagedInputsResult)
@@ -226,7 +228,8 @@ to Consist, start with the **Core** and **Logging/Loading** groups and reach for
 - `get_run`, `get_run_config`, `get_run_inputs`, `get_run_outputs`
 - `hydrate_run_outputs`, `materialize_run_outputs`
 - `stage_artifact`, `stage_inputs`
-- `set_artifact_recovery_roots`, `archive_artifact`, `archive_run_outputs`,
+- `set_artifact_recovery_roots`, `register_artifact_recovery_copy`,
+  `register_run_output_recovery_copies`, `archive_artifact`, `archive_run_outputs`,
   `archive_current_run_outputs`
 - `get_artifact_lineage`, `print_lineage`, `history`
 - `diff_runs`, `get_config_facet`, `get_config_facets`, `get_run_config_kv`

--- a/docs/api/tracker.md
+++ b/docs/api/tracker.md
@@ -189,6 +189,8 @@ and `digest`.
         - stage_artifact
         - stage_inputs
         - set_artifact_recovery_roots
+        - register_artifact_recovery_copy
+        - register_run_output_recovery_copies
         - archive_artifact
         - archive_run_outputs
         - archive_current_run_outputs

--- a/docs/guides/historical-recovery.md
+++ b/docs/guides/historical-recovery.md
@@ -163,8 +163,11 @@ registered = tracker.register_run_output_recovery_copies(
 `register_artifact_recovery_copy(...)` does not copy bytes. It expects the
 artifact to already exist at
 `recovery_root / <artifact-uri-relative-path>`, blocks symlinks and directory
-artifacts, and compares the file bytes to `artifact.hash` and any supplied
-`content_hash` before updating metadata.
+artifacts, and compares the file bytes to a full SHA-256 before updating
+metadata. Pass `content_hash` when the artifact was logged with fast metadata
+hashing or otherwise lacks a byte-level `artifact.hash`; without a byte-level
+hash, verified registration returns `unverifiable_hash` and leaves metadata
+unchanged.
 
 Use the low-level metadata helper only when verification is handled elsewhere
 or you intentionally need to override recovery metadata:

--- a/src/consist/__init__.py
+++ b/src/consist/__init__.py
@@ -59,6 +59,8 @@ from consist.api import (
     stage_artifact,
     stage_inputs,
     set_artifact_recovery_roots,
+    register_artifact_recovery_copy,
+    register_run_output_recovery_copies,
     archive_artifact,
     archive_run_outputs,
     archive_current_run_outputs,
@@ -103,9 +105,11 @@ from consist.core.noop import (
     NoopTracker,
 )
 from consist.core.materialize import (
+    ArtifactRecoveryCopyRegistration,
     HydratedRunOutput,
     HydratedRunOutputsResult,
     MaterializationResult,
+    RunOutputRecoveryCopiesRegistration,
     StagedInput,
     StagedInputsResult,
 )
@@ -141,6 +145,8 @@ __all__ = [
     "NoopTracker",
     "HydratedRunOutput",
     "HydratedRunOutputsResult",
+    "ArtifactRecoveryCopyRegistration",
+    "RunOutputRecoveryCopiesRegistration",
     "MaterializationResult",
     "StagedInput",
     "StagedInputsResult",
@@ -193,6 +199,8 @@ __all__ = [
     "stage_artifact",
     "stage_inputs",
     "set_artifact_recovery_roots",
+    "register_artifact_recovery_copy",
+    "register_run_output_recovery_copies",
     "archive_artifact",
     "archive_run_outputs",
     "archive_current_run_outputs",

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -69,8 +69,10 @@ from consist.types import (
 if TYPE_CHECKING:
     from consist.core.config_canonicalization import ConfigAdapter
     from consist.core.materialize import (
+        ArtifactRecoveryCopyRegistration,
         HydratedRunOutputsResult,
         MaterializationResult,
+        RunOutputRecoveryCopiesRegistration,
         StagedInput,
         StagedInputsResult,
     )
@@ -1286,6 +1288,65 @@ def set_artifact_recovery_roots(
     """
     return _resolve_tracker(tracker).set_artifact_recovery_roots(
         artifact, roots, append=append
+    )
+
+
+def register_artifact_recovery_copy(
+    artifact: Artifact,
+    recovery_root: str | Path,
+    *,
+    verify: bool = True,
+    content_hash: str | None = None,
+    append: bool = True,
+    tracker: Optional["Tracker"] = None,
+) -> "ArtifactRecoveryCopyRegistration":
+    """
+    Verify and record an externally copied artifact recovery location.
+
+    The expected copy must already exist at
+    ``recovery_root / <artifact-uri-relative-path>``. Consist verifies the
+    existing file and then records ``recovery_root`` in
+    ``artifact.meta["recovery_roots"]`` without copying bytes itself.
+
+    ``content_hash`` is interpreted as a full file SHA-256 and takes precedence
+    when supplied. Without it, ``artifact.hash`` is only used for byte
+    verification when the tracker is using full content hashing. Directory
+    artifacts are intentionally blocked until directory manifest support exists.
+    """
+    return _resolve_tracker(tracker).register_artifact_recovery_copy(
+        artifact,
+        recovery_root,
+        verify=verify,
+        content_hash=content_hash,
+        append=append,
+    )
+
+
+def register_run_output_recovery_copies(
+    run_id: str,
+    recovery_root: str | Path,
+    *,
+    keys: Sequence[str] | None = None,
+    verify: bool = True,
+    append: bool = True,
+    content_hashes: Mapping[str, str] | None = None,
+    tracker: Optional["Tracker"] = None,
+) -> "RunOutputRecoveryCopiesRegistration":
+    """
+    Verify and record externally copied recovery locations for run outputs.
+
+    This is the bulk form of ``register_artifact_recovery_copy(...)`` for
+    workflows where an external archive or HPC process has already copied run
+    outputs into a recovery root. Unknown requested output keys raise
+    immediately; per-artifact blockers are returned in the keyed result.
+    """
+    return _resolve_tracker(tracker).register_run_output_recovery_copies(
+        run_id,
+        recovery_root,
+        keys=keys,
+        verify=verify,
+        append=append,
+        content_hashes=content_hashes,
     )
 
 

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -1312,6 +1312,8 @@ def register_artifact_recovery_copy(
     when supplied. Without it, ``artifact.hash`` is only used for byte
     verification when the tracker is using full content hashing. Directory
     artifacts are intentionally blocked until directory manifest support exists.
+    ``append`` defaults to True, like ``archive_artifact(...)``; pass
+    ``append=False`` to replace existing recovery roots.
     """
     return _resolve_tracker(tracker).register_artifact_recovery_copy(
         artifact,
@@ -1339,6 +1341,8 @@ def register_run_output_recovery_copies(
     workflows where an external archive or HPC process has already copied run
     outputs into a recovery root. Unknown requested output keys raise
     immediately; per-artifact blockers are returned in the keyed result.
+    ``append`` defaults to True, like ``archive_run_outputs(...)``; pass
+    ``append=False`` to replace existing recovery roots.
     """
     return _resolve_tracker(tracker).register_run_output_recovery_copies(
         run_id,

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -15,6 +15,7 @@ only need summary buckets.
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Iterator, Mapping as MappingABC
 from dataclasses import dataclass, field
 from contextlib import suppress
@@ -24,7 +25,15 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Iterable, Literal, Mapping, Sequence, TYPE_CHECKING, cast
+from typing import (
+    Iterable,
+    Literal,
+    Mapping,
+    Sequence,
+    TYPE_CHECKING,
+    cast,
+    get_args,
+)
 
 import pandas as pd
 from sqlalchemy import MetaData, Table, select
@@ -340,27 +349,11 @@ class RunOutputRecoveryCopiesRegistration(
 
     @property
     def summary(self) -> str:
-        counts: dict[str, int] = {
-            "registered": 0,
-            "missing_copy": 0,
-            "hash_mismatch": 0,
-            "skipped_unmapped": 0,
-            "symlink_destination": 0,
-            "unsupported_directory": 0,
-            "unverifiable_hash": 0,
-            "failed": 0,
-        }
-        for output in self.outputs.values():
-            counts[output.status] += 1
-        return (
-            f"registered={counts['registered']} "
-            f"missing_copy={counts['missing_copy']} "
-            f"hash_mismatch={counts['hash_mismatch']} "
-            f"skipped_unmapped={counts['skipped_unmapped']} "
-            f"symlink_destination={counts['symlink_destination']} "
-            f"unsupported_directory={counts['unsupported_directory']} "
-            f"unverifiable_hash={counts['unverifiable_hash']} "
-            f"failed={counts['failed']}"
+        counts = Counter(output.status for output in self.outputs.values())
+        known_statuses = list(get_args(RecoveryCopyStatus))
+        extra_statuses = sorted(set(counts) - set(known_statuses))
+        return " ".join(
+            f"{status}={counts[status]}" for status in known_statuses + extra_statuses
         )
 
 

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -53,6 +53,17 @@ StagingStatus = Literal[
     "failed",
 ]
 
+RecoveryCopyStatus = Literal[
+    "registered",
+    "missing_copy",
+    "hash_mismatch",
+    "skipped_unmapped",
+    "symlink_destination",
+    "unsupported_directory",
+    "unverifiable_hash",
+    "failed",
+]
+
 
 @dataclass(slots=True)
 class MaterializationResult:
@@ -257,6 +268,98 @@ class HydratedRunOutputsResult(MappingABC[str, HydratedRunOutput]):
             f"preserved_existing={counts['preserved_existing']} "
             f"skipped_unmapped={counts['skipped_unmapped']} "
             f"missing_source={counts['missing_source']} "
+            f"failed={counts['failed']}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactRecoveryCopyRegistration:
+    """Outcome for adopting one externally copied artifact recovery location.
+
+    ``registered`` means Consist verified the existing copy according to the
+    requested policy and persisted the recovery root. Other statuses are
+    advisory blockers; the artifact identity is unchanged and recovery metadata
+    was not updated.
+    """
+
+    artifact: Artifact
+    key: str | None
+    artifact_id: str
+    recovery_root: Path
+    expected_path: Path | None
+    status: RecoveryCopyStatus
+    message: str | None = None
+    metadata_updated: bool = False
+
+
+@dataclass(slots=True)
+class RunOutputRecoveryCopiesRegistration(
+    MappingABC[str, ArtifactRecoveryCopyRegistration]
+):
+    """Key-indexed result for adopting externally copied run-output bytes."""
+
+    outputs: dict[str, ArtifactRecoveryCopyRegistration] = field(default_factory=dict)
+
+    def __getitem__(self, key: str) -> ArtifactRecoveryCopyRegistration:
+        return self.outputs[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.outputs)
+
+    def __len__(self) -> int:
+        return len(self.outputs)
+
+    def items(self):
+        return self.outputs.items()
+
+    def keys(self):
+        return self.outputs.keys()
+
+    def values(self):
+        return self.outputs.values()
+
+    @property
+    def registered(self) -> dict[str, ArtifactRecoveryCopyRegistration]:
+        return {
+            key: output
+            for key, output in self.outputs.items()
+            if output.status == "registered"
+        }
+
+    @property
+    def blocked(self) -> dict[str, ArtifactRecoveryCopyRegistration]:
+        return {
+            key: output
+            for key, output in self.outputs.items()
+            if output.status != "registered"
+        }
+
+    @property
+    def complete(self) -> bool:
+        return not self.blocked
+
+    @property
+    def summary(self) -> str:
+        counts: dict[str, int] = {
+            "registered": 0,
+            "missing_copy": 0,
+            "hash_mismatch": 0,
+            "skipped_unmapped": 0,
+            "symlink_destination": 0,
+            "unsupported_directory": 0,
+            "unverifiable_hash": 0,
+            "failed": 0,
+        }
+        for output in self.outputs.values():
+            counts[output.status] += 1
+        return (
+            f"registered={counts['registered']} "
+            f"missing_copy={counts['missing_copy']} "
+            f"hash_mismatch={counts['hash_mismatch']} "
+            f"skipped_unmapped={counts['skipped_unmapped']} "
+            f"symlink_destination={counts['symlink_destination']} "
+            f"unsupported_directory={counts['unsupported_directory']} "
+            f"unverifiable_hash={counts['unverifiable_hash']} "
             f"failed={counts['failed']}"
         )
 

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 import shutil
 from collections.abc import Mapping as MappingABC
@@ -64,6 +65,7 @@ from consist.core.config_canonicalization import (
 )
 from consist.core.config_facets import ConfigFacetManager
 from consist.core.decorators import define_step as define_step_decorator
+from consist.core.error_messages import format_problem_cause_fix
 from consist.core.events import EventManager
 from consist.core.fs import FileSystemManager
 from consist.core.identity import IdentityManager
@@ -78,13 +80,15 @@ from consist.core.views import ViewFactory, ViewRegistry
 from consist.core.ingestion import ingest_artifact
 from consist.core.lineage import LineageService
 from consist.core.materialize import (
+    ArtifactRecoveryCopyRegistration,
+    RecoveryCopyStatus,
+    RunOutputRecoveryCopiesRegistration,
     hydrate_run_outputs as hydrate_run_outputs_core,  # noqa: F401
 )
 from consist.core.materialize_options import normalize_materialize_output_keys
 from consist.core.matrix import MatrixViewFactory
 from consist.core.netcdf_views import NetCdfMetadataView
 from consist.core.openmatrix_views import OpenMatrixMetadataView
-from consist.core.error_messages import format_problem_cause_fix
 from consist.core.spatial_views import SpatialMetadataView
 from consist.core.queries import RunQueryService
 from consist.core.settings import ConsistSettings
@@ -125,6 +129,18 @@ if TYPE_CHECKING:
 
 AccessMode = Literal["standard", "analysis", "read_only"]
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _compute_file_sha256(path: Path) -> str:
+    """Compute a full content SHA-256 for one regular file."""
+    sha256 = hashlib.sha256()
+    with path.open("rb") as file:
+        while True:
+            chunk = file.read(65536)
+            if not chunk:
+                break
+            sha256.update(chunk)
+    return sha256.hexdigest()
 
 
 def _is_safe_identifier(identifier: str) -> bool:
@@ -1067,6 +1083,218 @@ class Tracker:
         if mode == "move":
             artifact.abs_path = str(destination.resolve())
         return destination
+
+    def register_artifact_recovery_copy(
+        self,
+        artifact: Artifact,
+        recovery_root: str | os.PathLike[str],
+        *,
+        verify: bool = True,
+        content_hash: str | None = None,
+        append: bool = True,
+    ) -> ArtifactRecoveryCopyRegistration:
+        """
+        Verify and record an externally copied artifact recovery location.
+
+        Unlike ``archive_artifact(...)``, this helper never copies bytes. It
+        expects external infrastructure to have already copied the artifact to
+        ``recovery_root / <uri-relative-path>``. Consist verifies that location
+        and only then appends or replaces ``artifact.meta["recovery_roots"]``.
+
+        Directory artifacts are intentionally blocked here until Consist has a
+        first-class directory manifest contract for recovery-root equivalence.
+        ``content_hash`` is interpreted as a full file SHA-256 and takes
+        precedence when supplied. Without it, ``artifact.hash`` is only used for
+        byte verification when this tracker is using full content hashing; fast
+        metadata hashes are not byte-equivalence proofs.
+        """
+        if not isinstance(artifact, Artifact):
+            raise TypeError("artifact must be an Artifact instance.")
+        if self.db is None:
+            raise RuntimeError(
+                "Cannot register artifact recovery copy: tracker has no database configured."
+            )
+
+        recovery_root_path = Path(recovery_root).resolve()
+        artifact_id = str(artifact.id) if artifact.id is not None else ""
+
+        def _result(
+            status: str,
+            *,
+            expected_path: Path | None = None,
+            message: str | None = None,
+            metadata_updated: bool = False,
+        ) -> ArtifactRecoveryCopyRegistration:
+            return ArtifactRecoveryCopyRegistration(
+                artifact=artifact,
+                key=artifact.key,
+                artifact_id=artifact_id,
+                recovery_root=recovery_root_path,
+                expected_path=expected_path,
+                status=cast(RecoveryCopyStatus, status),
+                message=message,
+                metadata_updated=metadata_updated,
+            )
+
+        relative_path = self.fs.get_remappable_relative_path(artifact.container_uri)
+        if relative_path is None:
+            return _result(
+                "skipped_unmapped",
+                message=(
+                    f"Artifact {artifact.key!r} does not have a rematerializable URI "
+                    "layout. Absolute-path and file:// artifacts cannot be adopted "
+                    "from root-only recovery metadata."
+                ),
+            )
+
+        expected_path = recovery_root_path / relative_path
+        expected_path_resolved = expected_path.resolve()
+        if expected_path.is_symlink():
+            return _result(
+                "symlink_destination",
+                expected_path=expected_path_resolved,
+                message=(
+                    "Symlink detected in recovery destination: "
+                    f"{expected_path_resolved}"
+                ),
+            )
+        if not expected_path.exists():
+            return _result(
+                "missing_copy",
+                expected_path=expected_path_resolved,
+                message=f"Expected recovery copy does not exist: {expected_path_resolved}",
+            )
+        if expected_path.is_dir():
+            return _result(
+                "unsupported_directory",
+                expected_path=expected_path_resolved,
+                message=(
+                    "Directory recovery-copy adoption is not supported yet; use "
+                    "archive_artifact(...) or wait for directory manifest support."
+                ),
+            )
+        if not expected_path.is_file():
+            return _result(
+                "failed",
+                expected_path=expected_path_resolved,
+                message=(
+                    "Expected recovery copy is not a regular file: "
+                    f"{expected_path_resolved}"
+                ),
+            )
+
+        expected_hashes: list[tuple[str, str]] = []
+        if content_hash:
+            expected_hashes.append(("content_hash", content_hash))
+        elif artifact.hash and self.identity.hashing_strategy == "full":
+            expected_hashes.append(("artifact.hash", artifact.hash))
+
+        if verify and not expected_hashes:
+            return _result(
+                "unverifiable_hash",
+                expected_path=expected_path_resolved,
+                message=(
+                    "Verification requested, but no full file hash is available. "
+                    "Pass content_hash=<sha256> or use verify=False to register "
+                    "the existing copy without byte verification."
+                ),
+            )
+
+        if verify and expected_hashes:
+            try:
+                actual_hash = _compute_file_sha256(expected_path_resolved)
+            except Exception as exc:
+                return _result(
+                    "failed",
+                    expected_path=expected_path_resolved,
+                    message=(
+                        f"Could not hash recovery copy {expected_path_resolved}: {exc}"
+                    ),
+                )
+            mismatches = [
+                label
+                for label, expected_hash in expected_hashes
+                if actual_hash != expected_hash
+            ]
+            if mismatches:
+                return _result(
+                    "hash_mismatch",
+                    expected_path=expected_path_resolved,
+                    message=(
+                        "Recovery copy hash did not match "
+                        f"{', '.join(mismatches)} for artifact {artifact.key!r}."
+                    ),
+                )
+
+        try:
+            self.set_artifact_recovery_roots(
+                artifact, [recovery_root_path], append=append
+            )
+        except Exception as exc:
+            return _result(
+                "failed",
+                expected_path=expected_path_resolved,
+                message=f"Could not update recovery_roots metadata: {exc}",
+            )
+
+        return _result(
+            "registered",
+            expected_path=expected_path_resolved,
+            message="Recovery copy verified and registered.",
+            metadata_updated=True,
+        )
+
+    def register_run_output_recovery_copies(
+        self,
+        run_id: str,
+        recovery_root: str | os.PathLike[str],
+        *,
+        keys: Sequence[str] | None = None,
+        verify: bool = True,
+        append: bool = True,
+        content_hashes: Mapping[str, str] | None = None,
+    ) -> RunOutputRecoveryCopiesRegistration:
+        """
+        Verify and record externally copied recovery locations for run outputs.
+
+        Unknown requested output keys raise immediately. Per-artifact blockers
+        such as missing files or hash mismatches are returned in the keyed
+        result without aborting the rest of the requested outputs.
+        """
+        normalized_keys = normalize_materialize_output_keys(
+            keys,
+            caller="register_run_output_recovery_copies",
+        )
+        outputs = self.get_run_outputs(run_id)
+        if normalized_keys is not None:
+            missing = [key for key in normalized_keys if key not in outputs]
+            if missing:
+                raise KeyError(
+                    "Requested output keys were not found for run "
+                    f"{run_id!r}: {', '.join(repr(key) for key in missing)}"
+                )
+            selected = {key: outputs[key] for key in normalized_keys}
+        else:
+            selected = outputs
+
+        if content_hashes is not None:
+            unknown_hash_keys = [key for key in content_hashes if key not in selected]
+            if unknown_hash_keys:
+                raise KeyError(
+                    "content_hashes contained keys that were not selected for run "
+                    f"{run_id!r}: {', '.join(repr(key) for key in unknown_hash_keys)}"
+                )
+
+        registered: dict[str, ArtifactRecoveryCopyRegistration] = {}
+        for key, artifact in selected.items():
+            registered[key] = self.register_artifact_recovery_copy(
+                artifact,
+                recovery_root,
+                verify=verify,
+                content_hash=content_hashes.get(key) if content_hashes else None,
+                append=append,
+            )
+        return RunOutputRecoveryCopiesRegistration(outputs=registered)
 
     def archive_run_outputs(
         self,

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -1107,6 +1107,11 @@ class Tracker:
         precedence when supplied. Without it, ``artifact.hash`` is only used for
         byte verification when this tracker is using full content hashing; fast
         metadata hashes are not byte-equivalence proofs.
+
+        ``append`` defaults to True so verified adoption behaves like
+        ``archive_artifact(...)``: the newly verified root is added to existing
+        recovery metadata. Use ``append=False`` to replace existing recovery
+        roots, matching ``set_artifact_recovery_roots(...)`` replace semantics.
         """
         if not isinstance(artifact, Artifact):
             raise TypeError("artifact must be an Artifact instance.")
@@ -1119,7 +1124,7 @@ class Tracker:
         artifact_id = str(artifact.id) if artifact.id is not None else ""
 
         def _result(
-            status: str,
+            status: RecoveryCopyStatus,
             *,
             expected_path: Path | None = None,
             message: str | None = None,
@@ -1131,7 +1136,7 @@ class Tracker:
                 artifact_id=artifact_id,
                 recovery_root=recovery_root_path,
                 expected_path=expected_path,
-                status=cast(RecoveryCopyStatus, status),
+                status=status,
                 message=message,
                 metadata_updated=metadata_updated,
             )
@@ -1184,7 +1189,7 @@ class Tracker:
             )
 
         expected_hashes: list[tuple[str, str]] = []
-        if content_hash:
+        if content_hash is not None:
             expected_hashes.append(("content_hash", content_hash))
         elif artifact.hash and self.identity.hashing_strategy == "full":
             expected_hashes.append(("artifact.hash", artifact.hash))
@@ -1260,6 +1265,11 @@ class Tracker:
         Unknown requested output keys raise immediately. Per-artifact blockers
         such as missing files or hash mismatches are returned in the keyed
         result without aborting the rest of the requested outputs.
+
+        ``append`` defaults to True so verified adoption behaves like
+        ``archive_run_outputs(...)``: the newly verified root is added to
+        existing recovery metadata. Use ``append=False`` to replace existing
+        recovery roots.
         """
         normalized_keys = normalize_materialize_output_keys(
             keys,

--- a/tests/unit/api/test_public_exports.py
+++ b/tests/unit/api/test_public_exports.py
@@ -1,18 +1,30 @@
 from consist import (
+    ArtifactRecoveryCopyRegistration,
     HydratedRunOutput,
     HydratedRunOutputsResult,
     MaterializationResult,
+    RunOutputRecoveryCopiesRegistration,
     StagedInput,
     StagedInputsResult,
+    register_artifact_recovery_copy,
+    register_run_output_recovery_copies,
     stage_artifact,
     stage_inputs,
+)
+from consist.api import (
+    register_artifact_recovery_copy as register_artifact_recovery_copy_api,
+)
+from consist.api import (
+    register_run_output_recovery_copies as register_run_output_recovery_copies_api,
 )
 from consist.api import stage_artifact as stage_artifact_api
 from consist.api import stage_inputs as stage_inputs_api
 from consist.core.materialize import (
+    ArtifactRecoveryCopyRegistration as CoreArtifactRecoveryCopyRegistration,
     HydratedRunOutput as CoreHydratedRunOutput,
     HydratedRunOutputsResult as CoreHydratedRunOutputsResult,
     MaterializationResult as CoreMaterializationResult,
+    RunOutputRecoveryCopiesRegistration as CoreRunOutputRecoveryCopiesRegistration,
     StagedInput as CoreStagedInput,
     StagedInputsResult as CoreStagedInputsResult,
 )
@@ -25,6 +37,13 @@ def test_materialization_result_is_exported_from_top_level() -> None:
 def test_hydrated_run_output_types_are_exported_from_top_level() -> None:
     assert HydratedRunOutput is CoreHydratedRunOutput
     assert HydratedRunOutputsResult is CoreHydratedRunOutputsResult
+
+
+def test_recovery_copy_types_and_helpers_are_exported_from_top_level() -> None:
+    assert ArtifactRecoveryCopyRegistration is CoreArtifactRecoveryCopyRegistration
+    assert RunOutputRecoveryCopiesRegistration is CoreRunOutputRecoveryCopiesRegistration
+    assert register_artifact_recovery_copy is register_artifact_recovery_copy_api
+    assert register_run_output_recovery_copies is register_run_output_recovery_copies_api
 
 
 def test_staged_input_types_and_helpers_are_exported_from_top_level() -> None:

--- a/tests/unit/api/test_public_exports.py
+++ b/tests/unit/api/test_public_exports.py
@@ -41,9 +41,13 @@ def test_hydrated_run_output_types_are_exported_from_top_level() -> None:
 
 def test_recovery_copy_types_and_helpers_are_exported_from_top_level() -> None:
     assert ArtifactRecoveryCopyRegistration is CoreArtifactRecoveryCopyRegistration
-    assert RunOutputRecoveryCopiesRegistration is CoreRunOutputRecoveryCopiesRegistration
+    assert (
+        RunOutputRecoveryCopiesRegistration is CoreRunOutputRecoveryCopiesRegistration
+    )
     assert register_artifact_recovery_copy is register_artifact_recovery_copy_api
-    assert register_run_output_recovery_copies is register_run_output_recovery_copies_api
+    assert (
+        register_run_output_recovery_copies is register_run_output_recovery_copies_api
+    )
 
 
 def test_staged_input_types_and_helpers_are_exported_from_top_level() -> None:

--- a/tests/unit/api/test_run_materialize_outputs_api.py
+++ b/tests/unit/api/test_run_materialize_outputs_api.py
@@ -831,7 +831,9 @@ def test_api_register_artifact_recovery_copy_delegates_with_default_tracker(
     expected = object()
 
     class _FakeTracker:
-        def register_artifact_recovery_copy(self, artifact_arg, recovery_root, **kwargs):
+        def register_artifact_recovery_copy(
+            self, artifact_arg, recovery_root, **kwargs
+        ):
             calls["artifact"] = artifact_arg
             calls["recovery_root"] = recovery_root
             calls["kwargs"] = kwargs
@@ -859,7 +861,9 @@ def test_api_register_artifact_recovery_copy_delegates_with_default_tracker(
             "append": False,
         },
     }
-    assert consist.register_artifact_recovery_copy is register_artifact_recovery_copy_api
+    assert (
+        consist.register_artifact_recovery_copy is register_artifact_recovery_copy_api
+    )
 
 
 def test_api_register_run_output_recovery_copies_delegates_with_default_tracker(

--- a/tests/unit/api/test_run_materialize_outputs_api.py
+++ b/tests/unit/api/test_run_materialize_outputs_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import os
 from pathlib import Path
 import uuid
 
@@ -12,6 +14,12 @@ from consist.api import materialize_run_outputs as materialize_run_outputs_api
 from consist.api import archive_artifact as archive_artifact_api
 from consist.api import archive_current_run_outputs as archive_current_run_outputs_api
 from consist.api import archive_run_outputs as archive_run_outputs_api
+from consist.api import (
+    register_artifact_recovery_copy as register_artifact_recovery_copy_api,
+)
+from consist.api import (
+    register_run_output_recovery_copies as register_run_output_recovery_copies_api,
+)
 from consist.api import set_artifact_recovery_roots as set_artifact_recovery_roots_api
 from consist.core.tracker import Tracker
 from consist.models.artifact import Artifact
@@ -302,6 +310,251 @@ def test_archive_artifact_copies_bytes_and_records_recovery_root(
     assert refreshed.meta["recovery_roots"] == [str(archive_root.resolve())]
 
 
+def test_register_artifact_recovery_copy_verifies_existing_file_without_copying(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    output_path = tracker.run_dir / "outputs" / "adopted.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("value\n1\n", encoding="utf-8")
+    recovery_root = tmp_path / "external_archive"
+
+    with tracker.start_run("producer_adopt_copy", model="producer"):
+        artifact = tracker.log_artifact(output_path, key="adopted", direction="output")
+
+    expected_path = recovery_root / "outputs" / "adopted.csv"
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    expected_path.write_text("value\n1\n", encoding="utf-8")
+
+    result = register_artifact_recovery_copy_api(
+        artifact,
+        recovery_root,
+        tracker=tracker,
+    )
+
+    assert result.status == "registered"
+    assert result.expected_path == expected_path.resolve()
+    assert result.metadata_updated is True
+    assert output_path.exists()
+    refreshed = tracker.get_run_outputs("producer_adopt_copy")["adopted"]
+    assert refreshed.recovery_roots == [str(recovery_root.resolve())]
+
+
+def test_register_artifact_recovery_copy_missing_file_blocks_metadata_update(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    output_path = tracker.run_dir / "outputs" / "missing_archive.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("value\n1\n", encoding="utf-8")
+    recovery_root = tmp_path / "external_archive_missing"
+
+    with tracker.start_run("producer_adopt_missing", model="producer"):
+        artifact = tracker.log_artifact(
+            output_path, key="missing_archive", direction="output"
+        )
+
+    result = tracker.register_artifact_recovery_copy(artifact, recovery_root)
+
+    assert result.status == "missing_copy"
+    assert result.metadata_updated is False
+    refreshed = tracker.get_run_outputs("producer_adopt_missing")["missing_archive"]
+    assert "recovery_roots" not in refreshed.meta
+
+
+def test_register_artifact_recovery_copy_hash_mismatch_blocks_metadata_update(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    output_path = tracker.run_dir / "outputs" / "mismatch.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("value\n1\n", encoding="utf-8")
+    recovery_root = tmp_path / "external_archive_mismatch"
+
+    with tracker.start_run("producer_adopt_mismatch", model="producer"):
+        artifact = tracker.log_artifact(output_path, key="mismatch", direction="output")
+
+    expected_path = recovery_root / "outputs" / "mismatch.csv"
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    expected_path.write_text("value\n999\n", encoding="utf-8")
+
+    result = tracker.register_artifact_recovery_copy(artifact, recovery_root)
+
+    assert result.status == "hash_mismatch"
+    assert result.metadata_updated is False
+    refreshed = tracker.get_run_outputs("producer_adopt_mismatch")["mismatch"]
+    assert "recovery_roots" not in refreshed.meta
+
+
+def test_register_artifact_recovery_copy_uses_full_hash_when_tracker_is_fast(
+    tmp_path: Path,
+) -> None:
+    tracker = Tracker(
+        run_dir=tmp_path / "runs_fast",
+        db_path=str(tmp_path / "fast.duckdb"),
+        hashing_strategy="fast",
+    )
+    try:
+        output_path = tracker.run_dir / "outputs" / "fast_hash.csv"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_text = "value\n1\n"
+        output_path.write_text(output_text, encoding="utf-8")
+        recovery_root = tmp_path / "external_archive_fast"
+
+        with tracker.start_run("producer_adopt_fast", model="producer"):
+            artifact = tracker.log_artifact(
+                output_path, key="fast_hash", direction="output"
+            )
+
+        expected_path = recovery_root / "outputs" / "fast_hash.csv"
+        expected_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_path.write_text(output_text, encoding="utf-8")
+        content_hash = hashlib.sha256(output_text.encode("utf-8")).hexdigest()
+
+        result = tracker.register_artifact_recovery_copy(
+            artifact,
+            recovery_root,
+            content_hash=content_hash,
+        )
+
+        assert result.status == "registered"
+        refreshed = tracker.get_run_outputs("producer_adopt_fast")["fast_hash"]
+        assert refreshed.recovery_roots == [str(recovery_root.resolve())]
+    finally:
+        if tracker.engine:
+            tracker.engine.dispose()
+
+
+def test_register_artifact_recovery_copy_fast_hash_requires_byte_hash(
+    tmp_path: Path,
+) -> None:
+    tracker = Tracker(
+        run_dir=tmp_path / "runs_fast_unverifiable",
+        db_path=str(tmp_path / "fast_unverifiable.duckdb"),
+        hashing_strategy="fast",
+    )
+    try:
+        output_path = tracker.run_dir / "outputs" / "fast_unverifiable.csv"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("value\n1\n", encoding="utf-8")
+        recovery_root = tmp_path / "external_archive_fast_unverifiable"
+
+        with tracker.start_run("producer_adopt_fast_unverifiable", model="producer"):
+            artifact = tracker.log_artifact(
+                output_path, key="fast_unverifiable", direction="output"
+            )
+
+        expected_path = recovery_root / "outputs" / "fast_unverifiable.csv"
+        expected_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_path.write_text("value\n1\n", encoding="utf-8")
+
+        result = tracker.register_artifact_recovery_copy(artifact, recovery_root)
+
+        assert result.status == "unverifiable_hash"
+        assert result.metadata_updated is False
+        refreshed = tracker.get_run_outputs("producer_adopt_fast_unverifiable")[
+            "fast_unverifiable"
+        ]
+        assert "recovery_roots" not in refreshed.meta
+    finally:
+        if tracker.engine:
+            tracker.engine.dispose()
+
+
+def test_register_artifact_recovery_copy_rejects_same_metadata_wrong_bytes(
+    tmp_path: Path,
+) -> None:
+    tracker = Tracker(
+        run_dir=tmp_path / "runs_fast_same_metadata",
+        db_path=str(tmp_path / "fast_same_metadata.duckdb"),
+        hashing_strategy="fast",
+    )
+    try:
+        output_path = tracker.run_dir / "outputs" / "same_metadata.csv"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_text = "value\n1\n"
+        output_path.write_text(output_text, encoding="utf-8")
+        recovery_root = tmp_path / "external_archive_same_metadata"
+
+        with tracker.start_run("producer_adopt_same_metadata", model="producer"):
+            artifact = tracker.log_artifact(
+                output_path, key="same_metadata", direction="output"
+            )
+
+        expected_path = recovery_root / "outputs" / "same_metadata.csv"
+        expected_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_path.write_text("value\n9\n", encoding="utf-8")
+        source_stat = output_path.stat()
+        os.utime(
+            expected_path,
+            ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+        )
+        content_hash = hashlib.sha256(output_text.encode("utf-8")).hexdigest()
+
+        result = tracker.register_artifact_recovery_copy(
+            artifact,
+            recovery_root,
+            content_hash=content_hash,
+        )
+
+        assert result.status == "hash_mismatch"
+        assert result.metadata_updated is False
+        refreshed = tracker.get_run_outputs("producer_adopt_same_metadata")[
+            "same_metadata"
+        ]
+        assert "recovery_roots" not in refreshed.meta
+    finally:
+        if tracker.engine:
+            tracker.engine.dispose()
+
+
+def test_register_artifact_recovery_copy_unmappable_layout_blocks_clearly(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    artifact = Artifact(
+        id=uuid.uuid4(),
+        key="absolute",
+        container_uri=str((tmp_path / "absolute.csv").resolve()),
+        driver="csv",
+        meta={},
+    )
+
+    result = tracker.register_artifact_recovery_copy(
+        artifact,
+        tmp_path / "external_archive_unmappable",
+    )
+
+    assert result.status == "skipped_unmapped"
+    assert result.expected_path is None
+    assert "root-only recovery metadata" in str(result.message)
+    assert result.metadata_updated is False
+
+
+def test_register_artifact_recovery_copy_symlink_destination_blocks_metadata_update(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    output_path = tracker.run_dir / "outputs" / "symlink.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("value\n1\n", encoding="utf-8")
+    recovery_root = tmp_path / "external_archive_symlink"
+
+    with tracker.start_run("producer_adopt_symlink", model="producer"):
+        artifact = tracker.log_artifact(output_path, key="symlink", direction="output")
+
+    expected_path = recovery_root / "outputs" / "symlink.csv"
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    expected_path.symlink_to(output_path)
+
+    result = tracker.register_artifact_recovery_copy(artifact, recovery_root)
+
+    assert result.status == "symlink_destination"
+    assert result.metadata_updated is False
+    refreshed = tracker.get_run_outputs("producer_adopt_symlink")["symlink"]
+    assert "recovery_roots" not in refreshed.meta
+
+
 def test_archive_artifact_unmappable_layout_has_actionable_error(
     tracker: Tracker,
     tmp_path: Path,
@@ -493,6 +746,163 @@ def test_archive_run_outputs_archives_selected_keys(
     outputs = tracker.get_run_outputs("producer_archive_bulk")
     assert outputs["a"].meta["recovery_roots"] == [str(archive_root.resolve())]
     assert "recovery_roots" not in outputs["b"].meta
+
+
+def test_register_run_output_recovery_copies_reports_mixed_statuses_and_unknown_keys(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    a_path = tracker.run_dir / "outputs" / "bulk_a.csv"
+    b_path = tracker.run_dir / "outputs" / "bulk_b.csv"
+    a_path.parent.mkdir(parents=True, exist_ok=True)
+    a_path.write_text("value\n1\n", encoding="utf-8")
+    b_path.write_text("value\n2\n", encoding="utf-8")
+    recovery_root = tmp_path / "external_archive_bulk"
+
+    with tracker.start_run("producer_adopt_bulk", model="producer"):
+        tracker.log_artifact(a_path, key="a", direction="output")
+        tracker.log_artifact(b_path, key="b", direction="output")
+
+    expected_a = recovery_root / "outputs" / "bulk_a.csv"
+    expected_a.parent.mkdir(parents=True, exist_ok=True)
+    expected_a.write_text("value\n1\n", encoding="utf-8")
+
+    result = register_run_output_recovery_copies_api(
+        "producer_adopt_bulk",
+        recovery_root,
+        keys=["a", "b"],
+        tracker=tracker,
+    )
+
+    assert result["a"].status == "registered"
+    assert result["b"].status == "missing_copy"
+    assert result.complete is False
+    assert result.summary == (
+        "registered=1 missing_copy=1 hash_mismatch=0 skipped_unmapped=0 "
+        "symlink_destination=0 unsupported_directory=0 unverifiable_hash=0 failed=0"
+    )
+    outputs = tracker.get_run_outputs("producer_adopt_bulk")
+    assert outputs["a"].recovery_roots == [str(recovery_root.resolve())]
+    assert "recovery_roots" not in outputs["b"].meta
+
+    with pytest.raises(KeyError, match="Requested output keys were not found"):
+        tracker.register_run_output_recovery_copies(
+            "producer_adopt_bulk",
+            recovery_root,
+            keys=["missing"],
+        )
+
+
+def test_register_run_output_recovery_copies_rejects_hashes_outside_selected_keys(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    a_path = tracker.run_dir / "outputs" / "selected_a.csv"
+    b_path = tracker.run_dir / "outputs" / "selected_b.csv"
+    a_path.parent.mkdir(parents=True, exist_ok=True)
+    a_path.write_text("value\n1\n", encoding="utf-8")
+    b_path.write_text("value\n2\n", encoding="utf-8")
+    recovery_root = tmp_path / "external_archive_selected"
+
+    with tracker.start_run("producer_adopt_selected", model="producer"):
+        tracker.log_artifact(a_path, key="a", direction="output")
+        tracker.log_artifact(b_path, key="b", direction="output")
+
+    with pytest.raises(KeyError, match="content_hashes contained keys"):
+        tracker.register_run_output_recovery_copies(
+            "producer_adopt_selected",
+            recovery_root,
+            keys=["a"],
+            content_hashes={"b": "unused"},
+        )
+
+
+def test_api_register_artifact_recovery_copy_delegates_with_default_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = Artifact(
+        id=uuid.uuid4(),
+        key="x",
+        container_uri="./x.csv",
+        driver="csv",
+        meta={},
+    )
+    calls: dict[str, object] = {}
+    expected = object()
+
+    class _FakeTracker:
+        def register_artifact_recovery_copy(self, artifact_arg, recovery_root, **kwargs):
+            calls["artifact"] = artifact_arg
+            calls["recovery_root"] = recovery_root
+            calls["kwargs"] = kwargs
+            return expected
+
+    monkeypatch.setattr(
+        "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
+    )
+
+    result = register_artifact_recovery_copy_api(
+        artifact,
+        "/tmp/recovery",
+        verify=False,
+        content_hash="abc",
+        append=False,
+    )
+
+    assert result is expected
+    assert calls == {
+        "artifact": artifact,
+        "recovery_root": "/tmp/recovery",
+        "kwargs": {
+            "verify": False,
+            "content_hash": "abc",
+            "append": False,
+        },
+    }
+    assert consist.register_artifact_recovery_copy is register_artifact_recovery_copy_api
+
+
+def test_api_register_run_output_recovery_copies_delegates_with_default_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+    expected = object()
+
+    class _FakeTracker:
+        def register_run_output_recovery_copies(self, run_id, recovery_root, **kwargs):
+            calls["run_id"] = run_id
+            calls["recovery_root"] = recovery_root
+            calls["kwargs"] = kwargs
+            return expected
+
+    monkeypatch.setattr(
+        "consist.api._resolve_tracker", lambda tracker=None: _FakeTracker()
+    )
+
+    result = register_run_output_recovery_copies_api(
+        "run_1",
+        "/tmp/recovery",
+        keys=("a",),
+        verify=False,
+        append=False,
+        content_hashes={"a": "abc"},
+    )
+
+    assert result is expected
+    assert calls == {
+        "run_id": "run_1",
+        "recovery_root": "/tmp/recovery",
+        "kwargs": {
+            "keys": ("a",),
+            "verify": False,
+            "append": False,
+            "content_hashes": {"a": "abc"},
+        },
+    }
+    assert (
+        consist.register_run_output_recovery_copies
+        is register_run_output_recovery_copies_api
+    )
 
 
 def test_api_archive_current_run_outputs_delegates_with_default_tracker(

--- a/tests/unit/api/test_run_materialize_outputs_api.py
+++ b/tests/unit/api/test_run_materialize_outputs_api.py
@@ -451,6 +451,7 @@ def test_register_artifact_recovery_copy_fast_hash_requires_byte_hash(
         result = tracker.register_artifact_recovery_copy(artifact, recovery_root)
 
         assert result.status == "unverifiable_hash"
+        assert result.expected_path == expected_path.resolve()
         assert result.metadata_updated is False
         refreshed = tracker.get_run_outputs("producer_adopt_fast_unverifiable")[
             "fast_unverifiable"
@@ -459,6 +460,78 @@ def test_register_artifact_recovery_copy_fast_hash_requires_byte_hash(
     finally:
         if tracker.engine:
             tracker.engine.dispose()
+
+
+def test_register_artifact_recovery_copy_verify_false_adopts_existing_copy(
+    tmp_path: Path,
+) -> None:
+    tracker = Tracker(
+        run_dir=tmp_path / "runs_verify_false",
+        db_path=str(tmp_path / "verify_false.duckdb"),
+        hashing_strategy="fast",
+    )
+    try:
+        output_path = tracker.run_dir / "outputs" / "verify_false.csv"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("value\n1\n", encoding="utf-8")
+        recovery_root = tmp_path / "external_archive_verify_false"
+
+        with tracker.start_run("producer_adopt_verify_false", model="producer"):
+            artifact = tracker.log_artifact(
+                output_path, key="verify_false", direction="output"
+            )
+
+        expected_path = recovery_root / "outputs" / "verify_false.csv"
+        expected_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_path.write_text("different bytes\n", encoding="utf-8")
+
+        result = tracker.register_artifact_recovery_copy(
+            artifact,
+            recovery_root,
+            verify=False,
+        )
+
+        assert result.status == "registered"
+        assert result.expected_path == expected_path.resolve()
+        assert result.metadata_updated is True
+        refreshed = tracker.get_run_outputs("producer_adopt_verify_false")[
+            "verify_false"
+        ]
+        assert refreshed.recovery_roots == [str(recovery_root.resolve())]
+    finally:
+        if tracker.engine:
+            tracker.engine.dispose()
+
+
+def test_register_artifact_recovery_copy_empty_content_hash_is_explicit(
+    tracker: Tracker,
+    tmp_path: Path,
+) -> None:
+    output_path = tracker.run_dir / "outputs" / "empty_hash.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("value\n1\n", encoding="utf-8")
+    recovery_root = tmp_path / "external_archive_empty_hash"
+
+    with tracker.start_run("producer_adopt_empty_hash", model="producer"):
+        artifact = tracker.log_artifact(
+            output_path, key="empty_hash", direction="output"
+        )
+
+    expected_path = recovery_root / "outputs" / "empty_hash.csv"
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    expected_path.write_text("value\n1\n", encoding="utf-8")
+
+    result = tracker.register_artifact_recovery_copy(
+        artifact,
+        recovery_root,
+        content_hash="",
+    )
+
+    assert result.status == "hash_mismatch"
+    assert result.expected_path == expected_path.resolve()
+    assert result.metadata_updated is False
+    refreshed = tracker.get_run_outputs("producer_adopt_empty_hash")["empty_hash"]
+    assert "recovery_roots" not in refreshed.meta
 
 
 def test_register_artifact_recovery_copy_rejects_same_metadata_wrong_bytes(


### PR DESCRIPTION
## Summary

Adds verified recovery-root adoption for artifacts that were copied by external infrastructure rather than by Consist.

This introduces a safer middle ground between:

- `archive_artifact(...)`, where Consist performs the copy/move
- `set_artifact_recovery_roots(...)`, which records metadata without verification

New APIs:

- `Tracker.register_artifact_recovery_copy(...)`
- `Tracker.register_run_output_recovery_copies(...)`
- top-level `consist.register_artifact_recovery_copy(...)`
- top-level `consist.register_run_output_recovery_copies(...)`

## Details

The new helpers expect archive-side bytes to already exist at:

```python
recovery_root / <artifact-uri-relative-path>
```

For each artifact, Consist verifies the existing file before updating `artifact.meta["recovery_roots"]`.

The implementation is intentionally conservative:

- supports regular files only
- blocks directory artifacts until directory manifest semantics exist
- blocks symlink destinations
- returns structured per-artifact statuses instead of mutating metadata on failure
- raises immediately for unknown requested run-output keys
- validates `content_hashes` only against selected bulk keys

Verification uses full file SHA-256 for byte checks. `content_hash` is treated as an explicit full SHA-256 and takes precedence. If no byte-level hash is available, verified registration returns `unverifiable_hash` and leaves metadata unchanged.

## Docs

Updates API docs and the historical recovery guide to distinguish:

- copying bytes with `archive_artifact(...)`
- verified adoption with `register_artifact_recovery_copy(...)`
- metadata-only overrides with `set_artifact_recovery_roots(...)`
