### PR TITLE
Fix requested input staging fast hash

### DIFF
--- a/src/consist/core/cache.py
+++ b/src/consist/core/cache.py
@@ -56,8 +56,21 @@ class CacheFs(Protocol):
 
 
 @runtime_checkable
+class CacheIdentity(Protocol):
+    def compute_file_checksum(self, file_path: str | Path) -> str: ...
+
+
+@runtime_checkable
+class CacheMaterializationRootContext(Protocol):
+    run_dir: Path
+    mounts: Dict[str, str]
+    allow_external_paths: bool
+
+
+@runtime_checkable
 class CacheHydrationContext(Protocol):
     run_dir: Path
+    allow_external_paths: bool
     current_consist: Optional[ConsistRecord]
     db: Optional[CacheDb]
     fs: CacheFs
@@ -108,7 +121,9 @@ class CacheMaterializationContext(Protocol):
     current_consist: Optional[ConsistRecord]
     db: Optional[CacheDb]
     fs: CacheFs
+    identity: CacheIdentity
     run_dir: Path
+    allow_external_paths: bool
     mounts: Dict[str, str]
 
     def resolve_uri(self, uri: str) -> str: ...
@@ -144,7 +159,7 @@ def _can_delegate_run_output_materialization(tracker: CacheHydrationContext) -> 
 
 
 def _allowed_materialization_roots(
-    tracker: CacheMaterializationContext,
+    tracker: CacheMaterializationRootContext,
     *,
     target_run: Run | None = None,
 ) -> tuple[Path, ...] | None:
@@ -835,6 +850,11 @@ def materialize_requested_inputs(
             return ("file", _file_hash(path))
         return None
 
+    def _artifact_hash_matches_path(artifact: Artifact, path: Path) -> bool:
+        if not artifact.hash:
+            return False
+        return tracker.identity.compute_file_checksum(path) == artifact.hash
+
     def _paths_match(source: Path, destination: Path) -> bool:
         if source.resolve() == destination.resolve():
             return True
@@ -935,8 +955,7 @@ def materialize_requested_inputs(
             if (
                 source_path is None
                 and artifact.hash
-                and destination_path.is_file()
-                and _file_hash(destination_path) == artifact.hash
+                and _artifact_hash_matches_path(artifact, destination_path)
             ):
                 artifact.abs_path = str(destination_path)
                 staged[key] = str(destination_path)
@@ -973,8 +992,7 @@ def materialize_requested_inputs(
                 if (
                     active_options.requested_input_validate_content_hash == "if-present"
                     and artifact.hash
-                    and staged_path.is_file()
-                    and _file_hash(staged_path) != artifact.hash
+                    and not _artifact_hash_matches_path(artifact, staged_path)
                 ):
                     raise ValueError(
                         format_problem_cause_fix(
@@ -1011,8 +1029,7 @@ def materialize_requested_inputs(
         if (
             active_options.requested_input_validate_content_hash == "if-present"
             and artifact.hash
-            and destination_path.is_file()
-            and _file_hash(destination_path) != artifact.hash
+            and not _artifact_hash_matches_path(artifact, destination_path)
         ):
             raise ValueError(
                 format_problem_cause_fix(

--- a/tests/unit/core/test_input_staging_runtime.py
+++ b/tests/unit/core/test_input_staging_runtime.py
@@ -57,6 +57,34 @@ def test_tracker_run_requested_input_materialization_stages_before_execution(
     assert result.run.meta["staged_inputs"]["data"] == str(staged_path.resolve())
 
 
+def test_tracker_run_requested_input_materialization_validates_fast_hash(
+    tracker, sample_csv
+) -> None:
+    tracker.identity.hashing_strategy = "fast"
+    source = sample_csv("runtime_stage_fast.csv", rows=3)
+    staged_path = tracker.run_dir / "workspace" / "runtime_stage_fast.csv"
+
+    def step(data: Path) -> None:
+        assert data == staged_path
+        assert pd.read_csv(data)["value"].tolist() == [0, 1, 2]
+
+    result = tracker.run(
+        fn=step,
+        name="requested_input_stage_fast_hash",
+        inputs={"data": source},
+        execution_options=ExecutionOptions(
+            input_binding="paths",
+            input_materialization="requested",
+            input_paths={"data": staged_path},
+        ),
+    )
+
+    assert result.cache_hit is False
+    assert staged_path.exists()
+    input_artifact = tracker.get_artifacts_for_run(result.run.id).inputs["data"]
+    assert tracker.identity.compute_file_checksum(staged_path) == input_artifact.hash
+
+
 def test_tracker_run_requested_input_materialization_runs_on_cache_hit(
     tracker, sample_csv
 ) -> None:

--- a/tests/unit/core/test_requested_input_staging.py
+++ b/tests/unit/core/test_requested_input_staging.py
@@ -45,6 +45,7 @@ class _FakeTracker:
             get_remappable_relative_path=lambda uri: None,
             get_historical_root=lambda **kwargs: None,
         )
+        self.identity = SimpleNamespace(compute_file_checksum=_sha256)
         self.run_dir = run_dir
         self.mounts = {}
 

--- a/tests/unit/integrations/beam/test_beam_config_adapter.py
+++ b/tests/unit/integrations/beam/test_beam_config_adapter.py
@@ -364,9 +364,7 @@ def test_beam_canonicalize_explicit_reference_policy_forces_bare_scalar(
     assert scalar_ref.status == "missing_ignored"
     assert scalar_ref.reason == "explicit_scalar_policy"
 
-    basename_ref = refs_by_key[
-        "beam.router.skim.activity-sim-skimmer.fileBaseName"
-    ]
+    basename_ref = refs_by_key["beam.router.skim.activity-sim-skimmer.fileBaseName"]
     assert basename_ref.raw_value == "activitySimODSkims"
     assert basename_ref.identity_policy == "output_or_runtime_ignored"
     assert basename_ref.status == "missing_ignored"


### PR DESCRIPTION
**Summary**

Fix requested input staging hash validation so it respects the tracker’s configured artifact identity strategy. Previously, `ExecutionOptions(input_materialization="requested", input_paths={...})` validated staged files with raw SHA-256 bytes, which could reject valid staged inputs when the tracker used `hashing_strategy="fast"`.

**Changes**

- Add a typed cache identity protocol for `identity.compute_file_checksum(...)`.
- Validate requested staged inputs through `tracker.identity.compute_file_checksum(...)` instead of raw SHA-256.
- Add a focused regression test covering requested input staging with `hashing_strategy="fast"`.
- Keep materialization-root typing narrow with a dedicated protocol so hydration and input staging both type-check cleanly.
