### PR TITLE
Structured config adapter identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## Unreleased
+
+### Added
+
+- Add structured config identity manifests for adapter-backed runs. This is a
+  breaking adapter API change: custom `ConfigAdapter.canonicalize(...)`
+  implementations must now return `CanonicalizationResult(..., identity=...)`.
+  The in-repo ActivitySim and BEAM adapters have been migrated.
+- Add manifest-first cache-miss details for adapter-backed config identity,
+  including changed, added, and removed config references/files, reference
+  status changes, and adapter identity option drift.
+- Add BEAM config reference policies and path alias normalization so run-local
+  config roots can be represented as stable logical references. Broader
+  container mount/directory input de-duplication remains a follow-up outside the
+  config-adapter contract.
+
 ## [0.1.2] - 2026-04-14
 
 ### Added

--- a/docs/api/run.md
+++ b/docs/api/run.md
@@ -99,6 +99,14 @@ The payload is intentionally compact:
   input keys, code-identity drift, or `fallbacks_used` when the explainer had
   to lean on fallback data.
 
+For adapter-backed runs, config miss details prefer
+`run.meta["config_identity_manifest"]` when both the current run and comparison
+candidate have one. That manifest-first path can report
+`config_references_changed` / `added` / `removed`,
+`config_files_changed` / `added` / `removed`, `reference_status_changed`, and
+`config_identity_options_changed`. Older or non-adapter runs still fall back to
+indexed config facets first and then the persisted JSON config snapshot.
+
 ::: consist.models.run.Run
     options:
       show_source: false

--- a/docs/integrations/config_adapters.md
+++ b/docs/integrations/config_adapters.md
@@ -26,12 +26,25 @@ CanonicalConfig
     ↓
 canonicalize()       ← Generate artifact specs + ingest specs
     ↓
