### PR TITLE
Adapter robustness fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## [0.1.4] - 2026-05-05
+
+### Fixed
+
+- Fix BEAM config reference discovery so multiline and long comma-separated
+  scalar values are not probed as filesystem paths, and path-resolution errors
+  fail closed during canonicalization.
+
 ## [0.1.3] - 2026-05-04
 
 ### Added
@@ -315,7 +323,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-[Unreleased]: https://github.com/LBNL-UCB-STI/consist/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/LBNL-UCB-STI/consist/compare/v0.1.4...HEAD
+
+[0.1.4]: https://github.com/LBNL-UCB-STI/consist/compare/v0.1.3...v0.1.4
 
 [0.1.3]: https://github.com/LBNL-UCB-STI/consist/compare/v0.1.2...v0.1.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "consist"
-version = "0.1.3"
+version = "0.1.4"
 description = "Provenance tracking, intelligent caching, and data virtualization for scientific simulation workflows."
 readme = "README.md"
 authors = [

--- a/src/consist/integrations/beam/config_adapter.py
+++ b/src/consist/integrations/beam/config_adapter.py
@@ -70,6 +70,8 @@ except ImportError:  # pragma: no cover
 
 
 _INCLUDE_RE = re.compile(r"^\s*include\s+(?:\"([^\"]+)\"|file\(\"([^\"]+)\"\))")
+_MAX_IMPLICIT_PATH_VALUE_LENGTH = 512
+_PATH_PROBE_EXCEPTIONS = (OSError, ValueError, RuntimeError)
 
 _DEFAULT_OVERRIDE_RUNTIME_KWARGS: dict[str, str] = {
     "config_dir": "selected_root_dir",
@@ -233,7 +235,7 @@ class BeamConfigAdapter:
             if ref.identity_policy in {"ignored", "output_or_runtime_ignored"}:
                 continue
             resolved = _resolve_reference(ref.raw_value, config.root_dirs)
-            if resolved is None or not resolved.exists():
+            if resolved is None or not _path_exists(resolved):
                 continue
             _add_artifact(
                 artifacts_by_path,
@@ -827,6 +829,21 @@ def _is_path_like_config_value(value: str) -> bool:
     )
 
 
+def _can_probe_implicit_path_value(value: str) -> bool:
+    candidate = value.strip()
+    if not candidate:
+        return False
+    if "\n" in candidate or "\r" in candidate:
+        return False
+    if len(candidate) > _MAX_IMPLICIT_PATH_VALUE_LENGTH:
+        return False
+    if "," in candidate and "/" not in candidate and "\\" not in candidate:
+        tokens = [token.strip() for token in candidate.split(",")]
+        if sum(bool(token) for token in tokens) > 1:
+            return False
+    return True
+
+
 def _collect_path_candidates(
     config_tree: dict[str, Any],
     *,
@@ -847,9 +864,21 @@ def _collect_path_candidates(
             for index, item in enumerate(node):
                 walk(item, f"{prefix}[{index}]")
             return
-        if isinstance(node, str) and (
-            prefix in explicit_policy_keys
-            or _is_path_like_config_value(node)
+        if not isinstance(node, str):
+            return
+        if prefix in explicit_policy_keys:
+            candidates.append(
+                _BeamPathCandidate(
+                    config_key=prefix,
+                    raw_value=node.strip(),
+                    index=len(candidates),
+                )
+            )
+            return
+        if not _can_probe_implicit_path_value(node):
+            return
+        if (
+            _is_path_like_config_value(node)
             or _resolves_under_config_root(node, root_dirs)
             or (allow_heuristic_refs and _is_path_like_config_key(prefix))
         ):
@@ -869,14 +898,22 @@ def _resolves_under_config_root(value: str, root_dirs: Sequence[Path]) -> bool:
     raw = value.strip()
     if not raw:
         return False
-    candidate = Path(raw).expanduser()
+    candidate = _safe_path(raw)
+    if candidate is None:
+        return False
     if candidate.is_absolute():
-        resolved = candidate.resolve()
-        return resolved.exists() and any(
-            resolved == root.resolve() or resolved.is_relative_to(root.resolve())
-            for root in root_dirs
+        resolved = _safe_resolve(candidate)
+        if resolved is None or not _path_exists(resolved):
+            return False
+        return any(
+            root_resolved is not None
+            and (resolved == root_resolved or resolved.is_relative_to(root_resolved))
+            for root_resolved in (_safe_resolve(root) for root in root_dirs)
         )
-    return any((root / candidate).resolve().exists() for root in root_dirs)
+    return any(
+        resolved is not None and _path_exists(resolved)
+        for resolved in (_safe_resolve(root / candidate) for root in root_dirs)
+    )
 
 
 def _merge_path_aliases(
@@ -963,6 +1000,41 @@ def _is_runtime_output_config_key(config_key: str) -> bool:
     return compact_key.endswith("filebasename")
 
 
+def _safe_path(value: str | Path) -> Optional[Path]:
+    try:
+        return Path(value).expanduser()
+    except _PATH_PROBE_EXCEPTIONS:
+        return None
+
+
+def _safe_resolve(path: Path) -> Optional[Path]:
+    try:
+        return path.resolve()
+    except _PATH_PROBE_EXCEPTIONS:
+        return None
+
+
+def _path_exists(path: Path) -> bool:
+    try:
+        return path.exists()
+    except _PATH_PROBE_EXCEPTIONS:
+        return False
+
+
+def _path_is_file(path: Path) -> bool:
+    try:
+        return path.is_file()
+    except _PATH_PROBE_EXCEPTIONS:
+        return False
+
+
+def _path_is_dir(path: Path) -> bool:
+    try:
+        return path.is_dir()
+    except _PATH_PROBE_EXCEPTIONS:
+        return False
+
+
 def _canonical_path_value(
     *,
     raw_value: str,
@@ -970,10 +1042,13 @@ def _canonical_path_value(
     root_dirs: Sequence[Path],
     path_aliases: Mapping[str, Path],
 ) -> str:
-    path = resolved or Path(raw_value)
-    path = path.expanduser()
+    path = resolved or _safe_path(raw_value)
+    if path is None:
+        return raw_value
     if path.is_absolute():
-        resolved_path = path.resolve()
+        resolved_path = _safe_resolve(path)
+        if resolved_path is None:
+            return raw_value
         alias_matches = sorted(
             (
                 (alias, root)
@@ -988,7 +1063,9 @@ def _canonical_path_value(
             rel = resolved_path.relative_to(root).as_posix()
             return alias if not rel else f"{alias}/{rel}"
         for root in root_dirs:
-            root_resolved = root.resolve()
+            root_resolved = _safe_resolve(root)
+            if root_resolved is None:
+                continue
             if resolved_path == root_resolved or resolved_path.is_relative_to(
                 root_resolved
             ):
@@ -1001,9 +1078,12 @@ def _canonical_path_value(
         return raw_value
 
     if resolved is not None:
+        resolved_path = _safe_resolve(resolved)
+        if resolved_path is None:
+            return raw_value
         return _canonical_path_value(
             raw_value=raw_value,
-            resolved=resolved.resolve(),
+            resolved=resolved_path,
             root_dirs=root_dirs,
             path_aliases=path_aliases,
         )
@@ -1064,7 +1144,7 @@ def _build_beam_config_identity(
     ):
         policy = _policy_for_candidate(candidate, reference_policies)
         resolved = _resolve_reference(candidate.raw_value, root_dirs)
-        exists = bool(resolved is not None and resolved.exists())
+        exists = bool(resolved is not None and _path_exists(resolved))
         canonical_value = _canonical_path_value(
             raw_value=candidate.raw_value,
             resolved=resolved,
@@ -1087,9 +1167,9 @@ def _build_beam_config_identity(
 
         digest: Optional[str] = None
         if exists and resolved is not None:
-            if identity_policy == "content_hash" and resolved.is_file():
+            if identity_policy == "content_hash" and _path_is_file(resolved):
                 digest = _digest_path(resolved, tracker)
-            elif identity_policy == "content_hash" and resolved.is_dir():
+            elif identity_policy == "content_hash" and _path_is_dir(resolved):
                 identity_policy = "delegated_to_artifacts"
                 reason = reason or "directory_content_delegated_to_artifact_inputs"
                 if not delegated_artifact_keys:
@@ -1101,7 +1181,7 @@ def _build_beam_config_identity(
                     delegated_artifact_keys = (
                         _artifact_key_for_path(resolved, root_dirs),
                     )
-        if exists and resolved is not None and resolved.is_dir():
+        if exists and resolved is not None and _path_is_dir(resolved):
             directories.append(
                 DirectoryIdentity(
                     canonical_value=canonical_value,
@@ -1200,14 +1280,21 @@ def _build_beam_config_identity(
 
 
 def _resolve_reference(value: str, root_dirs: Sequence[Path]) -> Optional[Path]:
-    candidate = Path(value)
+    raw = value.strip()
+    if not raw:
+        return None
+    candidate = _safe_path(raw)
+    if candidate is None:
+        return None
     if candidate.is_absolute():
         return candidate
     for root in root_dirs:
-        resolved = (root / candidate).resolve()
-        if resolved.exists():
+        resolved = _safe_resolve(root / candidate)
+        if resolved is not None and _path_exists(resolved):
             return resolved
-    return (root_dirs[0] / candidate).resolve() if root_dirs else None
+    if not root_dirs:
+        return None
+    return _safe_resolve(root_dirs[0] / candidate)
 
 
 def _artifact_key_for_path(path: Path, config_dirs: Sequence[Path]) -> str:
@@ -1406,7 +1493,7 @@ def _build_tabular_ingest_specs(
         candidates = _coerce_to_path_values(value)
         for candidate in candidates:
             resolved = _resolve_reference(candidate, root_dirs)
-            if resolved is None or not resolved.exists():
+            if resolved is None or not _path_exists(resolved):
                 logging.warning(
                     "[Consist][BEAM] Missing referenced path: %s", candidate
                 )

--- a/tests/unit/integrations/beam/test_beam_config_adapter.py
+++ b/tests/unit/integrations/beam/test_beam_config_adapter.py
@@ -13,6 +13,8 @@ from consist.core.config_canonicalization import ConfigAdapterOptions
 from consist.integrations.beam import BeamConfigAdapter, BeamConfigOverrides
 from consist.integrations.beam.config_adapter import BeamReferencePolicy
 from consist.integrations.beam.config_adapter import _load_config_tree
+from consist.integrations.beam.config_adapter import _resolve_reference
+from consist.integrations.beam.config_adapter import _resolves_under_config_root
 from consist.models.beam import BeamConfigCache, BeamConfigIngestRunLink
 from consist.types import CacheOptions, ExecutionOptions
 from tests.helpers.beam_fixtures import build_beam_test_configs
@@ -245,6 +247,164 @@ def test_beam_canonicalize_keeps_file_format_scalars_out_of_references(
     ):
         assert scalar_key not in refs_by_key
         assert scalar_key not in caplog.text
+
+
+def test_beam_canonicalize_keeps_multiline_scalars_out_of_references(
+    tracker,
+    tmp_path: Path,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + """
+beam.sim.metric.collector.metrics = \"\"\"
+beam-run, beam-iteration, beam-map-envelope,
+beam-run-households, beam-run-population-size,
+ride-hail-waiting-time, ride-hail-waiting-time-map, ride-hail-trip-distance
+\"\"\"
+""",
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(
+        primary_config=overlay_conf,
+        reference_policies={
+            "beam.agentsim.overridePath": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="dormant_test_reference",
+            )
+        },
+    )
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_multiline_scalar_unit", "beam")
+    result = adapter.canonicalize(
+        canonical,
+        run=run,
+        tracker=tracker,
+        strict=True,
+    )
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    assert "beam.sim.metric.collector.metrics" not in refs_by_key
+    assert refs_by_key["beam.inputDirectory"].status == "resolved"
+    assert (
+        refs_by_key["beam.agentsim.agents.vehicles.vehicleTypesFilePath"].status
+        == "resolved"
+    )
+    assert refs_by_key["beam.agentsim.overridePath"].status == "missing_ignored"
+
+
+def test_beam_canonicalize_keeps_long_comma_scalars_out_of_references(
+    tracker,
+    tmp_path: Path,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    event_list = ",".join(f"PersonSyntheticEvent{index}" for index in range(40))
+    assert len(event_list) > 512
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + f'\nbeam.outputs.events.eventsToWrite = "{event_list}"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(primary_config=overlay_conf)
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_long_comma_scalar_unit", "beam")
+    result = adapter.canonicalize(canonical, run=run, tracker=tracker)
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    assert "beam.outputs.events.eventsToWrite" not in refs_by_key
+
+
+def test_beam_multiline_scalar_changes_scalar_identity_not_reference_identity(
+    tracker,
+    tmp_path: Path,
+):
+    results = []
+    for suffix, metric_value in (
+        ("a", "beam-run, beam-iteration"),
+        ("b", "beam-run, beam-iteration, ride-hail-waiting-time"),
+    ):
+        case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path / suffix)
+        overlay_conf.write_text(
+            overlay_conf.read_text(encoding="utf-8")
+            + f'\nbeam.sim.metric.collector.metrics = """\n{metric_value}\n"""\n',
+            encoding="utf-8",
+        )
+        adapter = BeamConfigAdapter(
+            primary_config=overlay_conf,
+            reference_policies={
+                "beam.agentsim.overridePath": BeamReferencePolicy(
+                    identity_policy="ignored",
+                    required=False,
+                    reason="dormant_test_reference",
+                )
+            },
+        )
+        canonical = adapter.discover([case_dir], identity=tracker.identity)
+        run = tracker.begin_run(f"beam_scalar_identity_{suffix}", "beam")
+        results.append(
+            adapter.canonicalize(
+                canonical,
+                run=run,
+                tracker=tracker,
+                strict=True,
+            )
+        )
+        tracker.end_run()
+
+    assert results[0].identity.scalar_hash != results[1].identity.scalar_hash
+    assert results[0].identity.reference_hash == results[1].identity.reference_hash
+
+
+def test_beam_explicit_policy_overrides_scalar_path_prefilter(
+    tracker,
+    tmp_path: Path,
+):
+    case_dir, overlay_conf, _ = build_beam_test_configs(tmp_path)
+    event_list = "PersonArrivalEvent,PersonDepartureEvent,ActivityEndEvent"
+    overlay_conf.write_text(
+        overlay_conf.read_text(encoding="utf-8")
+        + f'\nbeam.outputs.events.eventsToWrite = "{event_list}"\n',
+        encoding="utf-8",
+    )
+    adapter = BeamConfigAdapter(
+        primary_config=overlay_conf,
+        reference_policies={
+            "beam.outputs.events.eventsToWrite": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="explicit_event_scalar",
+            ),
+            "beam.agentsim.overridePath": BeamReferencePolicy(
+                identity_policy="ignored",
+                required=False,
+                reason="dormant_test_reference",
+            ),
+        },
+    )
+    canonical = adapter.discover([case_dir], identity=tracker.identity)
+    run = tracker.begin_run("beam_explicit_filtered_scalar_policy_unit", "beam")
+    result = adapter.canonicalize(
+        canonical,
+        run=run,
+        tracker=tracker,
+        strict=True,
+    )
+
+    refs_by_key = {ref.config_key: ref for ref in result.identity.references}
+    event_ref = refs_by_key["beam.outputs.events.eventsToWrite"]
+    assert event_ref.raw_value == event_list
+    assert event_ref.identity_policy == "ignored"
+    assert event_ref.status == "missing_ignored"
+    assert event_ref.reason == "explicit_event_scalar"
+
+
+def test_beam_path_probe_errors_fail_closed(tmp_path: Path):
+    with patch.object(Path, "exists", side_effect=OSError("file name too long")):
+        assert _resolves_under_config_root("candidate.csv", [tmp_path]) is False
+
+    with patch.object(Path, "resolve", side_effect=OSError("file name too long")):
+        assert _resolve_reference("candidate.csv", [tmp_path]) is None
 
 
 def test_beam_canonicalize_does_not_use_key_only_path_heuristics_by_default(

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "consist"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

Fix BEAM config reference discovery so scalar config values are not treated as filesystem paths during canonicalization.

This prevents `BeamConfigAdapter` from crashing on normal BEAM scalar values such as multiline metrics lists and long comma-separated event lists, which can otherwise trigger `OSError: [Errno 36] File name too long` when probed via `Path.exists()`.

Closes #122 

## Changes

- Add an implicit path-value prefilter for BEAM config reference discovery:
  - skips multiline strings
  - skips very long strings
  - skips obvious comma-separated scalar lists
  - keeps explicit `BeamReferencePolicy` keys exempt
- Harden BEAM path probing so `OSError`, `ValueError`, and `RuntimeError` fail closed instead of aborting canonicalization.
- Preserve existing behavior for real path references, missing path-like references, explicit policies, and `allow_heuristic_refs`.
- Add regression coverage for multiline metrics scalars, long BEAM event lists, scalar/reference identity behavior, explicit policy exemptions, and filesystem probe errors.
- Bump package metadata and changelog for `0.1.4`.