### PR TITLE
Add HDF5 container recovery policy guards

### DIFF
--- a/docs/api/artifact.md
+++ b/docs/api/artifact.md
@@ -24,6 +24,12 @@ Use `Tracker.get_child_artifacts(...)` and `Tracker.get_parent_artifact(...)`
 to navigate first-class parent-child artifact relations. This is the supported
 query surface for HDF5 container artifacts and other container-child patterns.
 
+The parent-child relation describes lineage and container membership; it does
+not by itself make a child artifact independently recoverable. For HDF5
+containers, recovery authority comes from the parent container policy recorded
+by `log_h5_container(...)`. The default restart-safe pattern is parent-file
+recovery with descriptive child `h5_table` artifacts.
+
 ## Minimal runnable example
 
 ```python

--- a/docs/api/materialize.md
+++ b/docs/api/materialize.md
@@ -79,6 +79,13 @@ Use the lower-level helpers when you want to manage archival yourself:
 - `tracker.archive_run_outputs(...)` applies the same pattern to all or a
   selected subset of outputs for a run.
 
+For HDF5 containers, verified recovery-copy adoption respects the parent
+container policy. Parent H5 files with
+`container_recovery_unit="parent_file"` can register recovery roots; child
+`h5_table` artifacts whose parent declares
+`child_recovery_policy="descriptive_only"` return
+`blocked_by_container_policy`.
+
 ## Recommended Workflow
 
 Hydrate only the outputs you need into a fresh workspace root:

--- a/docs/api/public_api.md
+++ b/docs/api/public_api.md
@@ -258,6 +258,10 @@ to Consist, start with the **Core** and **Logging/Loading** groups and reach for
 `log_h5_container(...)` now supports `child_specs={...}` and
 `child_selection="all" | "include_only"` so callers can either customize
 discovered child artifacts or log only a selected subset of HDF5 dataset paths.
+It also accepts parent recovery policy kwargs such as
+`container_recovery_unit="parent_file"` and
+`child_recovery_policy="descriptive_only"` so downstream recovery tools can
+distinguish parent-file recovery from descriptive child-table artifacts.
 `log_h5_table(...)` accepts the same child-level semantic metadata surface as
 normal artifact logging: `description`, `facet`, `facet_schema_version`, and
 `facet_index`.

--- a/docs/api/tracker.md
+++ b/docs/api/tracker.md
@@ -86,11 +86,20 @@ supports:
 - child-spec fields that mirror normal artifact ergonomics: `key`,
   `description`, `facet`, `facet_schema_version`, `facet_index`, and extra
   metadata
+- `container_recovery_unit="parent_file"` and
+  `child_recovery_policy="descriptive_only"` to make HDF5 recovery semantics
+  explicit when the parent file is the authoritative recovery unit
 
 Use `log_h5_table(...)` when you want to register a single child artifact
 without scanning the whole container. It accepts the same semantic metadata
 surface (`description`, `facet`, `facet_schema_version`, `facet_index`) and can
 link the child to a parent container artifact.
+
+For HDF5 containers, a child table artifact is not independently recoverable
+unless its parent container policy explicitly allows child recovery. The current
+safe policy for restart-critical HDF5 files is to register verified recovery
+copies on the parent H5 artifact and keep child `h5_table` artifacts
+descriptive-only for schema, lineage, diffing, and diagnostics.
 
 ## Constructing with `TrackerConfig`
 

--- a/docs/api/tracker.md
+++ b/docs/api/tracker.md
@@ -101,6 +101,22 @@ safe policy for restart-critical HDF5 files is to register verified recovery
 copies on the parent H5 artifact and keep child `h5_table` artifacts
 descriptive-only for schema, lineage, diffing, and diagnostics.
 
+```python
+from consist import H5ChildSpec
+
+container, children = tracker.log_h5_container(
+    "input_data_for_2019_outputs.h5",
+    key="usim_input_archive_2019",
+    child_selection="include_only",
+    child_specs={
+        "/households": H5ChildSpec(key="usim_households"),
+        "/persons": H5ChildSpec(key="usim_persons"),
+    },
+    container_recovery_unit="parent_file",
+    child_recovery_policy="descriptive_only",
+)
+```
+
 ## Constructing with `TrackerConfig`
 
 Use `Tracker.from_config(...)` when you want a typed configuration object for

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,14 +16,16 @@ The CLI looks for the provenance database in this order:
 
 ## Artifact Path Resolution
 
-Some artifacts are stored with relative URIs like `./outputs/...`. For commands that load
-or validate artifact files (`preview`, `validate`, and shell `preview`/`schema_profile`),
+Some artifacts are stored with relative URIs like `./outputs/...`. For commands that load,
+validate, or profile artifact files (`preview`, `validate`, `schema capture-file`,
+and shell `preview`/`schema_profile`),
 Consist resolves relative paths in this order:
 
 1. Explicit `--run-dir`
 2. Parent directory of `--db-path`
-3. Current working directory
-4. `_physical_run_dir` from run metadata (**only** when `--trust-db` is enabled)
+3. `consist_runs/` next to `--db-path`
+4. Current working directory
+5. `_physical_run_dir` from run metadata (**only** when `--trust-db` is enabled)
 
 This keeps default behavior safe while still supporting archived/moved run directories.
 
@@ -176,7 +178,8 @@ Options:
 
 - `--sample-rows N`: rows to sample during inference (default `1000`)
 - `--if-changed`: reuse a prior schema observation when the artifact hash is unchanged; this affects schema capture only, not artifact-row reuse
-- `--trust-db`: allow metadata-based mount inference when resolving paths
+- `--run-dir PATH`: explicit base directory for relative artifact paths
+- `--trust-db`: allow metadata-based mount/run-dir inference when resolving paths
 - `--db-path`: explicit DB path
 
 ### consist schema export

--- a/docs/guides/historical-recovery.md
+++ b/docs/guides/historical-recovery.md
@@ -199,6 +199,15 @@ hashing or otherwise lacks a byte-level `artifact.hash`; without a byte-level
 hash, verified registration returns `unverifiable_hash` and leaves metadata
 unchanged.
 
+HDF5 containers have an extra recovery policy guard. A parent H5 artifact can
+declare `container_recovery_unit="parent_file"` and
+`child_recovery_policy="descriptive_only"` through `log_h5_container(...)`.
+With that policy, verified recovery-copy registration is allowed on the parent
+H5 file but child `h5_table` artifacts return
+`blocked_by_container_policy`. For HDF5 containers, a child table artifact is
+not independently recoverable unless its parent container policy explicitly
+allows child recovery.
+
 Use the low-level metadata helper only when verification is handled elsewhere
 or you intentionally need to override recovery metadata:
 

--- a/docs/guides/historical-recovery.md
+++ b/docs/guides/historical-recovery.md
@@ -208,6 +208,33 @@ H5 file but child `h5_table` artifacts return
 not independently recoverable unless its parent container policy explicitly
 allows child recovery.
 
+```python
+from consist import H5ChildSpec
+
+container, children = tracker.log_h5_container(
+    "input_data_for_2019_outputs.h5",
+    key="usim_input_archive_2019",
+    child_selection="include_only",
+    child_specs={
+        "/households": H5ChildSpec(key="usim_households"),
+        "/persons": H5ChildSpec(key="usim_persons"),
+    },
+    container_recovery_unit="parent_file",
+    child_recovery_policy="descriptive_only",
+)
+
+registered = tracker.register_run_output_recovery_copies(
+    "prior_run_id",
+    Path("/archive/iteration_004"),
+    keys=["usim_input_archive_2019"],
+)
+```
+
+Keep `keys=[...]` pointed at the parent H5 artifact for restart recovery. Child
+table artifacts remain useful for schema, lineage, diffing, and diagnostics, but
+they should not be used as recovery roots unless a future parent policy makes
+child recovery explicitly authoritative.
+
 Use the low-level metadata helper only when verification is handled elsewhere
 or you intentionally need to override recovery metadata:
 

--- a/src/consist/api.py
+++ b/src/consist/api.py
@@ -1315,6 +1315,8 @@ def register_artifact_recovery_copy(
     when supplied. Without it, ``artifact.hash`` is only used for byte
     verification when the tracker is using full content hashing. Directory
     artifacts are intentionally blocked until directory manifest support exists.
+    HDF5 child table artifacts are also blocked unless a future parent
+    container policy explicitly supports independent child recovery.
     ``append`` defaults to True, like ``archive_artifact(...)``; pass
     ``append=False`` to replace existing recovery roots.
     """

--- a/src/consist/cli.py
+++ b/src/consist/cli.py
@@ -896,15 +896,18 @@ def _resolve_schema_capture_path(
     artifact: "Artifact",
     run: "Run",
     override_path: Optional[Path],
+    db_path: Optional[str],
+    run_dir: Optional[str],
+    trust_db: bool,
 ) -> Path:
     if override_path is not None:
         return override_path.expanduser().resolve()
 
-    candidates: List[Path] = []
+    candidates: List[Tuple[str, Path]] = []
 
-    def _append_candidate(candidate_factory) -> None:
+    def _append_candidate(label: str, candidate_factory) -> None:
         try:
-            candidates.append(candidate_factory())
+            candidates.append((label, candidate_factory()))
         except (
             AttributeError,
             NotImplementedError,
@@ -915,17 +918,35 @@ def _resolve_schema_capture_path(
         ):
             return
 
-    _append_candidate(lambda: tracker.resolve_historical_path(artifact, run))
-    _append_candidate(
-        lambda: Path(tracker.resolve_uri(artifact.container_uri)).resolve()
-    )
+    if artifact.container_uri.startswith("./"):
+        resolution_bases, _ = _build_relative_resolution_bases(
+            tracker,
+            artifact,
+            db_path=db_path,
+            run_dir=run_dir,
+            trust_db=trust_db,
+        )
+        for label, base_dir in resolution_bases:
+            candidates.append(
+                (label, (base_dir / artifact.container_uri[2:]).resolve())
+            )
+    else:
+        if trust_db:
+            _append_candidate(
+                "trusted historical run metadata",
+                lambda: tracker.resolve_historical_path(artifact, run),
+            )
+        _append_candidate(
+            "current tracker resolution",
+            lambda: Path(tracker.resolve_uri(artifact.container_uri)).resolve(),
+        )
 
-    for candidate in candidates:
+    for _, candidate in candidates:
         if candidate.exists():
             return candidate
 
     if candidates:
-        rendered = ", ".join(str(path) for path in candidates)
+        rendered = ", ".join(f"{label}: {path}" for label, path in candidates)
         raise FileNotFoundError(
             "Could not resolve an existing artifact file path. "
             f"Tried: {rendered}. Provide --path to override."
@@ -958,6 +979,11 @@ def schema_capture_file(
         None,
         "--path",
         help="Override on-disk file path to profile.",
+    ),
+    run_dir: Optional[str] = typer.Option(
+        None,
+        "--run-dir",
+        help="Base directory for resolving relative artifact paths like ./outputs/...",
     ),
     sample_rows: int = typer.Option(
         1000,
@@ -1016,7 +1042,11 @@ def schema_capture_file(
 
     resolved_db_path = find_db_path(db_path)
     mount_overrides = _resolve_mount_overrides_or_exit(mount)
-    tracker = get_tracker(resolved_db_path, mounts=mount_overrides or None)
+    tracker = get_tracker(
+        resolved_db_path,
+        run_dir=run_dir,
+        mounts=mount_overrides or None,
+    )
     if artifact_id is not None:
         artifact = tracker.get_artifact(artifact_id)
     else:
@@ -1064,6 +1094,9 @@ def schema_capture_file(
             artifact=artifact,
             run=run,
             override_path=path,
+            db_path=resolved_db_path,
+            run_dir=run_dir,
+            trust_db=trust_db,
         )
     except FileNotFoundError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -2071,7 +2104,9 @@ def _build_relative_resolution_bases_for_uri(
         _append("explicit --run-dir", run_dir)
 
     if db_path:
-        _append("db-path parent", _resolve_cli_path(db_path).parent)
+        db_parent = _resolve_cli_path(db_path).parent
+        _append("db-path parent", db_parent)
+        _append("db-path parent / consist_runs", db_parent / "consist_runs")
 
     _append("current working directory", Path.cwd())
 

--- a/src/consist/core/artifacts.py
+++ b/src/consist/core/artifacts.py
@@ -8,6 +8,11 @@ from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Type, 
 
 from sqlmodel import SQLModel
 
+from consist.core.container_policy import (
+    ChildRecoveryPolicy,
+    ContainerRecoveryUnit,
+    apply_container_policy_meta,
+)
 from consist.core.drivers import ARRAY_DRIVERS, TABLE_DRIVERS
 from consist.core.cache_output_logging import _demote_cache_hit
 from consist.core.validation import validate_artifact_key
@@ -654,6 +659,9 @@ class ArtifactManager:
         table_hash_chunk_rows: Optional[int] = None,
         child_specs: Optional[Mapping[str, H5ChildSpec]] = None,
         child_selection: H5ChildSelectionMode = "all",
+        container_recovery_unit: ContainerRecoveryUnit | None = None,
+        child_recovery_policy: ChildRecoveryPolicy | None = None,
+        representation_policy: Optional[Mapping[str, Any]] = None,
         **meta: Any,
     ) -> tuple[Artifact, List[Artifact]]:
         """
@@ -689,6 +697,16 @@ class ArtifactManager:
         child_selection : {"all", "include_only"}, default "all"
             Whether discovered tables are all eligible for logging or restricted
             to the dataset paths listed in ``child_specs``.
+        container_recovery_unit : {"parent_file", "derived_children"}, optional
+            Recovery authority for the HDF5 container. Use ``"parent_file"`` when
+            verified recovery roots apply to the whole H5 file.
+        child_recovery_policy : {"descriptive_only", "independent"}, optional
+            Recovery policy for child ``h5_table`` artifacts. Use
+            ``"descriptive_only"`` when children are lineage/schema records and
+            not independently recoverable.
+        representation_policy : Optional[Mapping[str, Any]], optional
+            Optional policy metadata for derived physical representations such
+            as future parquet inspection caches.
         **meta : Any
             Additional metadata for the container artifact.
 
@@ -706,6 +724,13 @@ class ArtifactManager:
             raise RuntimeError("Cannot log artifact outside of a run context.")
         if child_selection not in {"all", "include_only"}:
             raise ValueError("child_selection must be 'all' or 'include_only'.")
+
+        apply_container_policy_meta(
+            meta,
+            container_recovery_unit=container_recovery_unit,
+            child_recovery_policy=child_recovery_policy,
+            representation_policy=representation_policy,
+        )
 
         path_obj = Path(path)
         if key is None:

--- a/src/consist/core/artifacts.py
+++ b/src/consist/core/artifacts.py
@@ -4,7 +4,17 @@ import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Literal,
+    Optional,
+    Type,
+    TypeAlias,
+    Union,
+)
 
 from sqlmodel import SQLModel
 
@@ -26,6 +36,11 @@ from consist.types import (
 
 if TYPE_CHECKING:
     from consist.core.tracker import Tracker
+
+
+ContainerPolicyMetaValue: TypeAlias = (
+    ContainerRecoveryUnit | ChildRecoveryPolicy | Mapping[str, object]
+)
 
 
 @dataclass(slots=True)
@@ -147,6 +162,45 @@ def _resolve_h5_child_spec(
         child_specs.get(normalized_path)
         or child_specs.get(normalized_path.lstrip("/"))
         or child_specs.get(table_path)
+    )
+
+
+def _container_policy_updates(
+    meta: Mapping[str, object],
+) -> dict[str, ContainerPolicyMetaValue]:
+    updates: dict[str, ContainerPolicyMetaValue] = {}
+    recovery_unit = meta.get("container_recovery_unit")
+    if recovery_unit == "parent_file":
+        updates["container_recovery_unit"] = "parent_file"
+    elif recovery_unit == "derived_children":
+        updates["container_recovery_unit"] = "derived_children"
+    child_policy = meta.get("child_recovery_policy")
+    if child_policy == "descriptive_only":
+        updates["child_recovery_policy"] = "descriptive_only"
+    elif child_policy == "independent":
+        updates["child_recovery_policy"] = "independent"
+    representation_policy = meta.get("representation_policy")
+    if isinstance(representation_policy, Mapping):
+        updates["representation_policy"] = {
+            str(key): value for key, value in representation_policy.items()
+        }
+    return updates
+
+
+def _clone_artifact_for_meta_update(artifact: Artifact) -> Artifact:
+    return Artifact(
+        id=artifact.id,
+        key=artifact.key,
+        container_uri=artifact.container_uri,
+        table_path=artifact.table_path,
+        array_path=artifact.array_path,
+        driver=artifact.driver,
+        hash=artifact.hash,
+        content_id=artifact.content_id,
+        parent_artifact_id=artifact.parent_artifact_id,
+        run_id=artifact.run_id,
+        meta=dict(artifact.meta or {}),
+        created_at=artifact.created_at,
     )
 
 
@@ -864,6 +918,15 @@ class ArtifactManager:
                     if cached_child_paths == requested_child_paths:
                         table_artifacts = list(cached_children)
                         reusing_cached_children = True
+                        policy_updates = _container_policy_updates(meta)
+                        if policy_updates:
+                            container.meta.update(policy_updates)
+                            if self.tracker.db is not None:
+                                self.tracker.db.update_artifact_meta(
+                                    _clone_artifact_for_meta_update(container),
+                                    dict(policy_updates),
+                                    raise_on_error=True,
+                                )
                     else:
                         _demote_cache_hit(
                             self.tracker.current_consist,

--- a/src/consist/core/container_policy.py
+++ b/src/consist/core/container_policy.py
@@ -1,0 +1,256 @@
+"""Recovery policy helpers for structured container artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from consist.models.artifact import Artifact
+
+ContainerRecoveryUnit = Literal["parent_file", "derived_children"]
+ChildRecoveryPolicy = Literal["descriptive_only", "independent"]
+RepresentationRole = Literal[
+    "none",
+    "derived_inspection_cache",
+    "authoritative_tabular_store",
+]
+
+CONTAINER_RECOVERY_UNITS = {"parent_file", "derived_children"}
+CHILD_RECOVERY_POLICIES = {"descriptive_only", "independent"}
+REPRESENTATION_ROLES = {
+    "none",
+    "derived_inspection_cache",
+    "authoritative_tabular_store",
+}
+
+DEFAULT_REPRESENTATION_POLICY: dict[str, dict[str, Any]] = {
+    "tabular_parquet": {
+        "role": "none",
+        "complete_for_rebuild": False,
+    }
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ContainerPolicy:
+    """Normalized view of container recovery metadata."""
+
+    container_recovery_unit: str | None = None
+    child_recovery_policy: str | None = None
+    representation_policy: Mapping[str, Any] = field(default_factory=dict)
+    errors: tuple[str, ...] = ()
+
+    @property
+    def valid(self) -> bool:
+        return not self.errors
+
+
+@dataclass(frozen=True, slots=True)
+class ContainerRecoveryValidation:
+    """Decision for recovery-root registration under container policy."""
+
+    allowed: bool
+    message: str | None = None
+
+
+def _copy_default_representation_policy() -> dict[str, dict[str, Any]]:
+    return {
+        name: dict(policy) for name, policy in DEFAULT_REPRESENTATION_POLICY.items()
+    }
+
+
+def normalize_container_policy(meta: Mapping[str, Any] | None) -> ContainerPolicy:
+    """Return a conservative normalized policy view from artifact metadata."""
+    if not meta:
+        return ContainerPolicy()
+
+    errors: list[str] = []
+    container_recovery_unit = meta.get("container_recovery_unit")
+    if container_recovery_unit is not None:
+        if (
+            not isinstance(container_recovery_unit, str)
+            or container_recovery_unit not in CONTAINER_RECOVERY_UNITS
+        ):
+            errors.append(
+                f"Unknown container_recovery_unit {container_recovery_unit!r}."
+            )
+
+    child_recovery_policy = meta.get("child_recovery_policy")
+    if child_recovery_policy is not None:
+        if (
+            not isinstance(child_recovery_policy, str)
+            or child_recovery_policy not in CHILD_RECOVERY_POLICIES
+        ):
+            errors.append(f"Unknown child_recovery_policy {child_recovery_policy!r}.")
+
+    representation_policy = meta.get("representation_policy")
+    if representation_policy is None:
+        representation_policy = {}
+    elif not isinstance(representation_policy, Mapping):
+        errors.append("representation_policy must be a mapping when provided.")
+        representation_policy = {}
+    else:
+        for name, policy in representation_policy.items():
+            if not isinstance(policy, Mapping):
+                errors.append(f"representation_policy[{name!r}] must be a mapping.")
+                continue
+            role = policy.get("role")
+            if role is not None and role not in REPRESENTATION_ROLES:
+                errors.append(f"Unknown representation_policy[{name!r}].role {role!r}.")
+
+    return ContainerPolicy(
+        container_recovery_unit=(
+            container_recovery_unit
+            if isinstance(container_recovery_unit, str)
+            else None
+        ),
+        child_recovery_policy=(
+            child_recovery_policy if isinstance(child_recovery_policy, str) else None
+        ),
+        representation_policy=representation_policy,
+        errors=tuple(errors),
+    )
+
+
+def apply_container_policy_meta(
+    meta: MutableMapping[str, Any],
+    *,
+    container_recovery_unit: ContainerRecoveryUnit | None = None,
+    child_recovery_policy: ChildRecoveryPolicy | None = None,
+    representation_policy: Mapping[str, Any] | None = None,
+) -> None:
+    """Apply normalized container recovery policy fields to artifact metadata."""
+    if container_recovery_unit is None and child_recovery_policy is None:
+        if representation_policy is None:
+            return
+
+    if (
+        container_recovery_unit is not None
+        and container_recovery_unit not in CONTAINER_RECOVERY_UNITS
+    ):
+        raise ValueError(
+            "container_recovery_unit must be one of: "
+            f"{', '.join(sorted(CONTAINER_RECOVERY_UNITS))}."
+        )
+    if (
+        child_recovery_policy is not None
+        and child_recovery_policy not in CHILD_RECOVERY_POLICIES
+    ):
+        raise ValueError(
+            "child_recovery_policy must be one of: "
+            f"{', '.join(sorted(CHILD_RECOVERY_POLICIES))}."
+        )
+
+    if container_recovery_unit is not None:
+        meta["container_recovery_unit"] = container_recovery_unit
+    if child_recovery_policy is not None:
+        meta["child_recovery_policy"] = child_recovery_policy
+
+    normalized_representation_policy: dict[str, Any]
+    if representation_policy is None:
+        normalized_representation_policy = _copy_default_representation_policy()
+    else:
+        normalized_representation_policy = {
+            name: dict(policy) if isinstance(policy, Mapping) else policy
+            for name, policy in representation_policy.items()
+        }
+
+    policy = normalize_container_policy(
+        {"representation_policy": normalized_representation_policy}
+    )
+    if not policy.valid:
+        raise ValueError("; ".join(policy.errors))
+    meta["representation_policy"] = normalized_representation_policy
+
+
+def validate_recovery_registration_policy(
+    artifact: Artifact,
+    *,
+    parent: Artifact | None = None,
+) -> ContainerRecoveryValidation:
+    """Validate whether an artifact may adopt a verified recovery root."""
+    driver = artifact.driver
+    meta = artifact.meta if isinstance(artifact.meta, Mapping) else {}
+
+    if driver in {"h5", "hdf5"}:
+        policy = normalize_container_policy(meta)
+        if not policy.valid:
+            return ContainerRecoveryValidation(
+                allowed=False,
+                message=(
+                    f"Artifact {artifact.key!r} has invalid container recovery "
+                    f"policy: {'; '.join(policy.errors)}"
+                ),
+            )
+        if policy.container_recovery_unit is None:
+            return ContainerRecoveryValidation(
+                allowed=False,
+                message=(
+                    f"Artifact {artifact.key!r} is an HDF5 container without "
+                    "container_recovery_unit policy. Declare "
+                    "container_recovery_unit='parent_file' before registering "
+                    "verified recovery roots."
+                ),
+            )
+        if policy.container_recovery_unit == "parent_file":
+            return ContainerRecoveryValidation(allowed=True)
+        return ContainerRecoveryValidation(
+            allowed=False,
+            message=(
+                f"Artifact {artifact.key!r} declares "
+                f"container_recovery_unit={policy.container_recovery_unit!r}, "
+                "but verified recovery-copy adoption only supports parent-file "
+                "HDF5 recovery today."
+            ),
+        )
+
+    if driver == "h5_table":
+        if parent is None:
+            return ContainerRecoveryValidation(
+                allowed=False,
+                message=(
+                    f"Artifact {artifact.key!r} is an HDF5 child table without "
+                    "a resolvable parent container policy. Register recovery "
+                    "roots on the parent H5 artifact instead."
+                ),
+            )
+        parent_meta = parent.meta if isinstance(parent.meta, Mapping) else {}
+        policy = normalize_container_policy(parent_meta)
+        if not policy.valid:
+            return ContainerRecoveryValidation(
+                allowed=False,
+                message=(
+                    f"Parent artifact {parent.key!r} has invalid container "
+                    f"recovery policy: {'; '.join(policy.errors)}"
+                ),
+            )
+        if policy.child_recovery_policy is None:
+            return ContainerRecoveryValidation(
+                allowed=False,
+                message=(
+                    f"Artifact {artifact.key!r} is an HDF5 child table whose "
+                    "parent has no child_recovery_policy. Register recovery "
+                    "roots on the parent H5 artifact instead."
+                ),
+            )
+        if policy.child_recovery_policy == "descriptive_only":
+            return ContainerRecoveryValidation(
+                allowed=False,
+                message=(
+                    f"Artifact {artifact.key!r} is an HDF5 child table whose "
+                    "parent declares child_recovery_policy='descriptive_only'. "
+                    "Register recovery roots on the parent H5 artifact instead."
+                ),
+            )
+        return ContainerRecoveryValidation(
+            allowed=False,
+            message=(
+                f"Artifact {artifact.key!r} is an HDF5 child table whose "
+                "parent declares child_recovery_policy='independent', but "
+                "independent child recovery is not supported until a complete "
+                "rebuild representation policy exists."
+            ),
+        )
+
+    return ContainerRecoveryValidation(allowed=True)

--- a/src/consist/core/materialize.py
+++ b/src/consist/core/materialize.py
@@ -67,6 +67,7 @@ RecoveryCopyStatus = Literal[
     "missing_copy",
     "hash_mismatch",
     "skipped_unmapped",
+    "blocked_by_container_policy",
     "symlink_destination",
     "unsupported_directory",
     "unverifiable_hash",

--- a/src/consist/core/tracker.py
+++ b/src/consist/core/tracker.py
@@ -65,6 +65,11 @@ from consist.core.config_canonicalization import (
 )
 from consist.core.config_facets import ConfigFacetManager
 from consist.core.decorators import define_step as define_step_decorator
+from consist.core.container_policy import (
+    ChildRecoveryPolicy,
+    ContainerRecoveryUnit,
+    validate_recovery_registration_policy,
+)
 from consist.core.error_messages import format_problem_cause_fix
 from consist.core.events import EventManager
 from consist.core.fs import FileSystemManager
@@ -1103,6 +1108,8 @@ class Tracker:
 
         Directory artifacts are intentionally blocked here until Consist has a
         first-class directory manifest contract for recovery-root equivalence.
+        HDF5 child table artifacts are also blocked unless a future parent
+        container policy explicitly supports independent child recovery.
         ``content_hash`` is interpreted as a full file SHA-256 and takes
         precedence when supplied. Without it, ``artifact.hash`` is only used for
         byte verification when this tracker is using full content hashing; fast
@@ -1139,6 +1146,21 @@ class Tracker:
                 status=status,
                 message=message,
                 metadata_updated=metadata_updated,
+            )
+
+        parent = (
+            self.get_parent_artifact(artifact)
+            if artifact.driver == "h5_table"
+            else None
+        )
+        policy_validation = validate_recovery_registration_policy(
+            artifact,
+            parent=parent,
+        )
+        if not policy_validation.allowed:
+            return _result(
+                "blocked_by_container_policy",
+                message=policy_validation.message,
             )
 
         relative_path = self.fs.get_remappable_relative_path(artifact.container_uri)
@@ -3083,6 +3105,9 @@ class Tracker:
         table_hash_chunk_rows: Optional[int] = None,
         child_specs: Optional[Mapping[str, H5ChildSpec]] = None,
         child_selection: H5ChildSelectionMode = "all",
+        container_recovery_unit: ContainerRecoveryUnit | None = None,
+        child_recovery_policy: ChildRecoveryPolicy | None = None,
+        representation_policy: Optional[Mapping[str, Any]] = None,
         **meta: Any,
     ) -> Tuple[Artifact, List[Artifact]]:
         """
@@ -3119,6 +3144,16 @@ class Tracker:
         child_selection : {"all", "include_only"}, default "all"
             Whether all discovered datasets are eligible for logging or only the
             dataset paths named in ``child_specs``.
+        container_recovery_unit : {"parent_file", "derived_children"}, optional
+            Recovery authority for the HDF5 container. Use ``"parent_file"`` when
+            verified recovery roots apply to the whole H5 file.
+        child_recovery_policy : {"descriptive_only", "independent"}, optional
+            Recovery policy for child ``h5_table`` artifacts. Use
+            ``"descriptive_only"`` when children are lineage/schema records and
+            not independently recoverable.
+        representation_policy : Optional[Mapping[str, Any]], optional
+            Optional policy metadata for derived physical representations such
+            as future parquet inspection caches.
         **meta : Any
             Additional metadata for the container artifact.
 
@@ -3166,6 +3201,9 @@ class Tracker:
             table_hash_chunk_rows=table_hash_chunk_rows,
             child_specs=child_specs,
             child_selection=child_selection,
+            container_recovery_unit=container_recovery_unit,
+            child_recovery_policy=child_recovery_policy,
+            representation_policy=representation_policy,
             **meta,
         )
 

--- a/tests/integration/artifacts/test_h5_support.py
+++ b/tests/integration/artifacts/test_h5_support.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 from consist.core.coupler import Coupler
 from consist.core.tracker import Tracker
@@ -115,6 +117,119 @@ def test_h5_child_specs_include_only_and_semantic_overrides(tracker: Tracker):
 
     children_from_query = tracker.get_child_artifacts(container)
     assert [artifact.id for artifact in children_from_query] == [child.id]
+
+
+def test_h5_parent_file_policy_allows_parent_recovery_and_blocks_children(
+    tracker: Tracker,
+    tmp_path,
+):
+    h5_path = tracker.run_dir / "outputs" / "policy_store.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        f.create_dataset("households", data=[1, 2, 3])
+        f.create_dataset("persons", data=[4, 5, 6])
+
+    with tracker.start_run("run_h5_policy", model="test_model"):
+        container, children = tracker.log_h5_container(
+            h5_path,
+            key="usim_store",
+            child_selection="include_only",
+            child_specs={
+                "/households": H5ChildSpec(key="households"),
+                "/persons": H5ChildSpec(key="persons"),
+            },
+            container_recovery_unit="parent_file",
+            child_recovery_policy="descriptive_only",
+        )
+
+    assert container.meta["container_recovery_unit"] == "parent_file"
+    assert container.meta["child_recovery_policy"] == "descriptive_only"
+    assert container.meta["representation_policy"]["tabular_parquet"] == {
+        "role": "none",
+        "complete_for_rebuild": False,
+    }
+
+    recovery_root = tmp_path / "external_archive_h5"
+    expected_path = recovery_root / "outputs" / "policy_store.h5"
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(h5_path, expected_path)
+
+    refreshed_outputs = tracker.get_run_outputs("run_h5_policy")
+    refreshed_container = refreshed_outputs["usim_store"]
+    assert refreshed_container.meta["container_recovery_unit"] == "parent_file"
+
+    parent_result = tracker.register_artifact_recovery_copy(
+        refreshed_container,
+        recovery_root,
+    )
+    assert parent_result.status == "registered"
+    assert parent_result.metadata_updated is True
+
+    refreshed_after_parent = tracker.get_run_outputs("run_h5_policy")
+    assert refreshed_after_parent["usim_store"].recovery_roots == [
+        str(recovery_root.resolve())
+    ]
+
+    child = next(child for child in children if child.key == "households")
+    refreshed_child = refreshed_after_parent["households"]
+    assert refreshed_child.parent_artifact_id == child.parent_artifact_id
+
+    child_result = tracker.register_artifact_recovery_copy(
+        refreshed_child,
+        recovery_root,
+    )
+    assert child_result.status == "blocked_by_container_policy"
+    assert child_result.metadata_updated is False
+    assert "child_recovery_policy='descriptive_only'" in child_result.message
+    assert "parent H5 artifact" in child_result.message
+
+    final_outputs = tracker.get_run_outputs("run_h5_policy")
+    assert "recovery_roots" not in final_outputs["households"].meta
+
+
+def test_h5_parent_child_policy_is_reported_in_bulk_recovery_registration(
+    tracker: Tracker,
+    tmp_path,
+):
+    h5_path = tracker.run_dir / "outputs" / "bulk_policy_store.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        f.create_dataset("households", data=[1, 2, 3])
+
+    with tracker.start_run("run_h5_bulk_policy", model="test_model"):
+        tracker.log_h5_container(
+            h5_path,
+            key="bulk_usim_store",
+            child_selection="include_only",
+            child_specs={"/households": H5ChildSpec(key="bulk_households")},
+            container_recovery_unit="parent_file",
+            child_recovery_policy="descriptive_only",
+        )
+
+    recovery_root = tmp_path / "external_archive_h5_bulk"
+    expected_path = recovery_root / "outputs" / "bulk_policy_store.h5"
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(h5_path, expected_path)
+
+    result = tracker.register_run_output_recovery_copies(
+        "run_h5_bulk_policy",
+        recovery_root,
+        keys=["bulk_usim_store", "bulk_households"],
+    )
+
+    assert result["bulk_usim_store"].status == "registered"
+    assert result["bulk_usim_store"].metadata_updated is True
+    assert result["bulk_households"].status == "blocked_by_container_policy"
+    assert result["bulk_households"].metadata_updated is False
+    assert result.registered.keys() == {"bulk_usim_store"}
+    assert result.blocked.keys() == {"bulk_households"}
+    assert "blocked_by_container_policy=1" in result.summary
+
+    refreshed = tracker.get_run_outputs("run_h5_bulk_policy")
+    assert refreshed["bulk_usim_store"].recovery_roots == [str(recovery_root.resolve())]
+    assert "recovery_roots" not in refreshed["bulk_households"].meta
 
 
 def test_h5_child_specs_include_only_with_empty_specs_logs_no_children(

--- a/tests/integration/artifacts/test_h5_support.py
+++ b/tests/integration/artifacts/test_h5_support.py
@@ -181,6 +181,7 @@ def test_h5_parent_file_policy_allows_parent_recovery_and_blocks_children(
     )
     assert child_result.status == "blocked_by_container_policy"
     assert child_result.metadata_updated is False
+    assert child_result.message is not None
     assert "child_recovery_policy='descriptive_only'" in child_result.message
     assert "parent H5 artifact" in child_result.message
 
@@ -367,6 +368,53 @@ def test_h5_container_cache_hit_reuses_cached_children(tracker: Tracker):
 
     assert container_hit.id == container_seed.id
     assert [child.id for child in children_hit] == [child.id for child in children_seed]
+
+
+def test_h5_container_cache_hit_persists_new_parent_recovery_policy(
+    tracker: Tracker,
+):
+    h5_path = tracker.run_dir / "cache_policy_reuse.h5"
+    h5_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with h5py.File(h5_path, "w") as f:
+        f.create_dataset("households", data=[1, 2, 3])
+
+    with tracker.start_run(
+        "run_h5_cache_policy_seed",
+        model="test_model",
+        cache_mode="overwrite",
+        config={"cache_policy_demo": True},
+    ) as t:
+        container_seed, _ = t.log_h5_container(
+            h5_path,
+            key="cached_h5_policy",
+            discover_tables=True,
+        )
+        assert "container_recovery_unit" not in container_seed.meta
+
+    with tracker.start_run(
+        "run_h5_cache_policy_hit",
+        model="test_model",
+        cache_mode="reuse",
+        config={"cache_policy_demo": True},
+    ) as t:
+        container_hit, _ = t.log_h5_container(
+            h5_path,
+            key="cached_h5_policy",
+            discover_tables=True,
+            container_recovery_unit="parent_file",
+            child_recovery_policy="descriptive_only",
+        )
+        assert t.is_cached
+
+    assert container_hit.id == container_seed.id
+    assert container_hit.meta["container_recovery_unit"] == "parent_file"
+    assert container_hit.meta["child_recovery_policy"] == "descriptive_only"
+
+    refreshed = tracker.get_artifact(container_seed.id)
+    assert refreshed is not None
+    assert refreshed.meta["container_recovery_unit"] == "parent_file"
+    assert refreshed.meta["child_recovery_policy"] == "descriptive_only"
 
 
 def test_h5_container_cache_hit_demotes_when_children_were_not_cached(

--- a/tests/unit/api/test_run_materialize_outputs_api.py
+++ b/tests/unit/api/test_run_materialize_outputs_api.py
@@ -852,7 +852,8 @@ def test_register_run_output_recovery_copies_reports_mixed_statuses_and_unknown_
     assert result.complete is False
     assert result.summary == (
         "registered=1 missing_copy=1 hash_mismatch=0 skipped_unmapped=0 "
-        "symlink_destination=0 unsupported_directory=0 unverifiable_hash=0 failed=0"
+        "blocked_by_container_policy=0 symlink_destination=0 "
+        "unsupported_directory=0 unverifiable_hash=0 failed=0"
     )
     outputs = tracker.get_run_outputs("producer_adopt_bulk")
     assert outputs["a"].recovery_roots == [str(recovery_root.resolve())]

--- a/tests/unit/cli/test_cli_artifacts_lineage_guards.py
+++ b/tests/unit/cli/test_cli_artifacts_lineage_guards.py
@@ -123,6 +123,7 @@ def test_schema_capture_file_passes_mount_overrides_to_tracker(tmp_path) -> None
     assert result.exit_code == 1
     mock_get_tracker.assert_called_once_with(
         "mock.db",
+        run_dir=None,
         mounts={"workspace": str(workspace_root.resolve())},
     )
 

--- a/tests/unit/core/test_container_policy.py
+++ b/tests/unit/core/test_container_policy.py
@@ -1,0 +1,98 @@
+import uuid
+
+from consist.core.container_policy import (
+    apply_container_policy_meta,
+    normalize_container_policy,
+    validate_recovery_registration_policy,
+)
+from consist.models.artifact import Artifact
+
+
+def _artifact(
+    *,
+    driver: str,
+    key: str = "artifact",
+    meta: dict | None = None,
+    parent_artifact_id: uuid.UUID | None = None,
+) -> Artifact:
+    return Artifact(
+        key=key,
+        container_uri=f"outputs://{key}",
+        driver=driver,
+        meta=meta or {},
+        parent_artifact_id=parent_artifact_id,
+    )
+
+
+def test_normal_file_artifact_without_container_policy_is_allowed() -> None:
+    artifact = _artifact(driver="csv")
+
+    validation = validate_recovery_registration_policy(artifact)
+
+    assert validation.allowed is True
+    assert validation.message is None
+
+
+def test_h5_parent_without_container_policy_is_blocked() -> None:
+    artifact = _artifact(driver="h5", key="store")
+
+    validation = validate_recovery_registration_policy(artifact)
+
+    assert validation.allowed is False
+    assert validation.message is not None
+    assert "container_recovery_unit" in validation.message
+
+
+def test_h5_parent_file_policy_allows_parent_registration() -> None:
+    meta: dict = {}
+    apply_container_policy_meta(
+        meta,
+        container_recovery_unit="parent_file",
+        child_recovery_policy="descriptive_only",
+    )
+    artifact = _artifact(driver="h5", key="store", meta=meta)
+
+    validation = validate_recovery_registration_policy(artifact)
+
+    assert validation.allowed is True
+    policy = normalize_container_policy(artifact.meta)
+    assert policy.container_recovery_unit == "parent_file"
+    assert policy.child_recovery_policy == "descriptive_only"
+    assert policy.representation_policy["tabular_parquet"]["role"] == "none"
+
+
+def test_descriptive_only_parent_policy_blocks_child_registration() -> None:
+    parent = _artifact(
+        driver="h5",
+        key="store",
+        meta={
+            "container_recovery_unit": "parent_file",
+            "child_recovery_policy": "descriptive_only",
+        },
+    )
+    child = _artifact(
+        driver="h5_table",
+        key="households",
+        parent_artifact_id=parent.id,
+    )
+
+    validation = validate_recovery_registration_policy(child, parent=parent)
+
+    assert validation.allowed is False
+    assert validation.message is not None
+    assert "child_recovery_policy='descriptive_only'" in validation.message
+    assert "parent H5 artifact" in validation.message
+
+
+def test_unknown_container_policy_values_fail_closed() -> None:
+    artifact = _artifact(
+        driver="h5",
+        key="store",
+        meta={"container_recovery_unit": "surprise"},
+    )
+
+    validation = validate_recovery_registration_policy(artifact)
+
+    assert validation.allowed is False
+    assert validation.message is not None
+    assert "Unknown container_recovery_unit" in validation.message


### PR DESCRIPTION
## Summary

Adds explicit recovery-policy metadata for structured HDF5 container artifacts so Consist can distinguish parent-file recovery from descriptive child-table artifacts.

This keeps the first implementation intentionally narrow:
- HDF5 parent artifacts can declare `container_recovery_unit="parent_file"`.
- HDF5 child table artifacts can be marked descriptive via `child_recovery_policy="descriptive_only"`.
- Verified recovery-copy registration allows parent H5 recovery when the parent declares parent-file recovery.
- Verified recovery-copy registration blocks descriptive child `h5_table` artifacts with a stable `blocked_by_container_policy` status.
- Existing non-HDF5 recovery-copy behavior remains unchanged.

## Changes

- Added container policy normalization/validation helpers for HDF5 recovery semantics.
- Extended `Tracker.log_h5_container(...)` with:
  - `container_recovery_unit`
  - `child_recovery_policy`
  - `representation_policy`
- Added `blocked_by_container_policy` to recovery-copy result statuses.
- Applied policy validation in `register_artifact_recovery_copy(...)`, including through bulk `register_run_output_recovery_copies(...)`.
- Persist parent recovery-policy metadata when H5 containers are re-logged on cache hits.
- Documented HDF5 parent-file recovery vs descriptive child-table artifacts in tracker/materialization/historical-recovery docs.
- Added HDF5 integration coverage for parent registration, child blocking, bulk registration, cache-hit policy persistence, and type-check-safe message assertions.