-CanonicalizationResult (artifacts + ingestables)
+CanonicalizationResult (identity + artifacts + ingestables)
     ↓
 tracker.canonicalize_config()  ← Log artifacts, ingest to DB
     ↓
 Queryable Tables + Full Provenance
 ```
+
+Adapter-backed runs also persist `run.meta["config_identity_manifest"]`, a
+structured manifest of the adapter identity inputs. This is part of the adapter
+contract: custom adapters must return `CanonicalizationResult(..., identity=...)`.
+Cache-miss explanations use that manifest before falling back to facets or JSON
+snapshots, so config misses can point to changed, added, or removed config
+references and files, reference status changes such as `missing_optional` to
+`resolved`, and changed adapter identity options.
+
+Config identity is still separate from runtime materialization. If a container
+mounts a broad mutable directory whose meaningful children are already declared
+as artifacts, that directory de-duplication belongs to the container/input
+identity layer rather than the config adapter manifest.
 
 ---
 

--- a/docs/integrations/config_adapters_beam.md
+++ b/docs/integrations/config_adapters_beam.md
@@ -170,6 +170,38 @@ with Session(tracker.engine) as session:
 - `resolve_substitutions=True` resolves HOCON substitutions; set to False to keep raw expressions.
 - `env_overrides` supplies environment variables for optional substitutions (e.g., `${?BEAM_OUTPUT}`).
 - `strict=True` raises on missing referenced files; otherwise missing paths are logged as warnings.
+- Canonicalization returns a structured `CanonicalConfigIdentity` manifest.
+  Path-like config values are recorded as keyed `ConfigReference` entries with
+  their dotted BEAM config key, canonical value, status, role, and identity
+  policy.
+- Reference identity policies are:
+  - `content_hash` for resolved file inputs.
+  - `path_alias` for aliased or logical input roots such as
+    `beam.inputDirectory`.
+  - `delegated_to_artifacts` for directories whose content identity is handled
+    by logged input artifacts instead of hashing the whole directory in the
+    config manifest.
+  - `ignored` for explicitly dormant or non-identity references configured via
+    `BeamReferencePolicy`.
+  - `output_or_runtime_ignored` for output/runtime locations that should not
+    make equivalent runs miss cache.
+
+Path aliases can be supplied on the adapter or per call:
+
+```python
+from consist.core.config_canonicalization import ConfigAdapterOptions
+
+tracker.canonicalize_config(
+    adapter,
+    [config_root],
+    options=ConfigAdapterOptions(
+        path_aliases={"beam_workspace": Path("/local/job123/workspace")}
+    ),
+)
+```
+
+Missing-reference warnings include the config key, status, policy, canonical
+value, and raw value. Use `strict=True` to make missing required references fail.
 
 ## Materialize Overrides
 

--- a/docs/integrations/config_adapters_beam.md
+++ b/docs/integrations/config_adapters_beam.md
@@ -171,9 +171,17 @@ with Session(tracker.engine) as session:
 - `env_overrides` supplies environment variables for optional substitutions (e.g., `${?BEAM_OUTPUT}`).
 - `strict=True` raises on missing referenced files; otherwise missing paths are logged as warnings.
 - Canonicalization returns a structured `CanonicalConfigIdentity` manifest.
-  Path-like config values are recorded as keyed `ConfigReference` entries with
-  their dotted BEAM config key, canonical value, status, role, and identity
-  policy.
+  Reference discovery is value-first: scalar strings become keyed
+  `ConfigReference` entries when the value itself looks like a path, resolves
+  under a config root, or the exact config key has an explicit
+  `BeamReferencePolicy`. Generic key-name scanning is disabled by default so
+  enum/control settings such as `fileFormat = "parquet"` and
+  `overwriteFiles = "overwriteExistingFiles"` remain ordinary scalar config
+  identity.
+- `BeamConfigAdapter(allow_heuristic_refs=True)` or
+  `ConfigAdapterOptions(allow_heuristic_refs=True)` re-enables key-suffix
+  discovery for legacy configs with bare filename values, but explicit
+  `reference_policies` are preferred for ambiguous scenario-specific settings.
 - Reference identity policies are:
   - `content_hash` for resolved file inputs.
   - `path_alias` for aliased or logical input roots such as
@@ -185,6 +193,29 @@ with Session(tracker.engine) as session:
     `BeamReferencePolicy`.
   - `output_or_runtime_ignored` for output/runtime locations that should not
     make equivalent runs miss cache.
+
+For ambiguous bare scalar values, configure a key-specific policy instead of
+relying on key-name inference:
+
+```python
+from consist.integrations.beam import BeamReferencePolicy
+
+adapter = BeamConfigAdapter(
+    primary_config=config_root / "sfbay-pilates-base.conf",
+    reference_policies={
+        "beam.agentsim.optionalExamplePath": BeamReferencePolicy(
+            identity_policy="ignored",
+            required=False,
+            reason="dormant_example_config",
+        ),
+        "beam.router.skim.activity-sim-skimmer.fileBaseName": BeamReferencePolicy(
+            identity_policy="output_or_runtime_ignored",
+            required=False,
+            reason="runtime_output_prefix",
+        ),
+    },
+)
+```
 
 Path aliases can be supplied on the adapter or per call:
 

--- a/src/consist/core/cache_miss_explainer.py
+++ b/src/consist/core/cache_miss_explainer.py
@@ -646,6 +646,222 @@ def _config_facet_diff(
     return diff, has_payload
 
 
+def _config_identity_manifest(run: Run) -> dict[str, Any]:
+    value = _get_run_meta_value(run, "config_identity_manifest")
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _manifest_list_entries(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    entries: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            entries.append(dict(item))
+        elif isinstance(item, str):
+            entries.append({"path": item})
+    return entries
+
+
+def _manifest_entry_label(
+    entry: Mapping[str, Any],
+    fields: Sequence[str],
+) -> Optional[str]:
+    for field_name in fields:
+        value = entry.get(field_name)
+        if value is None:
+            continue
+        label = str(value)
+        if label:
+            return label
+    return None
+
+
+def _manifest_entry_map(
+    entries: Sequence[Mapping[str, Any]],
+    *,
+    label_fields: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    mapped: dict[str, dict[str, Any]] = {}
+    for index, entry in enumerate(entries):
+        label = _manifest_entry_label(entry, label_fields)
+        if label is None:
+            label = f"entry_{index}"
+        mapped[label] = dict(entry)
+    return mapped
+
+
+def _without_keys(payload: Mapping[str, Any], keys: set[str]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if key not in keys}
+
+
+def _manifest_entry_diff(
+    current: Mapping[str, Mapping[str, Any]],
+    prior: Mapping[str, Mapping[str, Any]],
+    *,
+    ignore_changed_fields: set[str] | None = None,
+) -> dict[str, list[str]]:
+    ignored = ignore_changed_fields or set()
+    current_keys = set(current)
+    prior_keys = set(prior)
+    changed = sorted(
+        key
+        for key in current_keys & prior_keys
+        if _without_keys(current[key], ignored) != _without_keys(prior[key], ignored)
+    )
+    added = sorted(current_keys - prior_keys)
+    removed = sorted(prior_keys - current_keys)
+    diff: dict[str, list[str]] = {}
+    if changed:
+        diff["changed"] = changed
+    if added:
+        diff["added"] = added
+    if removed:
+        diff["removed"] = removed
+    return diff
+
+
+def _manifest_reference_map(manifest: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    return _manifest_entry_map(
+        _manifest_list_entries(manifest.get("references")),
+        label_fields=("config_key", "key", "canonical_value", "raw_value", "role"),
+    )
+
+
+def _manifest_config_file_entries(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    primary_config = manifest.get("primary_config")
+    if isinstance(primary_config, str) and primary_config:
+        entries.append({"path": primary_config, "role": "primary_config"})
+
+    explicit_entries: list[dict[str, Any]] = []
+    for key in ("config_files", "files"):
+        explicit_entries.extend(_manifest_list_entries(manifest.get(key)))
+    scalars = manifest.get("scalars")
+    if isinstance(scalars, Mapping):
+        explicit_entries.extend(_manifest_list_entries(scalars.get("files")))
+
+    if explicit_entries:
+        entries.extend(explicit_entries)
+        return entries
+
+    entries.extend(_manifest_list_entries(manifest.get("directories")))
+    return entries
+
+
+def _manifest_config_file_map(
+    manifest: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    return _manifest_entry_map(
+        _manifest_config_file_entries(manifest),
+        label_fields=("path", "canonical_value", "config_key", "key", "raw_value"),
+    )
+
+
+def _manifest_option_map(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    for key in (
+        "config_identity_options",
+        "identity_options",
+        "adapter_options",
+        "options",
+    ):
+        options = manifest.get(key)
+        if isinstance(options, Mapping):
+            return _flatten_config_payload(options)
+    scalars = manifest.get("scalars")
+    if isinstance(scalars, Mapping):
+        for key in ("options", "config_identity_options", "identity_options"):
+            options = scalars.get(key)
+            if isinstance(options, Mapping):
+                return _flatten_config_payload(options)
+    return {}
+
+
+def _changed_manifest_option_labels(
+    current: Mapping[str, Any],
+    prior: Mapping[str, Any],
+) -> list[str]:
+    diff = _changed_keys(current, prior)
+    labels = set()
+    for values in diff.values():
+        labels.update(values)
+    return sorted(labels)
+
+
+def _reference_status_changes(
+    current: Mapping[str, Mapping[str, Any]],
+    prior: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for key in sorted(set(current) & set(prior)):
+        current_status = current[key].get("status")
+        prior_status = prior[key].get("status")
+        if current_status == prior_status:
+            continue
+        if current_status is None and prior_status is None:
+            continue
+        changes.append(
+            {
+                "reference": key,
+                "candidate": prior_status,
+                "current": current_status,
+            }
+        )
+    return changes
+
+
+def _config_manifest_diff(run: Run, candidate: Run) -> dict[str, Any]:
+    current_manifest = _config_identity_manifest(run)
+    prior_manifest = _config_identity_manifest(candidate)
+    if not current_manifest or not prior_manifest:
+        return {}
+
+    details: dict[str, Any] = {}
+
+    current_references = _manifest_reference_map(current_manifest)
+    prior_references = _manifest_reference_map(prior_manifest)
+    reference_diff = _manifest_entry_diff(
+        current_references,
+        prior_references,
+        ignore_changed_fields={"status"},
+    )
+    for output_key, diff_key in (
+        ("config_references_changed", "changed"),
+        ("config_references_added", "added"),
+        ("config_references_removed", "removed"),
+    ):
+        values = reference_diff.get(diff_key)
+        if values:
+            details[output_key] = values
+
+    status_changes = _reference_status_changes(current_references, prior_references)
+    if status_changes:
+        details["reference_status_changed"] = status_changes
+
+    current_files = _manifest_config_file_map(current_manifest)
+    prior_files = _manifest_config_file_map(prior_manifest)
+    file_diff = _manifest_entry_diff(current_files, prior_files)
+    for output_key, diff_key in (
+        ("config_files_changed", "changed"),
+        ("config_files_added", "added"),
+        ("config_files_removed", "removed"),
+    ):
+        values = file_diff.get(diff_key)
+        if values:
+            details[output_key] = values
+
+    option_changes = _changed_manifest_option_labels(
+        _manifest_option_map(current_manifest),
+        _manifest_option_map(prior_manifest),
+    )
+    if option_changes:
+        details["config_identity_options_changed"] = option_changes
+
+    return details
+
+
 def _build_config_details(
     tracker: CacheMissExplainerContext,
     run: Run,
@@ -660,6 +876,11 @@ def _build_config_details(
     changed_adapter_identity = _changed_adapter_identity(run, candidate)
     if changed_adapter_identity:
         details["adapter_identity_changed"] = changed_adapter_identity
+
+    manifest_diff = _config_manifest_diff(run, candidate)
+    if manifest_diff:
+        details.update(manifest_diff)
+        return details
 
     facet_diff, has_facet_payload = _config_facet_diff(tracker, run, candidate)
     if facet_diff:

--- a/src/consist/core/config_canonicalization.py
+++ b/src/consist/core/config_canonicalization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -32,7 +34,6 @@ ConfigReferenceStatus = Literal[
     "missing_required",
     "missing_optional",
     "missing_ignored",
-    "unresolved_expression",
 ]
 ConfigReferenceIdentityPolicy = Literal[
     "content_hash",
@@ -54,6 +55,17 @@ def _json_safe(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]
     return value
+
+
+def _canonical_json_sha256(payload: Any) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 class CanonicalConfig(NamedTuple):
@@ -249,6 +261,14 @@ class CanonicalConfigIdentity:
                 for diagnostic in self.diagnostics
             ],
         }
+        scalars = data["scalars"]
+        if isinstance(scalars, Mapping):
+            files = scalars.get("files")
+            if files not in (None, [], ()):
+                data["files"] = _json_safe(files)
+            options = scalars.get("options")
+            if options not in (None, {}, []):
+                data["options"] = _json_safe(options)
         return {
             key: value for key, value in data.items() if value not in (None, {}, [], ())
         }

--- a/src/consist/core/config_canonicalization.py
+++ b/src/consist/core/config_canonicalization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import (
     Any,
@@ -27,6 +27,33 @@ from consist.types import IdentityInputs
 
 RowFactory = Callable[[str], Iterable[dict[str, Any]]]
 RowSource = Union[Iterable[dict[str, Any]], RowFactory]
+ConfigReferenceStatus = Literal[
+    "resolved",
+    "missing_required",
+    "missing_optional",
+    "missing_ignored",
+    "unresolved_expression",
+]
+ConfigReferenceIdentityPolicy = Literal[
+    "content_hash",
+    "directory_hash",
+    "fingerprint_manifest",
+    "path_alias",
+    "delegated_to_artifacts",
+    "scalar_value",
+    "ignored",
+    "output_or_runtime_ignored",
+]
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
 
 
 class CanonicalConfig(NamedTuple):
@@ -97,6 +124,153 @@ class ConfigAdapterOptions:
     bundle: bool = True
     ingest: bool = True
     allow_heuristic_refs: bool = True
+    path_aliases: Optional[Mapping[str, Union[str, Path]]] = None
+
+
+@dataclass(frozen=True)
+class ConfigPathAlias:
+    alias: str
+    path: Union[str, Path]
+    role: Optional[str] = None
+
+    def to_meta_dict(self) -> dict[str, Any]:
+        return {
+            "alias": self.alias,
+            "path": _json_safe(self.path),
+            "role": self.role,
+        }
+
+
+@dataclass(frozen=True)
+class ConfigReference:
+    config_key: Optional[str]
+    raw_value: str
+    canonical_value: Optional[str]
+    status: ConfigReferenceStatus
+    required: bool
+    role: Optional[str] = None
+    identity_policy: ConfigReferenceIdentityPolicy = "content_hash"
+    reason: Optional[str] = None
+    hash: Optional[str] = None
+    delegated_artifact_keys: tuple[str, ...] = ()
+
+    def to_meta_dict(self) -> dict[str, Any]:
+        data = {
+            "config_key": self.config_key,
+            "raw_value": self.raw_value,
+            "canonical_value": self.canonical_value,
+            "status": self.status,
+            "required": self.required,
+            "role": self.role,
+            "identity_policy": self.identity_policy,
+            "reason": self.reason,
+            "hash": self.hash,
+            "delegated_artifact_keys": list(self.delegated_artifact_keys),
+        }
+        return {key: value for key, value in data.items() if value not in (None, [])}
+
+
+@dataclass(frozen=True)
+class DirectoryIdentity:
+    canonical_value: str
+    role: Optional[str]
+    identity_policy: str
+    hash_strategy: Optional[str] = None
+    hash: Optional[str] = None
+
+    def to_meta_dict(self) -> dict[str, Any]:
+        data = {
+            "canonical_value": self.canonical_value,
+            "role": self.role,
+            "identity_policy": self.identity_policy,
+            "hash_strategy": self.hash_strategy,
+            "hash": self.hash,
+        }
+        return {key: value for key, value in data.items() if value is not None}
+
+
+@dataclass(frozen=True)
+class MaterializationRequirement:
+    canonical_value: str
+    required: bool
+    role: Optional[str] = None
+    reason: Optional[str] = None
+
+    def to_meta_dict(self) -> dict[str, Any]:
+        data = {
+            "canonical_value": self.canonical_value,
+            "required": self.required,
+            "role": self.role,
+            "reason": self.reason,
+        }
+        return {key: value for key, value in data.items() if value is not None}
+
+
+@dataclass(frozen=True)
+class CanonicalConfigIdentity:
+    adapter_name: str
+    adapter_version: Optional[str]
+    primary_config: Optional[str]
+    identity_hash: str
+    identity_schema_version: int = 1
+    scalar_hash: Optional[str] = None
+    reference_hash: Optional[str] = None
+    directory_hash: Optional[str] = None
+    scalars: Mapping[str, Any] = field(default_factory=dict)
+    references: tuple[ConfigReference, ...] = ()
+    directories: tuple[DirectoryIdentity, ...] = ()
+    materialization_requirements: tuple[MaterializationRequirement, ...] = ()
+    diagnostics: tuple[ConfigDiagnostic, ...] = ()
+
+    def to_meta_dict(self) -> dict[str, Any]:
+        data = {
+            "identity_schema_version": self.identity_schema_version,
+            "adapter_name": self.adapter_name,
+            "adapter_version": self.adapter_version,
+            "primary_config": self.primary_config,
+            "identity_hash": self.identity_hash,
+            "scalar_hash": self.scalar_hash,
+            "reference_hash": self.reference_hash,
+            "directory_hash": self.directory_hash,
+            "scalars": _json_safe(dict(self.scalars)),
+            "references": [ref.to_meta_dict() for ref in self.references],
+            "directories": [item.to_meta_dict() for item in self.directories],
+            "materialization_requirements": [
+                item.to_meta_dict() for item in self.materialization_requirements
+            ],
+            "diagnostics": [
+                {
+                    "message": diagnostic.message,
+                    "table_name": diagnostic.table_name,
+                    "source_path": _json_safe(diagnostic.source_path),
+                    "artifact_key": diagnostic.artifact_key,
+                    "exception_type": diagnostic.exception_type,
+                }
+                for diagnostic in self.diagnostics
+            ],
+        }
+        return {
+            key: value for key, value in data.items() if value not in (None, {}, [], ())
+        }
+
+
+def canonical_identity_from_config(
+    *,
+    adapter_name: str,
+    adapter_version: Optional[str],
+    config: CanonicalConfig,
+    identity_hash: Optional[str] = None,
+) -> CanonicalConfigIdentity:
+    return CanonicalConfigIdentity(
+        adapter_name=adapter_name,
+        adapter_version=adapter_version,
+        primary_config=(
+            config.primary_config.as_posix()
+            if config.primary_config is not None
+            else None
+        ),
+        identity_hash=identity_hash or config.content_hash,
+    )
 
 
 @dataclass(frozen=True)
@@ -200,10 +374,13 @@ class CanonicalizationResult(NamedTuple):
         Artifacts discovered for logging.
     ingestables : list[IngestSpec]
         Table ingestion specs for queryable config slices.
+    identity : CanonicalConfigIdentity
+        Structured adapter identity manifest.
     """
 
     artifacts: list[ArtifactSpec]
     ingestables: list[IngestSpec]
+    identity: CanonicalConfigIdentity
 
 
 class _IngestableDataFrameMixin:
@@ -257,8 +434,8 @@ class ConfigContribution(_IngestableDataFrameMixin):
 
     Attributes
     ----------
-    identity_hash : str
-        Hash that identifies the canonical config state.
+    identity : CanonicalConfigIdentity
+        Structured adapter identity manifest.
     adapter_version : Optional[str]
         Adapter version used to generate the contribution.
     artifacts : list[ArtifactSpec]
@@ -275,7 +452,7 @@ class ConfigContribution(_IngestableDataFrameMixin):
         Optional metadata for the contribution.
     """
 
-    identity_hash: str
+    identity: CanonicalConfigIdentity
     adapter_version: Optional[str]
     artifacts: list[ArtifactSpec]
     ingestables: list[IngestSpec]
@@ -283,6 +460,10 @@ class ConfigContribution(_IngestableDataFrameMixin):
     facet_schema_name: Optional[str] = None
     facet_schema_version: Optional[Union[str, int]] = None
     meta: Optional[dict[str, Any]] = None
+
+    @property
+    def identity_hash(self) -> str:
+        return self.identity.identity_hash
 
 
 @dataclass(frozen=True)
@@ -302,6 +483,8 @@ class ConfigPlan(_IngestableDataFrameMixin):
         Artifact specs to log at apply time.
     ingestables : list[IngestSpec]
         Ingest specs to apply at apply time.
+    identity : CanonicalConfigIdentity
+        Structured adapter identity manifest.
     facet : Optional[dict[str, Any]]
         Optional facet data derived from the config plan.
     facet_schema_name : Optional[str]
@@ -323,6 +506,7 @@ class ConfigPlan(_IngestableDataFrameMixin):
     canonical: CanonicalConfig
     artifacts: list[ArtifactSpec]
     ingestables: list[IngestSpec]
+    identity: CanonicalConfigIdentity
     facet: Optional[dict[str, Any]] = None
     facet_schema_name: Optional[str] = None
     facet_schema_version: Optional[Union[str, int]] = None
@@ -333,7 +517,7 @@ class ConfigPlan(_IngestableDataFrameMixin):
 
     @property
     def identity_hash(self) -> str:
-        return self.canonical.content_hash
+        return self.identity.identity_hash
 
     @property
     def signature(self) -> str:
@@ -492,6 +676,13 @@ def validate_config_plan(
 
 __all__ = [
     "CanonicalConfig",
+    "CanonicalConfigIdentity",
+    "ConfigPathAlias",
+    "ConfigReference",
+    "ConfigReferenceStatus",
+    "ConfigReferenceIdentityPolicy",
+    "DirectoryIdentity",
+    "MaterializationRequirement",
     "ArtifactSpec",
     "ConfigAdapterOptions",
     "ConfigDiagnostic",
@@ -504,6 +695,7 @@ __all__ = [
     "SupportsRunWithConfigOverrides",
     "RowFactory",
     "RowSource",
+    "canonical_identity_from_config",
     "compute_config_pack_hash",
     "validate_config_plan",
 ]

--- a/src/consist/core/config_canonicalization.py
+++ b/src/consist/core/config_canonicalization.py
@@ -128,14 +128,15 @@ class ConfigAdapterOptions:
         Whether to bundle configs when the adapter supports it.
     ingest : bool
         Whether to ingest queryable slices after canonicalization.
-    allow_heuristic_refs : bool
-        Whether adapters should scan heuristic keys for references.
+    allow_heuristic_refs : Optional[bool]
+        Whether adapters should scan heuristic keys for references. ``None``
+        means use the adapter's constructor default.
     """
 
     strict: bool = False
     bundle: bool = True
     ingest: bool = True
-    allow_heuristic_refs: bool = True
+    allow_heuristic_refs: Optional[bool] = None
     path_aliases: Optional[Mapping[str, Union[str, Path]]] = None
 
 

--- a/src/consist/core/tracker_config_plans.py
+++ b/src/consist/core/tracker_config_plans.py
@@ -47,6 +47,22 @@ def _quote_ident(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
+def _persist_config_identity_meta(
+    run: Run,
+    *,
+    adapter_name: str,
+    adapter_version: Optional[str],
+    contribution: ConfigContribution,
+) -> None:
+    if run.meta is None:
+        run.meta = {}
+    run.meta["config_bundle_hash"] = contribution.identity_hash
+    run.meta["config_adapter"] = adapter_name
+    if adapter_version is not None:
+        run.meta["config_adapter_version"] = adapter_version
+    run.meta["config_identity_manifest"] = contribution.identity.to_meta_dict()
+
+
 class TrackerConfigPlanService(_TrackerServiceBase):
     """
     Config planning and apply-time helpers extracted from ``Tracker``.
@@ -103,7 +119,7 @@ class TrackerConfigPlanService(_TrackerServiceBase):
             adapter, "canonicalize"
         ):
             kwargs["options"] = options
-        return adapter.canonicalize(
+        result = adapter.canonicalize(
             canonical,
             run=run,
             tracker=tracker,
@@ -111,6 +127,16 @@ class TrackerConfigPlanService(_TrackerServiceBase):
             plan_only=plan_only,
             **kwargs,
         )
+        if not result.identity.identity_hash:
+            raise ValueError(
+                "ConfigAdapter.canonicalize() returned an empty identity_hash."
+            )
+        if result.identity.adapter_name != adapter.model_name:
+            raise ValueError(
+                "ConfigAdapter.canonicalize() returned identity for "
+                f"{result.identity.adapter_name!r}, expected {adapter.model_name!r}."
+            )
+        return result
 
     def canonicalize_config(
         self,
@@ -160,7 +186,7 @@ class TrackerConfigPlanService(_TrackerServiceBase):
         )
 
         contribution = ConfigContribution(
-            identity_hash=canonical.content_hash,
+            identity=result.identity,
             adapter_version=getattr(adapter, "adapter_version", None),
             artifacts=result.artifacts,
             ingestables=result.ingestables,
@@ -177,12 +203,12 @@ class TrackerConfigPlanService(_TrackerServiceBase):
             profile_schema=profile_schema,
         )
 
-        if target_run.meta is None:
-            target_run.meta = {}
-        target_run.meta["config_bundle_hash"] = canonical.content_hash
-        target_run.meta["config_adapter"] = adapter.model_name
-        if contribution.adapter_version is not None:
-            target_run.meta["config_adapter_version"] = contribution.adapter_version
+        _persist_config_identity_meta(
+            target_run,
+            adapter_name=adapter.model_name,
+            adapter_version=contribution.adapter_version,
+            contribution=contribution,
+        )
 
         return contribution
 
@@ -231,6 +257,7 @@ class TrackerConfigPlanService(_TrackerServiceBase):
             canonical=canonical,
             artifacts=result.artifacts,
             ingestables=result.ingestables,
+            identity=result.identity,
             facet=facet_data,
             facet_schema_name=facet_schema_name,
             facet_schema_version=facet_schema_version,
@@ -362,7 +389,7 @@ class TrackerConfigPlanService(_TrackerServiceBase):
                     artifacts.append(bundle_spec)
 
         contribution = ConfigContribution(
-            identity_hash=plan.identity_hash,
+            identity=plan.identity,
             adapter_version=plan.adapter_version,
             artifacts=artifacts,
             ingestables=plan.ingestables,
@@ -379,12 +406,12 @@ class TrackerConfigPlanService(_TrackerServiceBase):
             profile_schema=profile_schema,
         )
 
-        if target_run.meta is None:
-            target_run.meta = {}
-        target_run.meta["config_bundle_hash"] = plan.identity_hash
-        target_run.meta["config_adapter"] = plan.adapter_name
-        if plan.adapter_version is not None:
-            target_run.meta["config_adapter_version"] = plan.adapter_version
+        _persist_config_identity_meta(
+            target_run,
+            adapter_name=plan.adapter_name,
+            adapter_version=plan.adapter_version,
+            contribution=contribution,
+        )
 
         if plan.facet is not None:
             facet_dict = plan.facet

--- a/src/consist/core/tracker_orchestration.py
+++ b/src/consist/core/tracker_orchestration.py
@@ -1012,7 +1012,7 @@ class RunTraceCoordinator:
             )
 
         output_base_dir = tracker.run_artifact_dir()
-        resolved_output_paths = {
+        resolved_output_paths: Dict[str, Union[str, Path]] = {
             str(key): self._helpers.resolve_output_path(tracker, ref, output_base_dir)
             for key, ref in output_paths.items()
         }

--- a/src/consist/integrations/activitysim/config_adapter.py
+++ b/src/consist/integrations/activitysim/config_adapter.py
@@ -442,7 +442,7 @@ class ActivitySimConfigAdapter:
         resolved_strict = options.strict if options is not None else strict
         allow_heuristics = (
             options.allow_heuristic_refs
-            if options is not None
+            if options is not None and options.allow_heuristic_refs is not None
             else self.allow_heuristic_refs
         )
         bundle_configs = options.bundle if options is not None else self.bundle_configs

--- a/src/consist/integrations/activitysim/config_adapter.py
+++ b/src/consist/integrations/activitysim/config_adapter.py
@@ -37,6 +37,7 @@ from consist.core.config_canonicalization import (
     ConfigReference,
     DirectoryIdentity,
     IngestSpec,
+    _canonical_json_sha256,
     compute_config_pack_hash,
 )
 from consist.core.identity import IdentityManager
@@ -90,17 +91,6 @@ try:
     import yaml
 except ImportError:  # pragma: no cover - optional dependency
     yaml = None
-
-
-def _canonical_json_sha256(payload: Any) -> str:
-    encoded = json.dumps(
-        payload,
-        sort_keys=True,
-        ensure_ascii=True,
-        separators=(",", ":"),
-        default=str,
-    )
-    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 _REFERENCE_KEYS = {

--- a/src/consist/integrations/activitysim/config_adapter.py
+++ b/src/consist/integrations/activitysim/config_adapter.py
@@ -31,8 +31,11 @@ from sqlmodel import SQLModel, col
 from consist.core.config_canonicalization import (
     ArtifactSpec,
     CanonicalConfig,
+    CanonicalConfigIdentity,
     CanonicalizationResult,
     ConfigAdapterOptions,
+    ConfigReference,
+    DirectoryIdentity,
     IngestSpec,
     compute_config_pack_hash,
 )
@@ -87,6 +90,17 @@ try:
     import yaml
 except ImportError:  # pragma: no cover - optional dependency
     yaml = None
+
+
+def _canonical_json_sha256(payload: Any) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 _REFERENCE_KEYS = {
@@ -478,9 +492,30 @@ class ActivitySimConfigAdapter:
             allow_heuristics=allow_heuristics,
             strict=resolved_strict,
             allow_out_of_root_refs=self.allow_out_of_root_csv_refs,
+            allow_out_of_root_yaml_includes=self.allow_out_of_root_yaml_includes,
         )
         for csv_path in referenced:
             add_artifact(csv_path, role="csv")
+
+        identity = _build_activitysim_config_identity(
+            adapter_name=self.model_name,
+            adapter_version=self.adapter_version,
+            config=config,
+            inherit_settings=inherit_settings,
+            referenced_csvs=referenced,
+            options={
+                "allow_heuristic_refs": allow_heuristics,
+                "allow_out_of_root_yaml_includes": (
+                    self.allow_out_of_root_yaml_includes
+                ),
+                "allow_out_of_root_csv_refs": self.allow_out_of_root_csv_refs,
+            },
+            runtime_options={
+                "bundle_configs": bundle_configs,
+                "check_probabilities": self.check_probabilities,
+                "strict": resolved_strict,
+            },
+        )
 
         if bundle_configs and not plan_only:
             if run is None or tracker is None:
@@ -489,11 +524,11 @@ class ActivitySimConfigAdapter:
                 config_dirs=config.root_dirs,
                 run=run,
                 tracker=tracker,
-                content_hash=config.content_hash,
+                content_hash=identity.identity_hash,
                 cache_dir=self.bundle_cache_dir,
             )
             add_artifact(bundle_path, role="bundle")
-            artifacts_by_path[bundle_path].meta["content_hash"] = config.content_hash
+            artifacts_by_path[bundle_path].meta["content_hash"] = identity.identity_hash
 
         artifacts = list(artifacts_by_path.values())
 
@@ -503,7 +538,7 @@ class ActivitySimConfigAdapter:
 
         if config.primary_config:
             source_key = _artifact_key_for_path(config.primary_config, config.root_dirs)
-            file_hash = config.content_hash
+            file_hash = identity.identity_hash
 
             def rows_factory(
                 run_id: str,
@@ -561,7 +596,11 @@ class ActivitySimConfigAdapter:
                     )
                     break
 
-        return CanonicalizationResult(artifacts=artifacts, ingestables=ingestables)
+        return CanonicalizationResult(
+            artifacts=artifacts,
+            ingestables=ingestables,
+            identity=identity,
+        )
 
     def _build_probabilities_ingest_specs(
         self,
@@ -2089,11 +2128,17 @@ def _collect_referenced_csvs(
     allow_heuristics: bool,
     strict: bool,
     allow_out_of_root_refs: bool,
+    allow_out_of_root_yaml_includes: bool = False,
 ) -> list[Path]:
     referenced: list[Path] = []
     seen: Set[Path] = set()
     for path in yaml_paths:
-        data = _load_effective_yaml(path.name, config_dirs, inherit_settings)
+        data = _load_effective_yaml(
+            path.name,
+            config_dirs,
+            inherit_settings,
+            allow_out_of_root_includes=allow_out_of_root_yaml_includes,
+        )
         for ref in sorted(
             _collect_reference_values(data, allow_heuristics=allow_heuristics)
         ):
@@ -2609,6 +2654,244 @@ def _digest_path_with_name(path: Path, tracker: Optional["Tracker"]) -> str:
     digest.update(b":")
     digest.update(content_hash.encode("utf-8"))
     return digest.hexdigest()
+
+
+def _build_activitysim_config_identity(
+    *,
+    adapter_name: str,
+    adapter_version: Optional[str],
+    config: CanonicalConfig,
+    inherit_settings: bool,
+    referenced_csvs: Sequence[Path],
+    options: Mapping[str, Any],
+    runtime_options: Mapping[str, Any],
+) -> CanonicalConfigIdentity:
+    file_entries: list[dict[str, Any]] = []
+    references: list[ConfigReference] = []
+
+    def add_file(path: Path, *, role: str) -> None:
+        key = _logical_config_key(path, config.root_dirs)
+        digest = _file_sha256(path)
+        root_index = _config_root_index(path, config.root_dirs)
+        entry = {"key": key, "role": role, "hash": digest}
+        if root_index is not None:
+            entry["root_index"] = root_index
+        file_entries.append(entry)
+        references.append(
+            ConfigReference(
+                config_key=key,
+                raw_value=path.name,
+                canonical_value=key,
+                status="resolved",
+                required=True,
+                role=role,
+                identity_policy="content_hash",
+                hash=digest,
+            )
+        )
+
+    active_yamls = _collect_active_yaml_files(
+        config,
+        inherit_settings=inherit_settings,
+        allow_out_of_root_includes=bool(options.get("allow_out_of_root_yaml_includes")),
+    )
+    for yaml_path in active_yamls:
+        add_file(yaml_path, role="yaml")
+    for csv_path in referenced_csvs:
+        add_file(csv_path, role="csv")
+
+    file_entries = sorted(file_entries, key=lambda item: (item["role"], item["key"]))
+    options_payload = dict(sorted(options.items()))
+    runtime_options_payload = dict(sorted(runtime_options.items()))
+    yaml_entries = [item for item in file_entries if item["role"] == "yaml"]
+    csv_entries = [item for item in file_entries if item["role"] == "csv"]
+    component_hashes = {
+        "active_yaml_hash": _canonical_json_sha256({"files": yaml_entries}),
+        "referenced_csv_hash": _canonical_json_sha256({"files": csv_entries}),
+    }
+    files_hash = _canonical_json_sha256({"files": file_entries})
+    options_hash = _canonical_json_sha256({"options": options_payload})
+    directory_entries = _build_directory_identity_entries(
+        file_entries=file_entries,
+        root_dirs=config.root_dirs,
+    )
+    directory_hash = _canonical_json_sha256({"directories": directory_entries})
+    primary_config = (
+        _logical_config_key(config.primary_config, config.root_dirs)
+        if config.primary_config is not None
+        else None
+    )
+    identity_hash = _canonical_json_sha256(
+        {
+            "identity_schema_version": 1,
+            "adapter_name": adapter_name,
+            "adapter_version": adapter_version,
+            "primary_config": primary_config,
+            "files_hash": files_hash,
+            "options_hash": options_hash,
+            "directory_hash": directory_hash,
+        }
+    )
+    return CanonicalConfigIdentity(
+        adapter_name=adapter_name,
+        adapter_version=adapter_version,
+        primary_config=primary_config,
+        identity_hash=identity_hash,
+        scalar_hash=options_hash,
+        reference_hash=files_hash,
+        directory_hash=directory_hash,
+        scalars={
+            "options": options_payload,
+            "runtime_options": runtime_options_payload,
+            "component_hashes": component_hashes,
+            "roles": {
+                "yaml": [item["key"] for item in yaml_entries],
+                "csv": [item["key"] for item in csv_entries],
+            },
+            "files": file_entries,
+        },
+        references=tuple(
+            sorted(
+                references,
+                key=lambda ref: (ref.role or "", ref.canonical_value or ""),
+            )
+        ),
+        directories=tuple(
+            DirectoryIdentity(
+                canonical_value=item["canonical_value"],
+                role=item["role"],
+                identity_policy=item["identity_policy"],
+                hash_strategy=item["hash_strategy"],
+                hash=item["hash"],
+            )
+            for item in directory_entries
+        ),
+    )
+
+
+def _config_root_index(path: Path, config_dirs: Sequence[Path]) -> int | None:
+    resolved = path.resolve()
+    for index, config_dir in enumerate(config_dirs):
+        root = config_dir.resolve()
+        if resolved.is_relative_to(root):
+            return index
+    return None
+
+
+def _logical_config_key(path: Path, config_dirs: Sequence[Path]) -> str:
+    resolved = path.resolve()
+    for index, config_dir in enumerate(config_dirs):
+        root = config_dir.resolve()
+        if resolved.is_relative_to(root):
+            return f"root:{index}:{resolved.relative_to(root).as_posix()}"
+    return f"external:{resolved.name}"
+
+
+def _collect_active_yaml_files(
+    config: CanonicalConfig,
+    *,
+    inherit_settings: bool,
+    allow_out_of_root_includes: bool,
+) -> list[Path]:
+    active: list[Path] = []
+    seen: set[Path] = set()
+
+    def add_with_includes(path: Path) -> None:
+        resolved = path.resolve()
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        active.append(resolved)
+        data = _load_yaml(resolved)
+        include_settings = data.get("include_settings")
+        if isinstance(include_settings, str):
+            include_names = [include_settings]
+        elif isinstance(include_settings, list):
+            include_names = [str(item) for item in include_settings]
+        else:
+            include_names = []
+        for include_name in include_names:
+            include_path = _resolve_yaml_path(
+                include_name,
+                config.root_dirs,
+                base_dir=resolved.parent,
+                allow_out_of_root=allow_out_of_root_includes,
+            )
+            if include_path is not None:
+                add_with_includes(include_path)
+
+    names: list[str] = []
+    for yaml_path in config.config_files:
+        if yaml_path.name not in names:
+            names.append(yaml_path.name)
+
+    if inherit_settings:
+        for name in names:
+            found_in_roots = False
+            for root_dir in config.root_dirs:
+                path = (root_dir / name).resolve()
+                if path.exists() and (
+                    allow_out_of_root_includes
+                    or _is_within_roots(path, config.root_dirs)
+                ):
+                    found_in_roots = True
+                    add_with_includes(path)
+            if not found_in_roots:
+                for yaml_path in config.config_files:
+                    if yaml_path.name == name and yaml_path.exists():
+                        add_with_includes(yaml_path)
+    else:
+        for yaml_path in config.config_files:
+            add_with_includes(yaml_path)
+    return active
+
+
+def _build_directory_identity_entries(
+    *,
+    file_entries: Sequence[Mapping[str, Any]],
+    root_dirs: Sequence[Path],
+) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for index, _root_dir in enumerate(root_dirs):
+        root_files = [
+            {
+                "key": item["key"],
+                "role": item["role"],
+                "hash": item["hash"],
+            }
+            for item in file_entries
+            if item.get("root_index") == index
+        ]
+        root_hash = _canonical_json_sha256({"root_index": index, "files": root_files})
+        entries.append(
+            {
+                "canonical_value": f"root:{index}",
+                "role": "config_root",
+                "identity_policy": "fingerprint_manifest",
+                "hash_strategy": "active-files",
+                "hash": root_hash,
+            }
+        )
+    external_files = [
+        {
+            "key": item["key"],
+            "role": item["role"],
+            "hash": item["hash"],
+        }
+        for item in file_entries
+        if item.get("root_index") is None
+    ]
+    if external_files:
+        entries.append(
+            {
+                "canonical_value": "external",
+                "role": "external_config_files",
+                "identity_policy": "fingerprint_manifest",
+                "hash_strategy": "active-files",
+                "hash": _canonical_json_sha256({"files": external_files}),
+            }
+        )
+    return entries
 
 
 def _file_sha256(path: Path) -> str:

--- a/src/consist/integrations/beam/__init__.py
+++ b/src/consist/integrations/beam/__init__.py
@@ -4,6 +4,12 @@ from consist.integrations.beam.config_adapter import (
     BeamConfigAdapter,
     BeamConfigOverrides,
     BeamIngestSpec,
+    BeamReferencePolicy,
 )
 
-__all__ = ["BeamConfigAdapter", "BeamConfigOverrides", "BeamIngestSpec"]
+__all__ = [
+    "BeamConfigAdapter",
+    "BeamConfigOverrides",
+    "BeamIngestSpec",
+    "BeamReferencePolicy",
+]

--- a/src/consist/integrations/beam/config_adapter.py
+++ b/src/consist/integrations/beam/config_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import hashlib
 import json
 import logging
 import re
@@ -14,8 +15,11 @@ from sqlmodel import SQLModel
 from consist.core.config_canonicalization import (
     ArtifactSpec,
     CanonicalConfig,
+    CanonicalConfigIdentity,
     CanonicalizationResult,
     ConfigAdapterOptions,
+    ConfigReference,
+    DirectoryIdentity,
     IngestSpec,
 )
 from consist.core.config_canonicalization import ConfigPlan
@@ -79,6 +83,22 @@ class BeamConfigOverrides:
         return {"values": self.values}
 
 
+@dataclass(frozen=True)
+class BeamReferencePolicy:
+    identity_policy: str
+    role: Optional[str] = None
+    required: bool = True
+    reason: Optional[str] = None
+    delegated_artifact_keys: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _BeamPathCandidate:
+    config_key: str
+    raw_value: str
+    index: int = 0
+
+
 @dataclass
 class BeamConfigAdapter:
     model_name: str = "beam"
@@ -88,6 +108,10 @@ class BeamConfigAdapter:
     resolve_substitutions: bool = True
     env_overrides: Optional[dict[str, str]] = None
     ingest_specs: list[BeamIngestSpec] = field(default_factory=list)
+    path_aliases: Optional[dict[str, str | Path]] = None
+    reference_policies: dict[str, BeamReferencePolicy | dict[str, Any]] = field(
+        default_factory=dict
+    )
 
     def discover(
         self,
@@ -153,29 +177,73 @@ class BeamConfigAdapter:
             resolve=self.resolve_substitutions,
             env_overrides=self.env_overrides,
         )
-        referenced_paths = _collect_path_references(config_tree)
-        for value in referenced_paths:
-            resolved = _resolve_reference(value, config.root_dirs)
+        path_aliases = _merge_path_aliases(
+            self.path_aliases,
+            options.path_aliases if options is not None else None,
+        )
+        reference_identity = _build_beam_config_identity(
+            adapter_name=self.model_name,
+            adapter_version=self.adapter_version,
+            primary_config=config.primary_config,
+            config_tree=config_tree,
+            root_dirs=config.root_dirs,
+            path_aliases=path_aliases,
+            reference_policies=self.reference_policies,
+            allow_heuristic_refs=(
+                options.allow_heuristic_refs if options is not None else True
+            ),
+            tracker=tracker,
+        )
+        canonical_config_tree = _canonicalize_config_tree_paths(
+            config_tree,
+            references=reference_identity.references,
+        )
+        for ref in reference_identity.references:
+            if ref.status.startswith("missing"):
+                if ref.status != "missing_ignored":
+                    logging.warning(
+                        "[Consist][BEAM] Missing referenced path for config key %s "
+                        "(status=%s, policy=%s, canonical=%s): %s. "
+                        "If this is a run-local or machine-local path, pass "
+                        "ConfigAdapterOptions(path_aliases=...).",
+                        ref.config_key or "<unknown>",
+                        ref.status,
+                        ref.identity_policy,
+                        ref.canonical_value,
+                        ref.raw_value,
+                    )
+                if resolved_strict and ref.status == "missing_required":
+                    raise FileNotFoundError(
+                        f"{ref.config_key or '<unknown>'}: {ref.raw_value}"
+                    )
+                continue
+            if ref.identity_policy in {"ignored", "output_or_runtime_ignored"}:
+                continue
+            resolved = _resolve_reference(ref.raw_value, config.root_dirs)
             if resolved is None or not resolved.exists():
-                logging.warning("[Consist][BEAM] Missing referenced path: %s", value)
-                if resolved_strict:
-                    raise FileNotFoundError(value)
                 continue
             _add_artifact(
                 artifacts_by_path,
                 resolved,
                 config.root_dirs,
                 role="ref",
-                meta={"config_reference": value},
+                meta={
+                    "config_reference": ref.raw_value,
+                    "config_reference_key": ref.config_key,
+                    "config_reference_policy": ref.identity_policy,
+                },
             )
 
-        rows = _iter_config_rows(config_tree, content_hash=config.content_hash)
+        rows = _iter_config_rows(
+            canonical_config_tree,
+            content_hash=reference_identity.identity_hash,
+        )
         if plan_only:
             # Return a fresh iterator each time the plan is materialized.
             def rows_factory(
                 run_id: str,
-                tree: dict[str, Any] = config_tree,
-                h: str = config.content_hash,
+                tree: dict[str, Any] = canonical_config_tree,
+                h: str = reference_identity.identity_hash,
             ) -> Iterable[dict[str, Any]]:
                 return _iter_config_rows(tree, content_hash=h)
         else:
@@ -188,12 +256,12 @@ class BeamConfigAdapter:
                 rows=rows_factory,
                 source_path=config.primary_config,
                 source=source_key,
-                content_hash=config.content_hash,
+                content_hash=reference_identity.identity_hash,
                 dedupe_on_hash=True,
             ),
             _run_link_spec(
                 table_name="beam_config_cache",
-                content_hash=config.content_hash,
+                content_hash=reference_identity.identity_hash,
                 config_name=config.primary_config.name,
                 run_id=run.id if run else None,
                 plan_only=plan_only,
@@ -214,7 +282,11 @@ class BeamConfigAdapter:
 
         artifacts = list(artifacts_by_path.values())
 
-        return CanonicalizationResult(artifacts=artifacts, ingestables=ingestables)
+        return CanonicalizationResult(
+            artifacts=artifacts,
+            ingestables=ingestables,
+            identity=reference_identity,
+        )
 
     def materialize(
         self,
@@ -258,6 +330,8 @@ class BeamConfigAdapter:
             resolve_substitutions=self.resolve_substitutions,
             env_overrides=self.env_overrides,
             ingest_specs=self.ingest_specs,
+            path_aliases=self.path_aliases,
+            reference_policies=self.reference_policies,
         )
         return materialized_adapter.discover(
             staged_root_dirs, identity=identity, strict=strict
@@ -717,50 +791,389 @@ def _normalize_value(
     return "json", None, None, None, json.dumps(value, sort_keys=True)
 
 
-def _collect_path_references(config_tree: dict[str, Any]) -> set[str]:
-    refs: set[str] = set()
-    ignore_tokens = {
-        "csv",
-        "csv.gz",
-        "xml",
-        "xml.gz",
-        "parquet",
-        "omx",
-        "h5",
-    }
+def _canonical_json_sha256(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=True, default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
-    def walk(node: Any) -> None:
+
+def _is_path_like_config_value(value: str) -> bool:
+    candidate = value.strip()
+    if not candidate:
+        return False
+    if candidate in {"csv", "csv.gz", "xml", "xml.gz", "parquet", "omx", "h5"}:
+        return False
+    if candidate.startswith(("http://", "https://", "tcp://")):
+        return False
+    return "/" in candidate or candidate.endswith(
+        (
+            ".csv",
+            ".csv.gz",
+            ".xml",
+            ".xml.gz",
+            ".gz",
+            ".parquet",
+            ".zip",
+            ".omx",
+            ".h5",
+        )
+    )
+
+
+def _collect_path_candidates(
+    config_tree: dict[str, Any],
+    *,
+    allow_heuristic_refs: bool,
+) -> list[_BeamPathCandidate]:
+    candidates: list[_BeamPathCandidate] = []
+
+    def walk(node: Any, prefix: str) -> None:
         if isinstance(node, dict):
-            for value in node.values():
-                walk(value)
-        elif isinstance(node, list):
-            for item in node:
-                walk(item)
-        elif isinstance(node, str):
-            candidate = node.strip()
-            if not candidate:
-                return
-            if candidate in ignore_tokens:
-                return
-            if candidate.startswith(("http://", "https://", "tcp://")):
-                return
-            if "/" in candidate or candidate.endswith(
-                (
-                    ".csv",
-                    ".csv.gz",
-                    ".xml",
-                    ".xml.gz",
-                    ".gz",
-                    ".parquet",
-                    ".zip",
-                    ".omx",
-                    ".h5",
+            for key, value in node.items():
+                next_prefix = f"{prefix}.{key}" if prefix else str(key)
+                walk(value, next_prefix)
+            return
+        if isinstance(node, list):
+            for index, item in enumerate(node):
+                walk(item, f"{prefix}[{index}]")
+            return
+        if isinstance(node, str) and (
+            _is_path_like_config_value(node)
+            or (allow_heuristic_refs and _is_path_like_config_key(prefix))
+        ):
+            candidates.append(
+                _BeamPathCandidate(
+                    config_key=prefix,
+                    raw_value=node.strip(),
+                    index=len(candidates),
                 )
-            ):
-                refs.add(candidate)
+            )
 
-    walk(config_tree)
-    return refs
+    walk(config_tree, "")
+    return candidates
+
+
+def _merge_path_aliases(
+    base: Optional[Mapping[str, str | Path]],
+    override: Optional[Mapping[str, str | Path]],
+) -> dict[str, Path]:
+    merged: dict[str, Path] = {}
+    for source in (base, override):
+        if not source:
+            continue
+        for alias, path in source.items():
+            if alias:
+                merged[str(alias)] = Path(path).expanduser().resolve()
+    return merged
+
+
+def _normalize_reference_policy(
+    value: BeamReferencePolicy | Mapping[str, Any] | None,
+) -> BeamReferencePolicy | None:
+    if value is None:
+        return None
+    if isinstance(value, BeamReferencePolicy):
+        return value
+    return BeamReferencePolicy(
+        identity_policy=str(value.get("identity_policy", "content_hash")),
+        role=value.get("role"),
+        required=bool(value.get("required", True)),
+        reason=value.get("reason"),
+        delegated_artifact_keys=tuple(value.get("delegated_artifact_keys", ())),
+    )
+
+
+def _reference_policy_options(
+    value: BeamReferencePolicy | Mapping[str, Any],
+) -> dict[str, Any]:
+    policy = _normalize_reference_policy(value)
+    if policy is None:
+        return {}
+    data = {
+        "identity_policy": policy.identity_policy,
+        "role": policy.role,
+        "required": policy.required,
+        "reason": policy.reason,
+        "delegated_artifact_keys": list(policy.delegated_artifact_keys),
+    }
+    return {key: item for key, item in data.items() if item not in (None, [], ())}
+
+
+def _policy_for_candidate(
+    candidate: _BeamPathCandidate,
+    policies: Mapping[str, BeamReferencePolicy | Mapping[str, Any]],
+) -> BeamReferencePolicy:
+    explicit = _normalize_reference_policy(policies.get(candidate.config_key))
+    if explicit is not None:
+        return explicit
+
+    key_lower = candidate.config_key.lower()
+    if key_lower.endswith("inputdirectory"):
+        return BeamReferencePolicy(
+            identity_policy="path_alias",
+            role="beam_input_root",
+            required=True,
+        )
+    if "output" in key_lower:
+        return BeamReferencePolicy(
+            identity_policy="output_or_runtime_ignored",
+            role="runtime_output",
+            required=False,
+            reason="runtime_output_path",
+        )
+    return BeamReferencePolicy(identity_policy="content_hash", required=True)
+
+
+def _is_path_like_config_key(config_key: str) -> bool:
+    normalized_key = config_key.lower()
+    compact_key = re.sub(r"[^a-z0-9]", "", normalized_key)
+    return any(
+        token in normalized_key or token in compact_key
+        for token in (
+            "directory",
+            "dir",
+            "filepath",
+            "file",
+            "path",
+        )
+    )
+
+
+def _canonical_path_value(
+    *,
+    raw_value: str,
+    resolved: Optional[Path],
+    root_dirs: Sequence[Path],
+    path_aliases: Mapping[str, Path],
+) -> str:
+    path = resolved or Path(raw_value)
+    path = path.expanduser()
+    if path.is_absolute():
+        resolved_path = path.resolve()
+        alias_matches = sorted(
+            (
+                (alias, root)
+                for alias, root in path_aliases.items()
+                if resolved_path == root or resolved_path.is_relative_to(root)
+            ),
+            key=lambda item: len(item[1].parts),
+            reverse=True,
+        )
+        if alias_matches:
+            alias, root = alias_matches[0]
+            rel = resolved_path.relative_to(root).as_posix()
+            return alias if not rel else f"{alias}/{rel}"
+        for root in root_dirs:
+            root_resolved = root.resolve()
+            if resolved_path == root_resolved or resolved_path.is_relative_to(
+                root_resolved
+            ):
+                rel = resolved_path.relative_to(root_resolved).as_posix()
+                return (
+                    f"config:{root_resolved.name}/{rel}"
+                    if rel
+                    else f"config:{root_resolved.name}"
+                )
+        return raw_value
+
+    if resolved is not None:
+        return _canonical_path_value(
+            raw_value=raw_value,
+            resolved=resolved.resolve(),
+            root_dirs=root_dirs,
+            path_aliases=path_aliases,
+        )
+    return raw_value
+
+
+def _canonicalize_config_tree_paths(
+    node: Any,
+    *,
+    references: Sequence[ConfigReference],
+    prefix: str = "",
+) -> Any:
+    by_key = {
+        ref.config_key: ref
+        for ref in references
+        if ref.config_key and ref.canonical_value is not None
+    }
+    if isinstance(node, dict):
+        return {
+            key: _canonicalize_config_tree_paths(
+                value,
+                references=references,
+                prefix=f"{prefix}.{key}" if prefix else str(key),
+            )
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [
+            _canonicalize_config_tree_paths(
+                item,
+                references=references,
+                prefix=f"{prefix}[{index}]",
+            )
+            for index, item in enumerate(node)
+        ]
+    if isinstance(node, str):
+        ref = by_key.get(prefix)
+        if ref is not None:
+            if ref.identity_policy in {"ignored", "output_or_runtime_ignored"}:
+                return {"identity_policy": ref.identity_policy}
+            return ref.canonical_value
+    return node
+
+
+def _build_beam_config_identity(
+    *,
+    adapter_name: str,
+    adapter_version: Optional[str],
+    primary_config: Optional[Path],
+    config_tree: dict[str, Any],
+    root_dirs: Sequence[Path],
+    path_aliases: Mapping[str, Path],
+    reference_policies: Mapping[str, BeamReferencePolicy | Mapping[str, Any]],
+    allow_heuristic_refs: bool,
+    tracker: Optional["Tracker"],
+) -> CanonicalConfigIdentity:
+    references: list[ConfigReference] = []
+    directories: list[DirectoryIdentity] = []
+    for candidate in _collect_path_candidates(
+        config_tree,
+        allow_heuristic_refs=allow_heuristic_refs,
+    ):
+        policy = _policy_for_candidate(candidate, reference_policies)
+        resolved = _resolve_reference(candidate.raw_value, root_dirs)
+        exists = bool(resolved is not None and resolved.exists())
+        canonical_value = _canonical_path_value(
+            raw_value=candidate.raw_value,
+            resolved=resolved,
+            root_dirs=root_dirs,
+            path_aliases=path_aliases,
+        )
+        required = policy.required
+        identity_policy = policy.identity_policy
+        reason = policy.reason
+        delegated_artifact_keys = policy.delegated_artifact_keys
+        if exists:
+            status = "resolved"
+        elif identity_policy in {"ignored", "output_or_runtime_ignored"}:
+            status = "missing_ignored"
+            required = False
+        elif required:
+            status = "missing_required"
+        else:
+            status = "missing_optional"
+
+        digest: Optional[str] = None
+        if exists and resolved is not None:
+            if identity_policy == "content_hash" and resolved.is_file():
+                digest = _digest_path(resolved, tracker)
+            elif identity_policy == "content_hash" and resolved.is_dir():
+                identity_policy = "delegated_to_artifacts"
+                reason = reason or "directory_content_delegated_to_artifact_inputs"
+                delegated_artifact_keys = delegated_artifact_keys or (
+                    _artifact_key_for_path(resolved, root_dirs),
+                )
+            elif identity_policy in {"path_alias", "delegated_to_artifacts"}:
+                delegated_artifact_keys = delegated_artifact_keys or (
+                    _artifact_key_for_path(resolved, root_dirs),
+                )
+        if exists and resolved is not None and resolved.is_dir():
+            directories.append(
+                DirectoryIdentity(
+                    canonical_value=canonical_value,
+                    role=policy.role,
+                    identity_policy=identity_policy,
+                    hash_strategy=getattr(
+                        getattr(tracker, "identity", None), "hashing_strategy", None
+                    ),
+                    hash=digest,
+                )
+            )
+
+        references.append(
+            ConfigReference(
+                config_key=candidate.config_key,
+                raw_value=candidate.raw_value,
+                canonical_value=canonical_value,
+                status=status,  # type: ignore[arg-type]
+                required=required,
+                role=policy.role,
+                identity_policy=identity_policy,  # type: ignore[arg-type]
+                reason=reason,
+                hash=digest,
+                delegated_artifact_keys=delegated_artifact_keys,
+            )
+        )
+
+    references = sorted(
+        references,
+        key=lambda ref: (ref.config_key or "", ref.raw_value, ref.identity_policy),
+    )
+    canonical_tree = _canonicalize_config_tree_paths(
+        config_tree,
+        references=references,
+    )
+    reference_payload = [
+        {
+            "config_key": ref.config_key,
+            "canonical_value": ref.canonical_value
+            if ref.canonical_value is not None
+            else ref.raw_value,
+            "status": ref.status,
+            "required": ref.required,
+            "role": ref.role,
+            "identity_policy": ref.identity_policy,
+            "hash": ref.hash,
+            "delegated_artifact_keys": list(ref.delegated_artifact_keys),
+            "reason": ref.reason,
+        }
+        for ref in references
+        if ref.identity_policy not in {"ignored", "output_or_runtime_ignored"}
+    ]
+    scalar_hash = _canonical_json_sha256({"config": canonical_tree})
+    reference_hash = _canonical_json_sha256({"references": reference_payload})
+    directory_hash = _canonical_json_sha256(
+        {"directories": [item.to_meta_dict() for item in directories]}
+    )
+    options_payload = {
+        "allow_heuristic_refs": allow_heuristic_refs,
+        "path_aliases": {
+            alias: path.as_posix() for alias, path in sorted(path_aliases.items())
+        },
+        "reference_policies": {
+            key: _reference_policy_options(value)
+            for key, value in sorted(reference_policies.items())
+        },
+    }
+    primary_config_key = (
+        _artifact_key_for_path(primary_config, root_dirs)
+        if primary_config is not None
+        else None
+    )
+    identity_hash = _canonical_json_sha256(
+        {
+            "identity_schema_version": 1,
+            "adapter_name": adapter_name,
+            "adapter_version": adapter_version,
+            "primary_config": primary_config_key,
+            "scalar_hash": scalar_hash,
+            "reference_hash": reference_hash,
+            "directory_hash": directory_hash,
+        }
+    )
+    return CanonicalConfigIdentity(
+        adapter_name=adapter_name,
+        adapter_version=adapter_version,
+        primary_config=primary_config_key,
+        identity_hash=identity_hash,
+        scalar_hash=scalar_hash,
+        reference_hash=reference_hash,
+        directory_hash=directory_hash,
+        scalars={"options": options_payload},
+        references=tuple(references),
+        directories=tuple(directories),
+    )
 
 
 def _resolve_reference(value: str, root_dirs: Sequence[Path]) -> Optional[Path]:

--- a/src/consist/integrations/beam/config_adapter.py
+++ b/src/consist/integrations/beam/config_adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import hashlib
 import json
 import logging
 import re
@@ -29,9 +28,9 @@ from consist.core.config_canonicalization import (
     ConfigAdapterOptions,
     ConfigReference,
     ConfigReferenceIdentityPolicy,
-    ConfigReferenceStatus,
     DirectoryIdentity,
     IngestSpec,
+    _canonical_json_sha256,
 )
 from consist.core.config_canonicalization import ConfigPlan
 from consist.core.identity import IdentityManager
@@ -802,11 +801,6 @@ def _normalize_value(
     return "json", None, None, None, json.dumps(value, sort_keys=True)
 
 
-def _canonical_json_sha256(payload: Any) -> str:
-    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=True, default=str)
-    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
-
-
 def _is_path_like_config_value(value: str) -> bool:
     candidate = value.strip()
     if not candidate:
@@ -1000,38 +994,32 @@ def _canonicalize_config_tree_paths(
     node: Any,
     *,
     references: Sequence[ConfigReference],
-    prefix: str = "",
 ) -> Any:
     by_key = {
         ref.config_key: ref
         for ref in references
         if ref.config_key and ref.canonical_value is not None
     }
-    if isinstance(node, dict):
-        return {
-            key: _canonicalize_config_tree_paths(
-                value,
-                references=references,
-                prefix=f"{prefix}.{key}" if prefix else str(key),
-            )
-            for key, value in node.items()
-        }
-    if isinstance(node, list):
-        return [
-            _canonicalize_config_tree_paths(
-                item,
-                references=references,
-                prefix=f"{prefix}[{index}]",
-            )
-            for index, item in enumerate(node)
-        ]
-    if isinstance(node, str):
-        ref = by_key.get(prefix)
-        if ref is not None:
-            if ref.identity_policy in {"ignored", "output_or_runtime_ignored"}:
-                return {"identity_policy": ref.identity_policy}
-            return ref.canonical_value
-    return node
+
+    def walk(value: Any, prefix: str = "") -> Any:
+        if isinstance(value, dict):
+            return {
+                key: walk(item, f"{prefix}.{key}" if prefix else str(key))
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                walk(item, f"{prefix}[{index}]") for index, item in enumerate(value)
+            ]
+        if isinstance(value, str):
+            ref = by_key.get(prefix)
+            if ref is not None:
+                if ref.identity_policy in {"ignored", "output_or_runtime_ignored"}:
+                    return {"identity_policy": ref.identity_policy}
+                return ref.canonical_value
+        return value
+
+    return walk(node)
 
 
 def _build_beam_config_identity(
@@ -1082,13 +1070,15 @@ def _build_beam_config_identity(
             elif identity_policy == "content_hash" and resolved.is_dir():
                 identity_policy = "delegated_to_artifacts"
                 reason = reason or "directory_content_delegated_to_artifact_inputs"
-                delegated_artifact_keys = delegated_artifact_keys or (
-                    _artifact_key_for_path(resolved, root_dirs),
-                )
+                if not delegated_artifact_keys:
+                    delegated_artifact_keys = (
+                        _artifact_key_for_path(resolved, root_dirs),
+                    )
             elif identity_policy in {"path_alias", "delegated_to_artifacts"}:
-                delegated_artifact_keys = delegated_artifact_keys or (
-                    _artifact_key_for_path(resolved, root_dirs),
-                )
+                if not delegated_artifact_keys:
+                    delegated_artifact_keys = (
+                        _artifact_key_for_path(resolved, root_dirs),
+                    )
         if exists and resolved is not None and resolved.is_dir():
             directories.append(
                 DirectoryIdentity(
@@ -1107,7 +1097,7 @@ def _build_beam_config_identity(
                 config_key=candidate.config_key,
                 raw_value=candidate.raw_value,
                 canonical_value=canonical_value,
-                status=cast(ConfigReferenceStatus, status),
+                status=status,
                 required=required,
                 role=policy.role,
                 identity_policy=cast(ConfigReferenceIdentityPolicy, identity_policy),

--- a/src/consist/integrations/beam/config_adapter.py
+++ b/src/consist/integrations/beam/config_adapter.py
@@ -119,6 +119,7 @@ class BeamConfigAdapter:
     env_overrides: Optional[dict[str, str]] = None
     ingest_specs: list[BeamIngestSpec] = field(default_factory=list)
     path_aliases: Optional[dict[str, str | Path]] = None
+    allow_heuristic_refs: bool = False
     reference_policies: dict[str, BeamReferencePolicy | dict[str, Any]] = field(
         default_factory=dict
     )
@@ -200,7 +201,9 @@ class BeamConfigAdapter:
             path_aliases=path_aliases,
             reference_policies=self.reference_policies,
             allow_heuristic_refs=(
-                options.allow_heuristic_refs if options is not None else True
+                options.allow_heuristic_refs
+                if options is not None and options.allow_heuristic_refs is not None
+                else self.allow_heuristic_refs
             ),
             tracker=tracker,
         )
@@ -827,9 +830,12 @@ def _is_path_like_config_value(value: str) -> bool:
 def _collect_path_candidates(
     config_tree: dict[str, Any],
     *,
+    root_dirs: Sequence[Path],
+    reference_policies: Mapping[str, BeamReferencePolicy | Mapping[str, Any]],
     allow_heuristic_refs: bool,
 ) -> list[_BeamPathCandidate]:
     candidates: list[_BeamPathCandidate] = []
+    explicit_policy_keys = set(reference_policies)
 
     def walk(node: Any, prefix: str) -> None:
         if isinstance(node, dict):
@@ -842,7 +848,9 @@ def _collect_path_candidates(
                 walk(item, f"{prefix}[{index}]")
             return
         if isinstance(node, str) and (
-            _is_path_like_config_value(node)
+            prefix in explicit_policy_keys
+            or _is_path_like_config_value(node)
+            or _resolves_under_config_root(node, root_dirs)
             or (allow_heuristic_refs and _is_path_like_config_key(prefix))
         ):
             candidates.append(
@@ -855,6 +863,20 @@ def _collect_path_candidates(
 
     walk(config_tree, "")
     return candidates
+
+
+def _resolves_under_config_root(value: str, root_dirs: Sequence[Path]) -> bool:
+    raw = value.strip()
+    if not raw:
+        return False
+    candidate = Path(raw).expanduser()
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+        return resolved.exists() and any(
+            resolved == root.resolve() or resolved.is_relative_to(root.resolve())
+            for root in root_dirs
+        )
+    return any((root / candidate).resolve().exists() for root in root_dirs)
 
 
 def _merge_path_aliases(
@@ -918,7 +940,7 @@ def _policy_for_candidate(
             role="beam_input_root",
             required=True,
         )
-    if "output" in key_lower:
+    if "output" in key_lower or _is_runtime_output_config_key(candidate.config_key):
         return BeamReferencePolicy(
             identity_policy="output_or_runtime_ignored",
             role="runtime_output",
@@ -929,18 +951,16 @@ def _policy_for_candidate(
 
 
 def _is_path_like_config_key(config_key: str) -> bool:
-    normalized_key = config_key.lower()
-    compact_key = re.sub(r"[^a-z0-9]", "", normalized_key)
+    compact_key = re.sub(r"[^a-z0-9]", "", config_key.lower())
     return any(
-        token in normalized_key or token in compact_key
-        for token in (
-            "directory",
-            "dir",
-            "filepath",
-            "file",
-            "path",
-        )
+        compact_key.endswith(suffix)
+        for suffix in ("directory", "dir", "filepath", "filename", "path", "file")
     )
+
+
+def _is_runtime_output_config_key(config_key: str) -> bool:
+    compact_key = re.sub(r"[^a-z0-9]", "", config_key.lower())
+    return compact_key.endswith("filebasename")
 
 
 def _canonical_path_value(
@@ -1038,6 +1058,8 @@ def _build_beam_config_identity(
     directories: list[DirectoryIdentity] = []
     for candidate in _collect_path_candidates(
         config_tree,
+        root_dirs=root_dirs,
+        reference_policies=reference_policies,
         allow_heuristic_refs=allow_heuristic_refs,
     ):
         policy = _policy_for_candidate(candidate, reference_policies)

--- a/src/consist/integrations/beam/config_adapter.py
+++ b/src/consist/integrations/beam/config_adapter.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import dataclass, field, replace
 import shutil
 from pathlib import Path
-from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, TYPE_CHECKING
+from typing import Any, cast, Iterable, Literal, Mapping, Optional, Sequence, TYPE_CHECKING
 
 from sqlmodel import SQLModel
 
@@ -19,6 +19,8 @@ from consist.core.config_canonicalization import (
     CanonicalizationResult,
     ConfigAdapterOptions,
     ConfigReference,
+    ConfigReferenceIdentityPolicy,
+    ConfigReferenceStatus,
     DirectoryIdentity,
     IngestSpec,
 )
@@ -1096,10 +1098,10 @@ def _build_beam_config_identity(
                 config_key=candidate.config_key,
                 raw_value=candidate.raw_value,
                 canonical_value=canonical_value,
-                status=status,  # type: ignore[arg-type]
+                status=cast(ConfigReferenceStatus, status),
                 required=required,
                 role=policy.role,
-                identity_policy=identity_policy,  # type: ignore[arg-type]
+                identity_policy=cast(ConfigReferenceIdentityPolicy, identity_policy),
                 reason=reason,
                 hash=digest,
                 delegated_artifact_keys=delegated_artifact_keys,

--- a/src/consist/integrations/beam/config_adapter.py
+++ b/src/consist/integrations/beam/config_adapter.py
@@ -8,7 +8,16 @@ import re
 from dataclasses import dataclass, field, replace
 import shutil
 from pathlib import Path
-from typing import Any, cast, Iterable, Literal, Mapping, Optional, Sequence, TYPE_CHECKING
+from typing import (
+    Any,
+    cast,
+    Iterable,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    TYPE_CHECKING,
+)
 
 from sqlmodel import SQLModel
 

--- a/src/consist/models/run.py
+++ b/src/consist/models/run.py
@@ -225,6 +225,7 @@ class Run(SQLModel, table=True):
             "name": meta.get("config_adapter"),
             "hash": meta.get("config_bundle_hash"),
             "version": meta.get("config_adapter_version"),
+            "identity_manifest": meta.get("config_identity_manifest"),
         }
 
         config_payload = meta.get("config")
@@ -259,6 +260,7 @@ class Run(SQLModel, table=True):
                 "name": meta.get("config_adapter"),
                 "version": meta.get("config_adapter_version"),
                 "identity_hash": meta.get("config_bundle_hash"),
+                "identity_manifest": meta.get("config_identity_manifest"),
             },
             "code_identity": {
                 "mode": meta.get("code_identity", "repo_git"),

--- a/tests/integration/tracker/test_pre_pilates_readiness.py
+++ b/tests/integration/tracker/test_pre_pilates_readiness.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from consist.core.config_canonicalization import CanonicalConfig, ConfigPlan
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    ConfigPlan,
+    canonical_identity_from_config,
+)
 from consist.types import CacheOptions
 
 
@@ -23,18 +27,24 @@ def test_pre_pilates_adapter_and_identity_inputs_surface(
     config_root = tmp_path / "adapter_config"
     config_root.mkdir(parents=True, exist_ok=True)
 
+    canonical = CanonicalConfig(
+        root_dirs=[config_root],
+        primary_config=None,
+        config_files=[],
+        external_files=[],
+        content_hash="adapter_identity_hash",
+    )
     adapter_plan = ConfigPlan(
         adapter_name="dummy_adapter",
         adapter_version="1.0",
-        canonical=CanonicalConfig(
-            root_dirs=[config_root],
-            primary_config=None,
-            config_files=[],
-            external_files=[],
-            content_hash="adapter_identity_hash",
-        ),
+        canonical=canonical,
         artifacts=[],
         ingestables=[],
+        identity=canonical_identity_from_config(
+            adapter_name="dummy_adapter",
+            adapter_version="1.0",
+            config=canonical,
+        ),
     )
 
     class DummyAdapter:

--- a/tests/unit/core/test_cache_miss_explainer.py
+++ b/tests/unit/core/test_cache_miss_explainer.py
@@ -294,6 +294,8 @@ def test_cache_miss_explanation_reads_canonical_identity_scalar_files():
             "options": {"allow_heuristic_refs": False},
         },
     ).to_meta_dict()
+    assert current_manifest["files"][0]["key"] == "root:0:settings.yaml"
+    assert current_manifest["options"]["allow_heuristic_refs"] is False
     candidate_manifest = CanonicalConfigIdentity(
         adapter_name="activitysim",
         adapter_version="test",
@@ -351,6 +353,67 @@ def test_cache_miss_explanation_reads_canonical_identity_scalar_files():
     assert explanation.details["config_identity_options_changed"] == [
         "allow_heuristic_refs"
     ]
+
+
+def test_cache_miss_explanation_falls_back_when_manifest_diff_empty():
+    """Identical manifests should not suppress older facet fallback details."""
+
+    manifest = CanonicalConfigIdentity(
+        adapter_name="activitysim",
+        adapter_version="test",
+        primary_config="root:0:settings.yaml",
+        identity_hash="identity",
+        scalars={
+            "files": [
+                {
+                    "key": "root:0:settings.yaml",
+                    "role": "yaml",
+                    "hash": "settings",
+                }
+            ]
+        },
+    ).to_meta_dict()
+    current = Run(
+        id="current",
+        model_name="activitysim",
+        config_hash="config_hash_current",
+        input_hash="input_hash",
+        git_hash="git_hash",
+        meta={"config_identity_manifest": manifest},
+    )
+    candidate = Run(
+        id="candidate",
+        model_name="activitysim",
+        config_hash="config_hash_candidate",
+        input_hash="input_hash",
+        git_hash="git_hash",
+        status="completed",
+        meta={"config_identity_manifest": manifest},
+    )
+
+    class StubTracker:
+        db = object()
+        current_consist = SimpleNamespace(facet={"sample_rate": 0.2})
+
+        def find_recent_completed_runs_for_model(
+            self, model_name: str, *, limit: int = 20
+        ) -> list[Run]:
+            assert model_name == "activitysim"
+            assert limit == 20
+            return [candidate]
+
+        def get_config_values(self, run_id: str):
+            assert run_id == "candidate"
+            return {"sample_rate": 0.1}
+
+        def get_run_config(self, run_id: str, *, allow_missing: bool = False):
+            raise AssertionError("JSON snapshot fallback should not be needed.")
+
+    explanation = CacheMissExplainer(StubTracker()).explain(current)
+
+    assert explanation.reason == "config_changed"
+    assert explanation.details["config_keys_changed"] == ["sample_rate"]
+    assert explanation.details["fallbacks_used"] == ["config_facet"]
 
 
 def test_cache_miss_explanation_records_callable_identity_mode_drift():

--- a/tests/unit/core/test_cache_miss_explainer.py
+++ b/tests/unit/core/test_cache_miss_explainer.py
@@ -5,8 +5,12 @@ import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
-from consist.core.config_canonicalization import CanonicalConfig, ConfigPlan
 from consist.core.cache_miss_explainer import CacheMissExplainer
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    CanonicalConfigIdentity,
+    ConfigPlan,
+)
 from consist.models.artifact import Artifact
 from consist.models.run import Run
 from consist.types import CacheOptions
@@ -124,6 +128,229 @@ def test_cache_miss_explanation_records_identity_input_digest_changes():
 
     assert explanation.reason == "config_changed"
     assert explanation.details["identity_inputs_changed"] == ["scenario_cfg"]
+
+
+def test_cache_miss_explanation_prefers_config_identity_manifest_diff():
+    """Structured adapter manifests should explain config misses before fallbacks.
+
+    The manifest carries adapter-native identity detail that is more precise than
+    indexed facets or JSON snapshots. When both runs have manifests, the
+    explainer should report reference, file, status, and option drift directly
+    and avoid labeling the result as a fallback.
+    """
+
+    current = Run(
+        id="current",
+        model_name="manifest_model",
+        config_hash="config_hash_current",
+        input_hash="input_hash",
+        git_hash="git_hash",
+        meta={
+            "config_identity_manifest": {
+                "references": [
+                    {
+                        "config_key": "coefficients",
+                        "canonical_value": "coefficients.csv",
+                        "status": "resolved",
+                        "hash": "coeff_hash_v2",
+                    },
+                    {
+                        "config_key": "skims",
+                        "canonical_value": "skims.omx",
+                        "status": "resolved",
+                        "hash": "skims_hash",
+                    },
+                    {
+                        "config_key": "land_use",
+                        "canonical_value": "land_use.csv",
+                        "status": "resolved",
+                        "hash": "land_use_hash",
+                    },
+                ],
+                "primary_config": "settings.yaml",
+                "directories": [
+                    {"canonical_value": "config_root", "hash": "settings_hash_v2"},
+                    {"canonical_value": "extra_config", "hash": "extra_hash"},
+                ],
+                "options": {
+                    "strict": True,
+                    "path_aliases": {"data": "/new/data"},
+                },
+            }
+        },
+    )
+    candidate = Run(
+        id="candidate",
+        model_name="manifest_model",
+        config_hash="config_hash_candidate",
+        input_hash="input_hash",
+        git_hash="git_hash",
+        status="completed",
+        meta={
+            "config_identity_manifest": {
+                "references": [
+                    {
+                        "config_key": "coefficients",
+                        "canonical_value": "coefficients.csv",
+                        "status": "resolved",
+                        "hash": "coeff_hash_v1",
+                    },
+                    {
+                        "config_key": "skims",
+                        "canonical_value": "skims.omx",
+                        "status": "missing_optional",
+                        "hash": "skims_hash",
+                    },
+                    {
+                        "config_key": "households",
+                        "canonical_value": "households.csv",
+                        "status": "resolved",
+                        "hash": "households_hash",
+                    },
+                ],
+                "primary_config": "settings.yaml",
+                "directories": [
+                    {"canonical_value": "config_root", "hash": "settings_hash_v1"},
+                    {"canonical_value": "legacy_config", "hash": "legacy_hash"},
+                ],
+                "options": {
+                    "strict": False,
+                    "path_aliases": {"data": "/old/data"},
+                    "allow_heuristic_refs": True,
+                },
+            }
+        },
+    )
+
+    class StubTracker:
+        db = object()
+        current_consist = SimpleNamespace(
+            config={"fallback": "current"},
+            facet={"fallback": "current"},
+        )
+
+        def find_recent_completed_runs_for_model(
+            self, model_name: str, *, limit: int = 20
+        ) -> list[Run]:
+            assert model_name == "manifest_model"
+            assert limit == 20
+            return [candidate]
+
+        def get_config_values(self, run_id: str):
+            assert run_id == "candidate"
+            return {"fallback": "candidate"}
+
+        def get_run_config(self, run_id: str, *, allow_missing: bool = False):
+            assert run_id == "candidate"
+            assert allow_missing is True
+            return {"fallback": "candidate"}
+
+    explanation = CacheMissExplainer(StubTracker()).explain(current)
+
+    assert explanation.reason == "config_changed"
+    assert explanation.details["config_references_changed"] == ["coefficients"]
+    assert explanation.details["config_references_added"] == ["land_use"]
+    assert explanation.details["config_references_removed"] == ["households"]
+    assert explanation.details["reference_status_changed"] == [
+        {
+            "reference": "skims",
+            "candidate": "missing_optional",
+            "current": "resolved",
+        }
+    ]
+    assert explanation.details["config_files_changed"] == ["config_root"]
+    assert explanation.details["config_files_added"] == ["extra_config"]
+    assert explanation.details["config_files_removed"] == ["legacy_config"]
+    assert set(explanation.details["config_identity_options_changed"]) == {
+        "allow_heuristic_refs",
+        "path_aliases.data",
+        "strict",
+    }
+    assert "config_keys_changed" not in explanation.details
+    assert "fallbacks_used" not in explanation.details
+
+
+def test_cache_miss_explanation_reads_canonical_identity_scalar_files():
+    """Real adapter manifests store file and option details in identity scalars."""
+
+    current_manifest = CanonicalConfigIdentity(
+        adapter_name="activitysim",
+        adapter_version="test",
+        primary_config="root:0:settings.yaml",
+        identity_hash="identity_v2",
+        scalars={
+            "files": [
+                {
+                    "key": "root:0:settings.yaml",
+                    "role": "yaml",
+                    "hash": "settings_v2",
+                },
+                {
+                    "key": "root:0:coefficients.csv",
+                    "role": "csv",
+                    "hash": "coefficients_v1",
+                },
+            ],
+            "options": {"allow_heuristic_refs": False},
+        },
+    ).to_meta_dict()
+    candidate_manifest = CanonicalConfigIdentity(
+        adapter_name="activitysim",
+        adapter_version="test",
+        primary_config="root:0:settings.yaml",
+        identity_hash="identity_v1",
+        scalars={
+            "files": [
+                {
+                    "key": "root:0:settings.yaml",
+                    "role": "yaml",
+                    "hash": "settings_v1",
+                },
+                {
+                    "key": "root:0:coefficients.csv",
+                    "role": "csv",
+                    "hash": "coefficients_v1",
+                },
+            ],
+            "options": {"allow_heuristic_refs": True},
+        },
+    ).to_meta_dict()
+    current = Run(
+        id="current",
+        model_name="activitysim",
+        config_hash="config_hash_current",
+        input_hash="input_hash",
+        git_hash="git_hash",
+        meta={"config_identity_manifest": current_manifest},
+    )
+    candidate = Run(
+        id="candidate",
+        model_name="activitysim",
+        config_hash="config_hash_candidate",
+        input_hash="input_hash",
+        git_hash="git_hash",
+        status="completed",
+        meta={"config_identity_manifest": candidate_manifest},
+    )
+
+    class StubTracker:
+        db = object()
+        current_consist = None
+
+        def find_recent_completed_runs_for_model(
+            self, model_name: str, *, limit: int = 20
+        ) -> list[Run]:
+            assert model_name == "activitysim"
+            assert limit == 20
+            return [candidate]
+
+    explanation = CacheMissExplainer(StubTracker()).explain(current)
+
+    assert explanation.reason == "config_changed"
+    assert explanation.details["config_files_changed"] == ["root:0:settings.yaml"]
+    assert explanation.details["config_identity_options_changed"] == [
+        "allow_heuristic_refs"
+    ]
 
 
 def test_cache_miss_explanation_records_callable_identity_mode_drift():
@@ -672,6 +899,12 @@ def test_cache_miss_explanation_records_adapter_identity_changes(
             ),
             artifacts=[],
             ingestables=[],
+            identity=CanonicalConfigIdentity(
+                adapter_name="dummy_adapter",
+                adapter_version="1.0",
+                primary_config=None,
+                identity_hash="adapter_hash_v1",
+            ),
         ),
         ConfigPlan(
             adapter_name="dummy_adapter",
@@ -685,6 +918,12 @@ def test_cache_miss_explanation_records_adapter_identity_changes(
             ),
             artifacts=[],
             ingestables=[],
+            identity=CanonicalConfigIdentity(
+                adapter_name="dummy_adapter",
+                adapter_version="2.0",
+                primary_config=None,
+                identity_hash="adapter_hash_v2",
+            ),
         ),
     ]
     calls = {"count": 0}

--- a/tests/unit/core/test_define_step.py
+++ b/tests/unit/core/test_define_step.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from consist.core.config_canonicalization import CanonicalConfig, ConfigPlan
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    ConfigPlan,
+    canonical_identity_from_config,
+)
 from consist.core.decorators import define_step
 from consist.core.tracker import Tracker
 from consist.types import CacheOptions, ExecutionOptions
@@ -68,18 +72,24 @@ def test_define_step_adapter_default_applied(
         del kwargs
         assert adapter is not None
         captured.extend(Path(p) for p in config_dirs)
+        canonical = CanonicalConfig(
+            root_dirs=[Path(p) for p in config_dirs],
+            primary_config=None,
+            config_files=[],
+            external_files=[],
+            content_hash="hash_a",
+        )
         return ConfigPlan(
             adapter_name="dummy",
             adapter_version="1.0",
-            canonical=CanonicalConfig(
-                root_dirs=[Path(p) for p in config_dirs],
-                primary_config=None,
-                config_files=[],
-                external_files=[],
-                content_hash="hash_a",
-            ),
+            canonical=canonical,
             artifacts=[],
             ingestables=[],
+            identity=canonical_identity_from_config(
+                adapter_name="dummy",
+                adapter_version="1.0",
+                config=canonical,
+            ),
         )
 
     # Keep behavior realistic while still asserting adapter resolution path.
@@ -123,18 +133,24 @@ def test_define_step_adapter_explicit_override(
     def fake_prepare_config(*, adapter, config_dirs, **kwargs):
         del adapter, kwargs
         called.extend(Path(p) for p in config_dirs)
+        canonical = CanonicalConfig(
+            root_dirs=[Path(p) for p in config_dirs],
+            primary_config=None,
+            config_files=[],
+            external_files=[],
+            content_hash="hash_b",
+        )
         return ConfigPlan(
             adapter_name="dummy",
             adapter_version="1.0",
-            canonical=CanonicalConfig(
-                root_dirs=[Path(p) for p in config_dirs],
-                primary_config=None,
-                config_files=[],
-                external_files=[],
-                content_hash="hash_b",
-            ),
+            canonical=canonical,
             artifacts=[],
             ingestables=[],
+            identity=canonical_identity_from_config(
+                adapter_name="dummy",
+                adapter_version="1.0",
+                config=canonical,
+            ),
         )
 
     monkeypatch.setattr(tracker, "prepare_config", fake_prepare_config)

--- a/tests/unit/core/test_error_message_diagnostics.py
+++ b/tests/unit/core/test_error_message_diagnostics.py
@@ -5,7 +5,11 @@ from typing import Any, cast
 
 import pytest
 
-from consist.core.config_canonicalization import CanonicalConfig, ConfigPlan
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    ConfigPlan,
+    canonical_identity_from_config,
+)
 from consist.types import CacheOptions, ExecutionOptions
 
 
@@ -45,18 +49,24 @@ def test_run_rejects_removed_config_plan_kwarg(tracker, tmp_path: Path) -> None:
     config_root = tmp_path / "cfg"
     config_root.mkdir(parents=True, exist_ok=True)
 
+    canonical = CanonicalConfig(
+        root_dirs=[config_root],
+        primary_config=None,
+        config_files=[],
+        external_files=[],
+        content_hash="hash",
+    )
     plan = ConfigPlan(
         adapter_name="dummy",
         adapter_version="1.0",
-        canonical=CanonicalConfig(
-            root_dirs=[config_root],
-            primary_config=None,
-            config_files=[],
-            external_files=[],
-            content_hash="hash",
-        ),
+        canonical=canonical,
         artifacts=[],
         ingestables=[],
+        identity=canonical_identity_from_config(
+            adapter_name="dummy",
+            adapter_version="1.0",
+            config=canonical,
+        ),
     )
 
     class DummyAdapter:

--- a/tests/unit/core/test_log_artifacts_batching.py
+++ b/tests/unit/core/test_log_artifacts_batching.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import pytest
 from sqlmodel import Session, select
 
-from consist.core.config_canonicalization import ArtifactSpec, ConfigContribution
+from consist.core.config_canonicalization import (
+    ArtifactSpec,
+    CanonicalConfigIdentity,
+    ConfigContribution,
+)
 from consist.models.run import RunArtifactLink
 from consist.types import ExecutionOptions
 
@@ -431,7 +435,12 @@ def test_apply_config_contribution_batches_artifact_sync(
     monkeypatch.setattr(tracker.db, "sync_artifact", counting_sync_artifact)
 
     contribution = ConfigContribution(
-        identity_hash="config-batch",
+        identity=CanonicalConfigIdentity(
+            adapter_name="test",
+            adapter_version="test-adapter",
+            primary_config=None,
+            identity_hash="config-batch",
+        ),
         adapter_version="test-adapter",
         artifacts=[
             ArtifactSpec(first, "config_a", "input", {"kind": "config"}),

--- a/tests/unit/core/test_scenario_run.py
+++ b/tests/unit/core/test_scenario_run.py
@@ -7,7 +7,11 @@ import pandas as pd
 import pytest
 
 import consist
-from consist.core.config_canonicalization import CanonicalConfig, ConfigPlan
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    ConfigPlan,
+    canonical_identity_from_config,
+)
 from consist.types import CacheOptions, ExecutionOptions, OutputPolicyOptions
 
 
@@ -396,18 +400,24 @@ def test_scenario_run_accepts_adapter_identity_flow(tracker, tmp_path, monkeypat
     config_root = tmp_path / "sc_adapter"
     config_root.mkdir(parents=True, exist_ok=True)
 
+    canonical = CanonicalConfig(
+        root_dirs=[config_root],
+        primary_config=None,
+        config_files=[],
+        external_files=[],
+        content_hash="scenario_adapter_hash",
+    )
     adapter_plan = ConfigPlan(
         adapter_name="scenario_adapter",
         adapter_version="1.0",
-        canonical=CanonicalConfig(
-            root_dirs=[config_root],
-            primary_config=None,
-            config_files=[],
-            external_files=[],
-            content_hash="scenario_adapter_hash",
-        ),
+        canonical=canonical,
         artifacts=[],
         ingestables=[],
+        identity=canonical_identity_from_config(
+            adapter_name="scenario_adapter",
+            adapter_version="1.0",
+            config=canonical,
+        ),
     )
 
     class DummyAdapter:
@@ -447,18 +457,24 @@ def test_scenario_run_forwards_define_step_adapter_identity_metadata(
     config_root = tmp_path / "sc_adapter_metadata"
     config_root.mkdir(parents=True, exist_ok=True)
 
+    canonical = CanonicalConfig(
+        root_dirs=[config_root],
+        primary_config=None,
+        config_files=[],
+        external_files=[],
+        content_hash="scenario_adapter_metadata_hash",
+    )
     adapter_plan = ConfigPlan(
         adapter_name="scenario_adapter_metadata",
         adapter_version="1.1",
-        canonical=CanonicalConfig(
-            root_dirs=[config_root],
-            primary_config=None,
-            config_files=[],
-            external_files=[],
-            content_hash="scenario_adapter_metadata_hash",
-        ),
+        canonical=canonical,
         artifacts=[],
         ingestables=[],
+        identity=canonical_identity_from_config(
+            adapter_name="scenario_adapter_metadata",
+            adapter_version="1.1",
+            config=canonical,
+        ),
     )
 
     class DummyAdapter:

--- a/tests/unit/core/test_tracker_config_plan_service.py
+++ b/tests/unit/core/test_tracker_config_plan_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from consist.core.config_canonicalization import (
     CanonicalConfig,
     CanonicalizationResult,
+    canonical_identity_from_config,
 )
 
 
@@ -40,7 +41,15 @@ class _BundleTrackerProbeAdapter:
         plan_only: bool = False,
         options=None,
     ) -> CanonicalizationResult:
-        return CanonicalizationResult(artifacts=[], ingestables=[])
+        return CanonicalizationResult(
+            artifacts=[],
+            ingestables=[],
+            identity=canonical_identity_from_config(
+                adapter_name=self.model_name,
+                adapter_version=None,
+                config=config,
+            ),
+        )
 
     def bundle_artifact(self, config: CanonicalConfig, *, run, tracker):
         self.seen_tracker = tracker

--- a/tests/unit/core/test_tracker_run.py
+++ b/tests/unit/core/test_tracker_run.py
@@ -10,7 +10,11 @@ import pandas as pd
 import pytest
 
 import consist
-from consist.core.config_canonicalization import CanonicalConfig, ConfigPlan
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    ConfigPlan,
+    canonical_identity_from_config,
+)
 from consist.core.tracker import Tracker
 from consist.models.artifact import Artifact
 from consist.models.run import RunResult
@@ -1135,18 +1139,24 @@ def test_tracker_run_adapter_identity_populates_meta(tracker, tmp_path, monkeypa
     config_root = tmp_path / "adapter_config"
     config_root.mkdir(parents=True, exist_ok=True)
 
+    canonical = CanonicalConfig(
+        root_dirs=[config_root],
+        primary_config=None,
+        config_files=[],
+        external_files=[],
+        content_hash="adapter_identity_hash",
+    )
     adapter_plan = ConfigPlan(
         adapter_name="dummy_adapter",
         adapter_version="1.0",
-        canonical=CanonicalConfig(
-            root_dirs=[config_root],
-            primary_config=None,
-            config_files=[],
-            external_files=[],
-            content_hash="adapter_identity_hash",
-        ),
+        canonical=canonical,
         artifacts=[],
         ingestables=[],
+        identity=canonical_identity_from_config(
+            adapter_name="dummy_adapter",
+            adapter_version="1.0",
+            config=canonical,
+        ),
     )
 
     class DummyAdapter:
@@ -1179,6 +1189,16 @@ def test_tracker_run_adapter_identity_populates_meta(tracker, tmp_path, monkeypa
     assert calls == [[config_root]]
     assert adapter_run.run.meta["config_adapter"] == "dummy_adapter"
     assert adapter_run.run.meta["config_bundle_hash"] == "adapter_identity_hash"
+    assert (
+        adapter_run.run.meta["config_identity_manifest"]["identity_hash"]
+        == "adapter_identity_hash"
+    )
+    assert (
+        adapter_run.run.identity_summary["config_adapter"]["identity_manifest"][
+            "identity_hash"
+        ]
+        == "adapter_identity_hash"
+    )
     assert adapter_run.run.meta["consist_hash_inputs"]
 
 

--- a/tests/unit/core/test_workflow.py
+++ b/tests/unit/core/test_workflow.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import pandas as pd
 import pytest
 from consist.core.coupler import Coupler
-from consist.core.config_canonicalization import CanonicalConfig, ConfigPlan
+from consist.core.config_canonicalization import (
+    CanonicalConfig,
+    ConfigPlan,
+    canonical_identity_from_config,
+)
 from consist.core.tracker import Tracker
 from consist.core.workflow import RunContext
 from consist.types import CacheOptions, ExecutionOptions
@@ -25,6 +29,11 @@ def _dummy_config_plan(
         canonical=canonical,
         artifacts=[],
         ingestables=[],
+        identity=canonical_identity_from_config(
+            adapter_name="dummy",
+            adapter_version=adapter_version,
+            config=canonical,
+        ),
     )
 
 

--- a/tests/unit/integrations/activitysim/test_activitysim_config_adapter.py
+++ b/tests/unit/integrations/activitysim/test_activitysim_config_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import shutil
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -105,6 +106,44 @@ def test_canonicalize_builds_ingestables_and_constants(tracker, tmp_path: Path):
         "activitysim_probabilities_meta_entries_cache",
         "activitysim_config_ingest_run_link",
     }
+
+
+def test_canonicalize_builds_path_stable_identity_manifest(tracker, tmp_path: Path):
+    case_a = tmp_path / "case_a"
+    base_dir, overlay_dir = build_activitysim_test_configs(case_a)
+    case_b = tmp_path / "case_b"
+    shutil.copytree(base_dir.parent, case_b)
+    clone_base = case_b / "base"
+    clone_overlay = case_b / "overlay"
+
+    adapter = ActivitySimConfigAdapter()
+    canonical_a = adapter.discover(
+        [overlay_dir, base_dir], identity=tracker.identity, strict=True
+    )
+    canonical_b = adapter.discover(
+        [clone_overlay, clone_base], identity=tracker.identity, strict=True
+    )
+
+    result_a = adapter.canonicalize(canonical_a, strict=True, plan_only=True)
+    result_b = adapter.canonicalize(canonical_b, strict=True, plan_only=True)
+
+    assert result_a.identity.identity_hash == result_b.identity.identity_hash
+    assert result_a.identity.primary_config == "root:0:settings.yaml"
+
+    refs = {ref.canonical_value: ref for ref in result_a.identity.references}
+    assert refs["root:1:settings_local.yaml"].role == "yaml"
+    assert refs["root:1:constants.yaml"].role == "yaml"
+    assert refs["root:1:stop_frequency_probs.csv"].role == "csv"
+    assert all(ref.hash for ref in refs.values())
+
+    scalars = result_a.identity.scalars
+    assert scalars["options"]["allow_heuristic_refs"] is True
+    assert "active_yaml_hash" in scalars["component_hashes"]
+    assert "referenced_csv_hash" in scalars["component_hashes"]
+    assert scalars["roles"]["yaml"]
+    assert scalars["roles"]["csv"]
+    assert result_a.identity.directory_hash
+    assert result_a.identity.directories
 
 
 def test_digest_includes_file_name(tmp_path: Path):

--- a/tests/unit/integrations/beam/test_beam_config_adapter.py
+++ b/tests/unit/integrations/beam/test_beam_config_adapter.py
@@ -198,30 +198,102 @@ def test_beam_canonicalize_does_not_treat_scalar_input_keys_as_paths(
     assert "beam.agentsim.vehicles.assignment" not in refs_by_key
 
 
-def test_beam_canonicalize_can_disable_key_based_path_heuristics(
+def test_beam_canonicalize_keeps_file_format_scalars_out_of_references(
+    tracker,
+    tmp_path: Path,
+    caplog,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + '\nbeam.exchange.scenario.fileFormat = "parquet"\n'
+        + '\nmatsim.modules.controler.eventsFileFormat = "xml"\n'
+        + '\nmatsim.modules.controler.overwriteFiles = "overwriteExistingFiles"\n'
+        + '\nmatsim.modules.controler.overwriteExistingFiles = "overwriteExistingFiles"\n'
+        + '\nbeam.router.skim.activity-sim-skimmer.fileBaseName = "activitySimODSkims"\n'
+        + '\nbeam.router.skim.drive-time-skimmer.fileBaseName = "skimsTravelTimeObservedVsSimulated"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(
+        primary_config=overlay_conf,
+        reference_policies={
+            "beam.agentsim.overridePath": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="dormant_test_reference",
+            )
+        },
+    )
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_scalar_formats_unit", "beam")
+    with caplog.at_level(logging.WARNING):
+        result = adapter.canonicalize(
+            canonical,
+            run=run,
+            tracker=tracker,
+            strict=True,
+        )
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    for scalar_key in (
+        "beam.exchange.scenario.fileFormat",
+        "matsim.modules.controler.eventsFileFormat",
+        "matsim.modules.controler.overwriteFiles",
+        "matsim.modules.controler.overwriteExistingFiles",
+        "beam.router.skim.activity-sim-skimmer.fileBaseName",
+        "beam.router.skim.drive-time-skimmer.fileBaseName",
+    ):
+        assert scalar_key not in refs_by_key
+        assert scalar_key not in caplog.text
+
+
+def test_beam_canonicalize_does_not_use_key_only_path_heuristics_by_default(
     tracker,
     tmp_path: Path,
 ):
     case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
     overlay_conf.write_text(
         overlay_conf.read_text(encoding="utf-8")
-        + '\nbeam.agentsim.customFileLabel = "scenario-a"\n',
+        + '\nbeam.agentsim.customFile = "scenario-a"\n',
         encoding="utf-8",
     )
-    adapter = BeamConfigAdapter(primary_config=overlay_conf)
-    canonical = adapter.discover([case_dir], identity=tracker.identity)
-    run = tracker.begin_run("beam_no_heuristic_refs_unit", "beam")
-    result = adapter.canonicalize(
-        canonical,
-        run=run,
-        tracker=tracker,
-        strict=True,
-        options=ConfigAdapterOptions(allow_heuristic_refs=False),
+    adapter = BeamConfigAdapter(
+        primary_config=overlay_conf,
+        reference_policies={
+            "beam.agentsim.overridePath": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="dormant_test_reference",
+            )
+        },
     )
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_default_no_heuristic_refs_unit", "beam")
+    result = adapter.canonicalize(canonical, run=run, tracker=tracker, strict=True)
 
     refs_by_key = {ref.config_key: ref for ref in result.identity.references}
-    assert "beam.agentsim.customFileLabel" not in refs_by_key
+    assert "beam.agentsim.customFile" not in refs_by_key
     assert result.identity.scalars["options"]["allow_heuristic_refs"] is False
+
+
+def test_beam_canonicalize_can_enable_key_based_path_heuristics(
+    tracker,
+    tmp_path: Path,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + '\nbeam.agentsim.customFile = "scenario-a"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(primary_config=overlay_conf, allow_heuristic_refs=True)
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_enable_heuristic_refs_unit", "beam")
+    result = adapter.canonicalize(canonical, run=run, tracker=tracker)
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    assert refs_by_key["beam.agentsim.customFile"].status == "missing_required"
+    assert result.identity.scalars["options"]["allow_heuristic_refs"] is True
 
 
 def test_beam_canonicalize_supports_explicit_reference_policy(tracker, tmp_path: Path):
@@ -248,6 +320,57 @@ def test_beam_canonicalize_supports_explicit_reference_policy(tracker, tmp_path:
     assert override_ref.identity_policy == "ignored"
     assert override_ref.status == "missing_ignored"
     assert override_ref.reason == "dormant_test_reference"
+
+
+def test_beam_canonicalize_explicit_reference_policy_forces_bare_scalar(
+    tracker,
+    tmp_path: Path,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + '\nbeam.inputs.networkMode = "car"\n'
+        + '\nbeam.router.skim.activity-sim-skimmer.fileBaseName = "activitySimODSkims"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(
+        primary_config=overlay_conf,
+        reference_policies={
+            "beam.inputs.networkMode": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="explicit_scalar_policy",
+            ),
+            "beam.router.skim.activity-sim-skimmer.fileBaseName": BeamReferencePolicy(
+                identity_policy="output_or_runtime_ignored",
+                required=False,
+                reason="explicit_runtime_basename",
+            ),
+            "beam.agentsim.overridePath": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="dormant_test_reference",
+            ),
+        },
+    )
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_explicit_scalar_policy_unit", "beam")
+    result = adapter.canonicalize(canonical, run=run, tracker=tracker, strict=True)
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    scalar_ref = refs_by_key["beam.inputs.networkMode"]
+    assert scalar_ref.raw_value == "car"
+    assert scalar_ref.identity_policy == "ignored"
+    assert scalar_ref.status == "missing_ignored"
+    assert scalar_ref.reason == "explicit_scalar_policy"
+
+    basename_ref = refs_by_key[
+        "beam.router.skim.activity-sim-skimmer.fileBaseName"
+    ]
+    assert basename_ref.raw_value == "activitySimODSkims"
+    assert basename_ref.identity_policy == "output_or_runtime_ignored"
+    assert basename_ref.status == "missing_ignored"
+    assert basename_ref.reason == "explicit_runtime_basename"
 
 
 def test_beam_materialize_overrides(tracker, tmp_path: Path):

--- a/tests/unit/integrations/beam/test_beam_config_adapter.py
+++ b/tests/unit/integrations/beam/test_beam_config_adapter.py
@@ -9,7 +9,9 @@ import pytest
 from sqlalchemy import func, select
 from sqlmodel import Session, SQLModel
 
+from consist.core.config_canonicalization import ConfigAdapterOptions
 from consist.integrations.beam import BeamConfigAdapter, BeamConfigOverrides
+from consist.integrations.beam.config_adapter import BeamReferencePolicy
 from consist.integrations.beam.config_adapter import _load_config_tree
 from consist.models.beam import BeamConfigCache, BeamConfigIngestRunLink
 from consist.types import CacheOptions, ExecutionOptions
@@ -75,6 +77,177 @@ def test_beam_canonicalize_artifacts_and_rows(tracker, tmp_path: Path, caplog):
     ingest_tables = {spec.table_name for spec in result.ingestables}
     assert "beam_config_cache" in ingest_tables
     assert "beam_config_ingest_run_link" in ingest_tables
+    assert result.identity.adapter_name == "beam"
+    assert result.identity.identity_hash
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    assert refs_by_key["beam.inputDirectory"].identity_policy == "path_alias"
+    assert refs_by_key["beam.inputDirectory"].delegated_artifact_keys
+    assert (
+        refs_by_key[
+            "beam.agentsim.agents.vehicles.vehicleTypesFilePath"
+        ].identity_policy
+        == "content_hash"
+    )
+    missing_ref = refs_by_key["beam.agentsim.overridePath"]
+    assert missing_ref.status == "missing_required"
+    assert missing_ref.canonical_value is not None
+    assert missing_ref.canonical_value.endswith("missing/does-not-exist.csv")
+    assert any("beam.agentsim.overridePath" in r.message for r in caplog.records)
+
+
+def test_beam_canonicalize_normalizes_path_aliases(tracker, tmp_path: Path):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    external_root = tmp_path / "machine_local"
+    external_root.mkdir()
+    data_path = external_root / "scenario.csv"
+    data_path.write_text("id,value\n1,2\n", encoding="utf-8")
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + f'\nbeam.agentsim.aliasInput = "{data_path}"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(primary_config=overlay_conf)
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_alias_unit", "beam")
+    result = adapter.canonicalize(
+        canonical,
+        run=run,
+        tracker=tracker,
+        options=ConfigAdapterOptions(path_aliases={"local_inputs": external_root}),
+    )
+
+    alias_ref = next(
+        ref
+        for ref in result.identity.references
+        if ref.config_key == "beam.agentsim.aliasInput"
+    )
+    assert alias_ref.identity_policy == "content_hash"
+    assert alias_ref.canonical_value == "local_inputs/scenario.csv"
+    assert alias_ref.hash
+    assert result.identity.scalars["options"]["path_aliases"] == {
+        "local_inputs": external_root.resolve().as_posix()
+    }
+    tracker.end_run()
+
+    data_path.write_text("id,value\n1,3\n", encoding="utf-8")
+    run_changed = tracker.begin_run("beam_alias_unit_changed", "beam")
+    changed = adapter.canonicalize(
+        canonical,
+        run=run_changed,
+        tracker=tracker,
+        options=ConfigAdapterOptions(path_aliases={"local_inputs": external_root}),
+    )
+    assert changed.identity.identity_hash != result.identity.identity_hash
+
+
+def test_beam_canonicalize_ignores_output_runtime_paths(tracker, tmp_path: Path):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    existing_events = tmp_path / "runtime" / "events.xml.gz"
+    existing_events.parent.mkdir()
+    existing_events.write_text("events\n", encoding="utf-8")
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + f'\nbeam.outputs.eventsFilePath = "{existing_events}"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(primary_config=overlay_conf)
+    canonical_a = adapter.discover([case_dir], identity=tracker.identity)
+    run_a = tracker.begin_run("beam_output_identity_a", "beam")
+    result_a = adapter.canonicalize(canonical_a, run=run_a, tracker=tracker)
+    tracker.end_run()
+
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8").replace(
+            str(existing_events),
+            str(tmp_path / "runtime_other" / "events.xml.gz"),
+        ),
+        encoding="utf-8",
+    )
+    canonical_b = adapter.discover([case_dir], identity=tracker.identity)
+    run_b = tracker.begin_run("beam_output_identity_b", "beam")
+    result_b = adapter.canonicalize(canonical_b, run=run_b, tracker=tracker)
+
+    output_ref = next(
+        ref
+        for ref in result_b.identity.references
+        if ref.config_key == "beam.outputs.eventsFilePath"
+    )
+    assert output_ref.identity_policy == "output_or_runtime_ignored"
+    assert output_ref.required is False
+    assert result_b.identity.identity_hash == result_a.identity.identity_hash
+
+
+def test_beam_canonicalize_does_not_treat_scalar_input_keys_as_paths(
+    tracker,
+    tmp_path: Path,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + '\nbeam.inputs.networkMode = "car"\n'
+        + '\nbeam.agentsim.vehicles.assignment = "household"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(primary_config=overlay_conf)
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_scalar_path_key_unit", "beam")
+    result = adapter.canonicalize(canonical, run=run, tracker=tracker)
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    assert "beam.inputs.networkMode" not in refs_by_key
+    assert "beam.agentsim.vehicles.assignment" not in refs_by_key
+
+
+def test_beam_canonicalize_can_disable_key_based_path_heuristics(
+    tracker,
+    tmp_path: Path,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + '\nbeam.agentsim.customFileLabel = "scenario-a"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(primary_config=overlay_conf)
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_no_heuristic_refs_unit", "beam")
+    result = adapter.canonicalize(
+        canonical,
+        run=run,
+        tracker=tracker,
+        strict=True,
+        options=ConfigAdapterOptions(allow_heuristic_refs=False),
+    )
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    assert "beam.agentsim.customFileLabel" not in refs_by_key
+    assert result.identity.scalars["options"]["allow_heuristic_refs"] is False
+
+
+def test_beam_canonicalize_supports_explicit_reference_policy(tracker, tmp_path: Path):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    adapter = BeamConfigAdapter(
+        primary_config=overlay_conf,
+        reference_policies={
+            "beam.agentsim.overridePath": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="dormant_test_reference",
+            )
+        },
+    )
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_policy_unit", "beam")
+    result = adapter.canonicalize(canonical, run=run, tracker=tracker, strict=True)
+
+    override_ref = next(
+        ref
+        for ref in result.identity.references
+        if ref.config_key == "beam.agentsim.overridePath"
+    )
+    assert override_ref.identity_policy == "ignored"
+    assert override_ref.status == "missing_ignored"
+    assert override_ref.reason == "dormant_test_reference"
 
 
 def test_beam_materialize_overrides(tracker, tmp_path: Path):

--- a/tests/unit/integrations/beam/test_beam_config_adapter.py
+++ b/tests/unit/integrations/beam/test_beam_config_adapter.py
@@ -364,9 +364,7 @@ def test_beam_canonicalize_explicit_reference_policy_forces_bare_scalar(
     assert scalar_ref.status == "missing_ignored"
     assert scalar_ref.reason == "explicit_scalar_policy"
 
-    basename_ref = refs_by_key[
-        "beam.router.skim.activity-sim-skimmer.fileBaseName"
-    ]
+    basename_ref = refs_by_key["beam.router.skim.activity-sim-skimmer.fileBaseName"]
     assert basename_ref.raw_value == "activitySimODSkims"
     assert basename_ref.identity_policy == "output_or_runtime_ignored"
     assert basename_ref.status == "missing_ignored"


### PR DESCRIPTION
## Summary

This PR implements a structured config adapter identity migration as an intentional breaking change to the config adapter contract.

Adapters must now return `CanonicalizationResult(identity=CanonicalConfigIdentity(...), ...)`. The canonical adapter identity is `result.identity.identity_hash`; existing public run metadata keys such as `config_bundle_hash`, `config_adapter`, and `config_adapter_version` remain compatibility aliases.

## What Changed

- Added core config identity dataclasses:
  - `CanonicalConfigIdentity`
  - `ConfigReference`
  - `ConfigPathAlias`
  - `DirectoryIdentity`
  - `MaterializationRequirement`
- Updated `CanonicalizationResult`, `ConfigPlan`, and `ConfigContribution` to carry structured identity.
- Persisted compact manifests in `run.meta["config_identity_manifest"]`.
- Kept `__consist_config_plan__` hash-focused: adapter, adapter version, and identity hash only.
- Exposed the structured manifest through `Run.identity_summary`.

## Adapter Changes

### BEAM

- Added keyed reference collection with config keys, raw values, canonical values, statuses, roles, requiredness, policies, hashes, and delegated artifact keys.
- Added path alias support through adapter defaults and `ConfigAdapterOptions(path_aliases=...)`.
- Added BEAM reference policies:
  - `content_hash`
  - `path_alias`
  - `delegated_to_artifacts`
  - `ignored`
  - `output_or_runtime_ignored`
- Canonicalized identity-relevant path-like scalar values before hashing and cache-row generation.
- Kept aliased files content-hashed by default; aliases canonicalize names but do not suppress file-byte identity unless explicitly delegated.
- Ignored output/runtime paths no longer affect identity.
- Narrowed heuristic path detection and wired `allow_heuristic_refs`.

### ActivitySim

- Replaced root-path-sensitive adapter identity with a path-stable manifest identity.
- Manifest includes logical config file keys, active YAMLs, referenced CSVs, roles, options, component hashes, and directory fingerprints.
- Identical config contents under different temp roots now produce stable identity.

## Cache-Miss Diagnostics

- Added manifest-first config miss diffing before facet/JSON fallback.
- New details include:
  - `config_references_changed`
  - `config_references_added`
  - `config_references_removed`
  - `config_files_changed`
  - `config_files_added`
  - `config_files_removed`
  - `reference_status_changed`
  - `config_identity_options_changed`

## Docs And Release Notes

- Updated config adapter docs and BEAM adapter docs.
- Updated run/cache-miss docs.
- Added changelog entry noting the breaking adapter API change.
- Documented that broader container mutable-directory identity/de-duplication is a follow-up outside this config-adapter PR.
