### PR TITLE
Improve root behavior in cli

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -140,6 +140,8 @@ Inspect artifacts in two modes:
 
 - **Run mode**: list input/output artifacts for one run.
 - **Query mode**: search artifacts by indexed facet predicates.
+- Run mode includes an `Access` column that shows whether each artifact is
+  reachable via its primary path or a recorded recovery root.
 
 ```bash
 consist artifacts <run_id>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,12 +25,11 @@ relative paths in this order:
 2. Parent directory of `--db-path`
 3. Current working directory
 4. `_physical_run_dir` from run metadata (**only** when `--trust-db` is enabled)
-5. Ordered `artifact.meta["recovery_roots"]`
+5. Ordered `artifact.meta["recovery_roots"]` (**only** when `--trust-db` is enabled)
 
 This keeps default behavior safe while still supporting archived/moved run directories.
-Recovery roots are checked from metadata without requiring a separate CLI flag; use
-`--trust-db` when you also want the CLI to reuse recorded run directories or mount
-snapshots from the database.
+Use `--trust-db` when you want the CLI to reuse recorded run directories, mount
+snapshots, or recovery roots from the database.
 
 Examples:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,16 +16,21 @@ The CLI looks for the provenance database in this order:
 
 ## Artifact Path Resolution
 
-Some artifacts are stored with relative URIs like `./outputs/...`. For commands that load
-or validate artifact files (`preview`, `validate`, and shell `preview`/`schema_profile`),
-Consist resolves relative paths in this order:
+Some artifacts are stored with relative URIs like `./outputs/...`. For commands
+that load, validate, or profile artifact files (`preview`, `validate`,
+`schema capture-file`, and shell `preview`/`schema_profile`), Consist resolves
+relative paths in this order:
 
 1. Explicit `--run-dir`
 2. Parent directory of `--db-path`
 3. Current working directory
 4. `_physical_run_dir` from run metadata (**only** when `--trust-db` is enabled)
+5. Ordered `artifact.meta["recovery_roots"]`
 
 This keeps default behavior safe while still supporting archived/moved run directories.
+Recovery roots are checked from metadata without requiring a separate CLI flag; use
+`--trust-db` when you also want the CLI to reuse recorded run directories or mount
+snapshots from the database.
 
 Examples:
 
@@ -40,6 +45,10 @@ consist preview trip_table \
 
 # Allow fallback to _physical_run_dir metadata from the DB
 consist preview trip_table --db-path archives/beam_core_demo.duckdb --trust-db
+
+# Mount-backed artifacts can use explicit mounts or trusted DB mount snapshots
+consist preview trips --db-path archive.duckdb --mount inputs=/data/archive/inputs
+consist validate --db-path archive.duckdb --trust-db
 ```
 
 ## Global Options
@@ -176,7 +185,9 @@ Options:
 
 - `--sample-rows N`: rows to sample during inference (default `1000`)
 - `--if-changed`: reuse a prior schema observation when the artifact hash is unchanged; this affects schema capture only, not artifact-row reuse
+- `--run-dir PATH`: base directory for resolving relative artifact paths
 - `--trust-db`: allow metadata-based mount inference when resolving paths
+- `--mount NAME=PATH`: explicit mount override; repeat for multiple schemes
 - `--db-path`: explicit DB path
 
 ### consist schema export
@@ -321,6 +332,7 @@ consist validate
 consist validate --fix  # Mark missing artifacts
 consist validate --db-path examples/runs/beam_core_demo/beam_core_demo_demo.duckdb
 consist validate --db-path archives/beam_core_demo.duckdb --run-dir /data/archive/beam_core_demo
+consist validate --db-path archives/beam_core_demo.duckdb --mount workspace=/data/archive/beam_core_demo
 consist validate --db-path archives/beam_core_demo.duckdb --trust-db
 ```
 
@@ -332,6 +344,7 @@ Start an interactive session for exploring provenance.
 consist shell
 consist shell --db-path examples/runs/beam_core_demo/beam_core_demo_demo.duckdb
 consist shell --run-dir /data/archive/beam_core_demo
+consist shell --mount workspace=/data/archive/beam_core_demo
 consist shell --trust-db  # Allow metadata-based mount/run-dir inference
 ```
 
@@ -358,6 +371,9 @@ Useful shell shortcuts:
   cached shell artifact refs and route them to `--artifact-id`.
 - `context` prints the active shell defaults for `db_path`, `run_dir`,
   `trust_db`, and mount overrides.
+- Shell defaults are applied to routed `preview`, `validate`, and
+  `schema capture-file` commands, so you do not need to repeat `--db-path`,
+  `--run-dir`, `--trust-db`, or `--mount` inside the shell.
 - `preview --hash <prefix>` and `schema_profile --hash <prefix>` search all
   artifacts by hash prefix.
 - `schema_stub --hash <prefix> --run-id <run_id>` narrows hash lookup to one run

--- a/docs/concepts/config-management.md
+++ b/docs/concepts/config-management.md
@@ -36,6 +36,16 @@ re-execution on change, be searchable for later filtering, or both.
 If you pass a Pydantic model, it is serialized via `model_dump()` before hashing
 and snapshotting.
 
+The full `config` payload is distinct from the canonical identity record that
+adapter-driven config planning can add to run metadata. When config adapters are
+used, Consist may also persist `run.meta["config_bundle_hash"]` and
+`run.meta["config_identity_manifest"]` as compact identity artifacts, plus
+queryable slices in `config_facet` and `run_config_kv`. Those records are for
+cache identity and filtering; they are not the full configuration payload.
+If a future storage split moves large config payloads into a separate database,
+keep that routing distinct from the identity manifest so cache semantics stay
+stable.
+
 ### Config Hashing
 
 Consist uses **canonical hashing**: converting dicts (and YAML/JSON) into a

--- a/src/consist/cli.py
+++ b/src/consist/cli.py
@@ -910,18 +910,14 @@ def _artifact_recovery_candidate_paths(
     """Return path candidates derived from artifact recovery roots."""
     if not trust_db:
         return []
-    fs = getattr(tracker, "fs", None)
-    relative_path_helper = getattr(fs, "get_remappable_relative_path", None)
-    roots_helper = getattr(fs, "normalize_recovery_roots", None)
-    if not callable(relative_path_helper) or not callable(roots_helper):
-        return []
+    fs = tracker.fs
 
-    relative_path = relative_path_helper(artifact.container_uri)
+    relative_path = fs.get_remappable_relative_path(artifact.container_uri)
     if relative_path is None:
         return []
 
     try:
-        roots = roots_helper((artifact.meta or {}).get("recovery_roots"))
+        roots = fs.normalize_recovery_roots((artifact.meta or {}).get("recovery_roots"))
     except (TypeError, ValueError):
         return []
 
@@ -950,10 +946,10 @@ def _load_artifact_from_resolved_path(
     load_kwargs: Dict[str, Any] = {}
     if artifact.driver == "csv" and n_rows is not None:
         load_kwargs["nrows"] = n_rows
-    table_path = getattr(artifact, "table_path", None)
+    table_path = artifact.table_path
     if table_path:
         load_kwargs["table_path"] = table_path
-    array_path = getattr(artifact, "array_path", None)
+    array_path = artifact.array_path
     if array_path:
         load_kwargs["array_path"] = array_path
 
@@ -1494,8 +1490,16 @@ def _render_artifacts_table(tracker: Tracker, run_id: str) -> List["Artifact"]:
     table.add_column("Key", style="green", overflow="fold")
     table.add_column("Artifact ID", style="cyan", overflow="fold")
     table.add_column("URI", style="dim", overflow="fold")
+    table.add_column("Access", overflow="fold")
     table.add_column("Driver")
     table.add_column("Hash", style="magenta")
+
+    def _style_artifact_access(status: str) -> str:
+        if status == "primary":
+            return "green"
+        if status == "recovery":
+            return "yellow"
+        return "red"
 
     inputs = sorted(run_artifacts.inputs.values(), key=lambda x: x.key)
     outputs = sorted(run_artifacts.outputs.values(), key=lambda x: x.key)
@@ -1503,12 +1507,15 @@ def _render_artifacts_table(tracker: Tracker, run_id: str) -> List["Artifact"]:
 
     for artifact in inputs:
         rendered.append(artifact)
+        accessibility = artifact.accessibility(tracker=tracker)
+        access_status = accessibility.status
         table.add_row(
             str(ref_index),
             "[blue]Input[/blue]",
             artifact.key,
             str(artifact.id),
             artifact.container_uri,
+            f"[{_style_artifact_access(access_status)}]{access_status}[/]",
             artifact.driver,
             artifact.hash[:12] if artifact.hash else "N/A",
         )
@@ -1519,12 +1526,15 @@ def _render_artifacts_table(tracker: Tracker, run_id: str) -> List["Artifact"]:
 
     for artifact in outputs:
         rendered.append(artifact)
+        accessibility = artifact.accessibility(tracker=tracker)
+        access_status = accessibility.status
         table.add_row(
             str(ref_index),
             "[green]Output[/green]",
             artifact.key,
             str(artifact.id),
             artifact.container_uri,
+            f"[{_style_artifact_access(access_status)}]{access_status}[/]",
             artifact.driver,
             artifact.hash[:12] if artifact.hash else "N/A",
         )

--- a/src/consist/cli.py
+++ b/src/consist/cli.py
@@ -1011,6 +1011,11 @@ def _resolve_schema_capture_path(
             lambda: Path(tracker.resolve_uri(artifact.container_uri)).resolve(),
         )
 
+    for label, candidate in _artifact_recovery_candidate_paths(
+        tracker, artifact, trust_db=trust_db
+    ):
+        candidates.append((label, candidate))
+
     for _, candidate in candidates:
         if candidate.exists():
             return candidate

--- a/src/consist/cli.py
+++ b/src/consist/cli.py
@@ -53,7 +53,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
-from sqlalchemy import and_, or_, select as sa_select
+from sqlalchemy import and_, or_
 from sqlmodel import Session, col, select
 
 from consist import Tracker
@@ -853,6 +853,11 @@ def _apply_inferred_mounts(tracker: Tracker, mounts: Mapping[str, str]) -> None:
     tracker.mounts = tracker.fs.mounts
 
 
+def _set_tracker_mounts(tracker: Tracker, mounts: Mapping[str, str]) -> None:
+    tracker.fs.mounts = dict(mounts)
+    tracker.mounts = tracker.fs.mounts
+
+
 def _ensure_tracker_mounts_for_artifact(
     tracker: Tracker, artifact: "Artifact", *, trust_db: bool
 ) -> None:
@@ -890,21 +895,78 @@ def _ensure_tracker_mounts_for_artifact(
     _apply_inferred_mounts(tracker, inferred)
 
 
+def _artifact_recovery_candidate_paths(
+    tracker: Tracker, artifact: "Artifact"
+) -> List[Tuple[str, Path]]:
+    """Return path candidates derived from artifact recovery roots."""
+    fs = getattr(tracker, "fs", None)
+    relative_path_helper = getattr(fs, "get_remappable_relative_path", None)
+    roots_helper = getattr(fs, "normalize_recovery_roots", None)
+    if not callable(relative_path_helper) or not callable(roots_helper):
+        return []
+
+    relative_path = relative_path_helper(artifact.container_uri)
+    if relative_path is None:
+        return []
+
+    try:
+        roots = roots_helper((artifact.meta or {}).get("recovery_roots"))
+    except (TypeError, ValueError):
+        return []
+
+    candidates: List[Tuple[str, Path]] = []
+    seen: set[Path] = set()
+    for index, root in enumerate(roots, start=1):
+        try:
+            candidate = (Path(root) / relative_path).resolve()
+        except OSError:
+            continue
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        candidates.append((f"artifact recovery_root #{index}", candidate))
+    return candidates
+
+
+def _load_artifact_from_resolved_path(
+    artifact: "Artifact",
+    path: Path,
+    *,
+    n_rows: int | None = None,
+) -> Any:
+    from consist.api import _load_from_disk
+
+    load_kwargs: Dict[str, Any] = {}
+    if artifact.driver == "csv" and n_rows is not None:
+        load_kwargs["nrows"] = n_rows
+    table_path = getattr(artifact, "table_path", None)
+    if table_path:
+        load_kwargs["table_path"] = table_path
+    array_path = getattr(artifact, "array_path", None)
+    if array_path:
+        load_kwargs["array_path"] = array_path
+
+    return _load_from_disk(str(path), artifact.driver, **load_kwargs)
+
+
 def _resolve_schema_capture_path(
     *,
     tracker: Tracker,
     artifact: "Artifact",
     run: "Run",
     override_path: Optional[Path],
+    db_path: Optional[str],
+    run_dir: Optional[str],
+    trust_db: bool,
 ) -> Path:
     if override_path is not None:
         return override_path.expanduser().resolve()
 
-    candidates: List[Path] = []
+    candidates: List[Tuple[str, Path]] = []
 
-    def _append_candidate(candidate_factory) -> None:
+    def _append_candidate(label: str, candidate_factory) -> None:
         try:
-            candidates.append(candidate_factory())
+            candidates.append((label, candidate_factory()))
         except (
             AttributeError,
             NotImplementedError,
@@ -915,17 +977,32 @@ def _resolve_schema_capture_path(
         ):
             return
 
-    _append_candidate(lambda: tracker.resolve_historical_path(artifact, run))
-    _append_candidate(
-        lambda: Path(tracker.resolve_uri(artifact.container_uri)).resolve()
-    )
+    if artifact.container_uri.startswith("./"):
+        resolution_bases, _ = _build_relative_resolution_bases(
+            tracker,
+            artifact,
+            db_path=db_path,
+            run_dir=run_dir,
+            trust_db=trust_db,
+        )
+        for label, base_dir in resolution_bases:
+            candidates.append(
+                (label, (base_dir / artifact.container_uri[2:]).resolve())
+            )
+    else:
+        _append_candidate(
+            "current tracker resolution",
+            lambda: Path(tracker.resolve_uri(artifact.container_uri)).resolve(),
+        )
 
-    for candidate in candidates:
+    candidates.extend(_artifact_recovery_candidate_paths(tracker, artifact))
+
+    for _, candidate in candidates:
         if candidate.exists():
             return candidate
 
     if candidates:
-        rendered = ", ".join(str(path) for path in candidates)
+        rendered = ", ".join(f"{label}: {path}" for label, path in candidates)
         raise FileNotFoundError(
             "Could not resolve an existing artifact file path. "
             f"Tried: {rendered}. Provide --path to override."
@@ -959,6 +1036,11 @@ def schema_capture_file(
         "--path",
         help="Override on-disk file path to profile.",
     ),
+    run_dir: Optional[str] = typer.Option(
+        None,
+        "--run-dir",
+        help="Base directory for resolving relative artifact paths like ./outputs/...",
+    ),
     sample_rows: int = typer.Option(
         1000,
         "--sample-rows",
@@ -977,7 +1059,7 @@ def schema_capture_file(
     trust_db: bool = typer.Option(
         False,
         "--trust-db",
-        help="Allow metadata-based mount inference when resolving artifact paths.",
+        help="Allow metadata-based mount and run-dir inference when resolving artifact paths.",
     ),
     mount: Optional[List[str]] = typer.Option(
         None,
@@ -1016,7 +1098,11 @@ def schema_capture_file(
 
     resolved_db_path = find_db_path(db_path)
     mount_overrides = _resolve_mount_overrides_or_exit(mount)
-    tracker = get_tracker(resolved_db_path, mounts=mount_overrides or None)
+    tracker = get_tracker(
+        resolved_db_path,
+        run_dir=run_dir,
+        mounts=mount_overrides or None,
+    )
     if artifact_id is not None:
         artifact = tracker.get_artifact(artifact_id)
     else:
@@ -1064,6 +1150,9 @@ def schema_capture_file(
             artifact=artifact,
             run=run,
             override_path=path,
+            db_path=resolved_db_path,
+            run_dir=run_dir,
+            trust_db=trust_db,
         )
     except FileNotFoundError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -1548,22 +1637,14 @@ def _render_summary(summary_data: Dict[str, Any]) -> None:
     console.print(model_table)
 
 
-def _iter_artifact_rows(
-    session: Session, *, batch_size: int
-) -> Iterable[Tuple[uuid.UUID, str, str, Optional[str]]]:
+def _iter_artifact_rows(session: Session, *, batch_size: int) -> Iterable["Artifact"]:
     from consist.models.artifact import Artifact
 
     last_created = None
     last_id = None
     while True:
         stmt = (
-            sa_select(
-                col(Artifact.id),
-                col(Artifact.key),
-                col(Artifact.container_uri),
-                col(Artifact.run_id),
-                col(Artifact.created_at),
-            )
+            select(Artifact)
             .order_by(col(Artifact.created_at), col(Artifact.id))
             .limit(batch_size)
         )
@@ -1581,10 +1662,10 @@ def _iter_artifact_rows(
         batch = session.exec(cast(Any, stmt)).all()
         if not batch:
             break
-        for art_id, key, uri, run_id, created_at in batch:
-            yield art_id, key, uri, run_id
-        last_id = batch[-1][0]
-        last_created = batch[-1][4]
+        for artifact in batch:
+            yield artifact
+        last_id = batch[-1].id
+        last_created = batch[-1].created_at
 
 
 def _render_scenarios(tracker: Tracker, limit: int = 20) -> None:
@@ -1708,7 +1789,15 @@ def validate(
     trust_db: bool = typer.Option(
         False,
         "--trust-db",
-        help="Allow metadata-based run-dir inference for relative artifact validation.",
+        help="Allow metadata-based mount and run-dir inference for artifact validation.",
+    ),
+    mount: Optional[List[str]] = typer.Option(
+        None,
+        "--mount",
+        help=(
+            "Mount override mapping (repeatable): NAME=PATH. "
+            "Example: --mount workspace=/path/to/archive"
+        ),
     ),
     fix: bool = typer.Option(
         False, help="Attempt to fix issues (mark artifacts as missing)."
@@ -1716,7 +1805,12 @@ def validate(
 ) -> None:
     """Check that artifacts referenced in DB actually exist on disk."""
     resolved_db_path = find_db_path(db_path)
-    tracker = get_tracker(resolved_db_path, run_dir=run_dir)
+    mount_overrides = _resolve_mount_overrides_or_exit(mount)
+    tracker = get_tracker(
+        resolved_db_path,
+        run_dir=run_dir,
+        mounts=mount_overrides or None,
+    )
     from consist.models.artifact import Artifact
 
     with _tracker_session(tracker) as session:
@@ -1729,44 +1823,55 @@ def validate(
             except ValueError:
                 batch_size = 1000
 
-        for artifact_id, key, uri, run_id in _iter_artifact_rows(
-            session, batch_size=batch_size
-        ):
-            if uri.startswith("./"):
-                resolution_bases, _ = _build_relative_resolution_bases_for_uri(
-                    tracker,
-                    container_uri=uri,
-                    run_id=run_id,
-                    db_path=resolved_db_path,
-                    run_dir=run_dir,
-                    trust_db=trust_db,
+        for artifact in _iter_artifact_rows(session, batch_size=batch_size):
+            original_mounts = dict(tracker.mounts)
+            try:
+                _ensure_tracker_mounts_for_artifact(
+                    tracker, artifact, trust_db=trust_db
                 )
-                if resolution_bases:
-                    found = False
-                    for _, base_dir in resolution_bases:
-                        candidate = (base_dir / uri[2:]).resolve()
+                uri = artifact.container_uri
+                found = False
+                if uri.startswith("./"):
+                    resolution_bases, _ = _build_relative_resolution_bases_for_uri(
+                        tracker,
+                        container_uri=uri,
+                        run_id=artifact.run_id,
+                        db_path=resolved_db_path,
+                        run_dir=run_dir,
+                        trust_db=trust_db,
+                    )
+                    if resolution_bases:
+                        for _, base_dir in resolution_bases:
+                            candidate = (base_dir / uri[2:]).resolve()
+                            if candidate.exists():
+                                found = True
+                                break
+                if not found:
+                    for _, candidate in _artifact_recovery_candidate_paths(
+                        tracker, artifact
+                    ):
                         if candidate.exists():
                             found = True
                             break
-                    if not found:
-                        missing.append((key, uri, run_id))
-                        missing_ids.append(artifact_id)
+                if found:
                     continue
-            try:
-                abs_path = tracker.resolve_uri(uri)
-                if not Path(abs_path).exists():
-                    missing.append((key, uri, run_id))
-                    missing_ids.append(artifact_id)
-            except (
-                AttributeError,
-                NotImplementedError,
-                OSError,
-                RuntimeError,
-                TypeError,
-                ValueError,
-            ):
-                missing.append((key, uri, run_id))
-                missing_ids.append(artifact_id)
+                try:
+                    abs_path = tracker.resolve_uri(uri)
+                    if not Path(abs_path).exists():
+                        missing.append((artifact.key, uri, artifact.run_id))
+                        missing_ids.append(artifact.id)
+                except (
+                    AttributeError,
+                    NotImplementedError,
+                    OSError,
+                    RuntimeError,
+                    TypeError,
+                    ValueError,
+                ):
+                    missing.append((artifact.key, uri, artifact.run_id))
+                    missing_ids.append(artifact.id)
+            finally:
+                _set_tracker_mounts(tracker, original_mounts)
 
         if not missing:
             console.print("[green]✓ All artifacts validated successfully[/green]")
@@ -2160,6 +2265,7 @@ def _load_artifact_with_diagnostics(
     trust_db: bool = False,
 ) -> Any | None:
     attempted_paths: List[Tuple[str, Path]] = []
+    recovery_paths = _artifact_recovery_candidate_paths(tracker, artifact)
 
     def _load_once() -> Any:
         import consist
@@ -2186,6 +2292,20 @@ def _load_artifact_with_diagnostics(
         finally:
             _set_tracker_run_dir(tracker, original_run_dir)
 
+    def _load_from_recovery_roots() -> Any | None:
+        for label, candidate in recovery_paths:
+            if not candidate.exists():
+                attempted_paths.append((label, candidate))
+                continue
+            try:
+                return _load_artifact_from_resolved_path(
+                    artifact, candidate, n_rows=n_rows
+                )
+            except FileNotFoundError:
+                attempted_paths.append((label, candidate))
+                continue
+        return None
+
     try:
         if artifact.container_uri.startswith("./") and resolution_bases:
             original_run_dir = _resolve_cli_path(tracker.run_dir)
@@ -2193,6 +2313,9 @@ def _load_artifact_with_diagnostics(
                 loaded = _load_from_base(base_dir, label, original_run_dir)
                 if loaded is not None:
                     return loaded
+            loaded = _load_from_recovery_roots()
+            if loaded is not None:
+                return loaded
 
             _print_missing_artifact_file_help(
                 tracker,
@@ -2205,6 +2328,9 @@ def _load_artifact_with_diagnostics(
 
         return _load_once()
     except FileNotFoundError:
+        loaded = _load_from_recovery_roots()
+        if loaded is not None:
+            return loaded
         _print_missing_artifact_file_help(
             tracker,
             artifact,
@@ -2603,7 +2729,12 @@ class ConsistShell(cmd.Cmd):
             prepared.extend(["--db-path", self.db_path])
 
         if (
-            command_path in {("preview",), ("validate",)}
+            command_path
+            in {
+                ("preview",),
+                ("validate",),
+                ("schema", "capture-file"),
+            }
             and self.run_dir
             and not self._has_option(prepared, "--run-dir")
         ):
@@ -2622,7 +2753,12 @@ class ConsistShell(cmd.Cmd):
             prepared.append("--trust-db")
 
         if (
-            command_path in {("preview",), ("schema", "capture-file")}
+            command_path
+            in {
+                ("preview",),
+                ("validate",),
+                ("schema", "capture-file"),
+            }
             and self.mount_overrides
             and not self._has_option(prepared, "--mount")
         ):
@@ -3085,7 +3221,10 @@ class ConsistShell(cmd.Cmd):
         self._invoke_cli_command("search", arg)
 
     def do_validate(self, arg: str) -> None:
-        """Validate artifact files. Usage: validate [--fix] [--run-dir PATH]"""
+        """Validate artifact files.
+
+        Usage: validate [--fix] [--run-dir PATH] [--trust-db] [--mount NAME=PATH]
+        """
         self._invoke_cli_command("validate", arg)
 
     def do_scenario(self, arg: str) -> None:
@@ -3890,7 +4029,10 @@ def shell(
     run_dir: Optional[str] = typer.Option(
         None,
         "--run-dir",
-        help="Base directory for resolving relative artifact paths in shell preview/schema_profile.",
+        help=(
+            "Base directory for resolving relative artifact paths in shell "
+            "preview/schema_profile/validate/schema capture-file commands."
+        ),
     ),
     mount: Optional[List[str]] = typer.Option(
         None,

--- a/src/consist/cli.py
+++ b/src/consist/cli.py
@@ -858,6 +858,15 @@ def _set_tracker_mounts(tracker: Tracker, mounts: Mapping[str, str]) -> None:
     tracker.mounts = tracker.fs.mounts
 
 
+@contextmanager
+def _preserve_tracker_mounts(tracker: Tracker) -> Iterator[None]:
+    original_mounts = dict(tracker.mounts)
+    try:
+        yield
+    finally:
+        _set_tracker_mounts(tracker, original_mounts)
+
+
 def _ensure_tracker_mounts_for_artifact(
     tracker: Tracker, artifact: "Artifact", *, trust_db: bool
 ) -> None:
@@ -896,9 +905,11 @@ def _ensure_tracker_mounts_for_artifact(
 
 
 def _artifact_recovery_candidate_paths(
-    tracker: Tracker, artifact: "Artifact"
+    tracker: Tracker, artifact: "Artifact", *, trust_db: bool
 ) -> List[Tuple[str, Path]]:
     """Return path candidates derived from artifact recovery roots."""
+    if not trust_db:
+        return []
     fs = getattr(tracker, "fs", None)
     relative_path_helper = getattr(fs, "get_remappable_relative_path", None)
     roots_helper = getattr(fs, "normalize_recovery_roots", None)
@@ -995,7 +1006,9 @@ def _resolve_schema_capture_path(
             lambda: Path(tracker.resolve_uri(artifact.container_uri)).resolve(),
         )
 
-    candidates.extend(_artifact_recovery_candidate_paths(tracker, artifact))
+    candidates.extend(
+        _artifact_recovery_candidate_paths(tracker, artifact, trust_db=trust_db)
+    )
 
     for _, candidate in candidates:
         if candidate.exists():
@@ -1848,7 +1861,7 @@ def validate(
                                 break
                 if not found:
                     for _, candidate in _artifact_recovery_candidate_paths(
-                        tracker, artifact
+                        tracker, artifact, trust_db=trust_db
                     ):
                         if candidate.exists():
                             found = True
@@ -2265,7 +2278,9 @@ def _load_artifact_with_diagnostics(
     trust_db: bool = False,
 ) -> Any | None:
     attempted_paths: List[Tuple[str, Path]] = []
-    recovery_paths = _artifact_recovery_candidate_paths(tracker, artifact)
+    recovery_paths = _artifact_recovery_candidate_paths(
+        tracker, artifact, trust_db=trust_db
+    )
 
     def _load_once() -> Any:
         import consist
@@ -2416,7 +2431,14 @@ def preview(
         "--run-dir",
         help="Base directory for resolving relative artifact paths like ./outputs/...",
     ),
-    n_rows: int = typer.Option(5, "--rows", "-n", help="Number of rows to display."),
+    n_rows: int = typer.Option(
+        5,
+        "--rows",
+        "-n",
+        min=1,
+        max=MAX_PREVIEW_ROWS,
+        help="Number of rows to display.",
+    ),
     trust_db: bool = typer.Option(
         False,
         "--trust-db",
@@ -3482,24 +3504,27 @@ class ConsistShell(cmd.Cmd):
                     )
                 return
 
-            _ensure_tracker_mounts_for_artifact(
-                self.tracker, artifact, trust_db=self.trust_db
-            )
-            resolution_bases, db_metadata_run_dir = _build_relative_resolution_bases(
-                self.tracker,
-                artifact,
-                db_path=self.db_path,
-                run_dir=self.run_dir,
-                trust_db=self.trust_db,
-            )
-            data = _load_artifact_with_diagnostics(
-                self.tracker,
-                artifact,
-                n_rows=n_rows,
-                resolution_bases=resolution_bases,
-                db_metadata_run_dir=db_metadata_run_dir,
-                trust_db=self.trust_db,
-            )
+            with _preserve_tracker_mounts(self.tracker):
+                _ensure_tracker_mounts_for_artifact(
+                    self.tracker, artifact, trust_db=self.trust_db
+                )
+                resolution_bases, db_metadata_run_dir = (
+                    _build_relative_resolution_bases(
+                        self.tracker,
+                        artifact,
+                        db_path=self.db_path,
+                        run_dir=self.run_dir,
+                        trust_db=self.trust_db,
+                    )
+                )
+                data = _load_artifact_with_diagnostics(
+                    self.tracker,
+                    artifact,
+                    n_rows=n_rows,
+                    resolution_bases=resolution_bases,
+                    db_metadata_run_dir=db_metadata_run_dir,
+                    trust_db=self.trust_db,
+                )
             if data is None:
                 return
 
@@ -3605,35 +3630,38 @@ class ConsistShell(cmd.Cmd):
                     )
                 return
 
-            _ensure_tracker_mounts_for_artifact(
-                self.tracker, artifact, trust_db=self.trust_db
-            )
-            resolution_bases, db_metadata_run_dir = _build_relative_resolution_bases(
-                self.tracker,
-                artifact,
-                db_path=self.db_path,
-                run_dir=self.run_dir,
-                trust_db=self.trust_db,
-            )
-
-            if self.tracker.db and artifact.id:
-                fetched = self.tracker.db.get_artifact_schema_for_artifact(
-                    artifact_id=artifact.id
+            with _preserve_tracker_mounts(self.tracker):
+                _ensure_tracker_mounts_for_artifact(
+                    self.tracker, artifact, trust_db=self.trust_db
                 )
-                if fetched is not None:
-                    schema, fields = fetched
-                    console.print(
-                        f"Schema: {artifact.key} [dim]({artifact.driver}, db profile)[/dim]"
+                resolution_bases, db_metadata_run_dir = (
+                    _build_relative_resolution_bases(
+                        self.tracker,
+                        artifact,
+                        db_path=self.db_path,
+                        run_dir=self.run_dir,
+                        trust_db=self.trust_db,
                     )
-                    _render_schema_profile(schema, fields)
-                    return
-            data = _load_artifact_with_diagnostics(
-                self.tracker,
-                artifact,
-                resolution_bases=resolution_bases,
-                db_metadata_run_dir=db_metadata_run_dir,
-                trust_db=self.trust_db,
-            )
+                )
+
+                if self.tracker.db and artifact.id:
+                    fetched = self.tracker.db.get_artifact_schema_for_artifact(
+                        artifact_id=artifact.id
+                    )
+                    if fetched is not None:
+                        schema, fields = fetched
+                        console.print(
+                            f"Schema: {artifact.key} [dim]({artifact.driver}, db profile)[/dim]"
+                        )
+                        _render_schema_profile(schema, fields)
+                        return
+                data = _load_artifact_with_diagnostics(
+                    self.tracker,
+                    artifact,
+                    resolution_bases=resolution_bases,
+                    db_metadata_run_dir=db_metadata_run_dir,
+                    trust_db=self.trust_db,
+                )
             if data is None:
                 return
 

--- a/src/consist/core/schema_export.py
+++ b/src/consist/core/schema_export.py
@@ -246,8 +246,7 @@ def _to_class_name(table_name: str) -> str:
 def _validate_class_name(class_name: str) -> str:
     if not class_name.isidentifier() or keyword.iskeyword(class_name):
         raise ValueError(
-            "class_name must be a valid Python class identifier, "
-            f"got {class_name!r}."
+            f"class_name must be a valid Python class identifier, got {class_name!r}."
         )
     return class_name
 

--- a/src/consist/core/schema_export.py
+++ b/src/consist/core/schema_export.py
@@ -243,6 +243,15 @@ def _to_class_name(table_name: str) -> str:
     return "".join(p[:1].upper() + p[1:] for p in parts)
 
 
+def _validate_class_name(class_name: str) -> str:
+    if not class_name.isidentifier() or keyword.iskeyword(class_name):
+        raise ValueError(
+            "class_name must be a valid Python class identifier, "
+            f"got {class_name!r}."
+        )
+    return class_name
+
+
 def _iter_export_fields(
     fields: Iterable[ArtifactSchemaField],
     *,
@@ -291,7 +300,9 @@ def render_sqlmodel_stub(
         tname = summary.get("table_name")
         resolved_table_name = tname if isinstance(tname, str) and tname else "table"
 
-    resolved_class_name = class_name or _to_class_name(resolved_table_name)
+    resolved_class_name = _validate_class_name(
+        class_name or _to_class_name(resolved_table_name)
+    )
 
     export_fields = _iter_export_fields(
         fields,

--- a/src/consist/models/artifact.py
+++ b/src/consist/models/artifact.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 import weakref
+from dataclasses import dataclass
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,10 +31,17 @@ UTC = timezone.utc
 if TYPE_CHECKING:
     import pandas as pd
 
+    from consist.core.fs import FileSystemManager
     from consist.core.tracker import Tracker
 
 
 class _ArtifactTrackerRef(Protocol):
+    def resolve_uri(self, uri: str) -> str: ...
+
+
+class _TrackerWithFS(Protocol):
+    fs: "FileSystemManager"
+
     def resolve_uri(self, uri: str) -> str: ...
 
 
@@ -105,6 +113,45 @@ def set_tracker_ref(artifact: object, tracker: _ArtifactTrackerRef) -> None:
         object.__setattr__(artifact, "_tracker", tracker_ref)
     except (AttributeError, TypeError):
         return
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactLocationStatus:
+    """Reachability status for one artifact location."""
+
+    label: str
+    path: Path
+    exists: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactAccessibility:
+    """Structured accessibility report for an artifact."""
+
+    locations: tuple[ArtifactLocationStatus, ...]
+
+    @property
+    def status(self) -> str:
+        """Return a concise accessibility status string."""
+        if self.locations and self.locations[0].exists:
+            return "primary"
+        for location in self.locations[1:]:
+            if location.exists:
+                return "recovery"
+        return "missing"
+
+    @property
+    def accessible(self) -> bool:
+        """Return whether any checked location is reachable."""
+        return any(location.exists for location in self.locations)
+
+    @property
+    def best_location(self) -> Optional[ArtifactLocationStatus]:
+        """Return the first reachable location, if any."""
+        for location in self.locations:
+            if location.exists:
+                return location
+        return None
 
 
 class UUIDType(TypeDecorator):
@@ -296,6 +343,11 @@ class Artifact(SQLModel, table=True):
             return [str(item) for item in roots if isinstance(item, (str, Path))]
         return []
 
+    @property
+    def locations(self) -> tuple[ArtifactLocationStatus, ...]:
+        """Return the currently checked locations for this artifact."""
+        return self.accessibility().locations
+
     @abs_path.setter
     def abs_path(self, value: str) -> None:
         """
@@ -345,6 +397,71 @@ class Artifact(SQLModel, table=True):
         if tracker is not None:
             return Path(tracker.resolve_uri(self.container_uri))
         return self.path
+
+    def accessibility(
+        self, tracker: Optional["Tracker"] = None
+    ) -> ArtifactAccessibility:
+        """
+        Inspect the primary path and any advisory recovery roots.
+
+        The primary location uses the currently attached tracker when available,
+        or the explicit ``tracker`` argument when provided. Recovery roots are
+        only checked when a tracker is available so the remappable layout can be
+        derived safely.
+        """
+        tracker_obj: Optional[_TrackerWithFS] = None
+        if tracker is not None:
+            tracker_obj = cast(_TrackerWithFS, tracker)
+        if tracker_obj is None:
+            tracker_ref = get_tracker_ref(self)
+            if tracker_ref is not None:
+                tracker_candidate = tracker_ref()
+                if tracker_candidate is not None:
+                    tracker_obj = cast(_TrackerWithFS, tracker_candidate)
+
+        try:
+            primary_path = (
+                Path(tracker_obj.resolve_uri(self.container_uri))
+                if tracker_obj is not None
+                else self.path
+            )
+        except Exception:
+            primary_path = self.path
+        locations = [
+            ArtifactLocationStatus(
+                label="primary",
+                path=primary_path,
+                exists=primary_path.exists(),
+            )
+        ]
+
+        if tracker_obj is None:
+            return ArtifactAccessibility(locations=tuple(locations))
+
+        fs = tracker_obj.fs
+        relative_path_helper = fs.get_remappable_relative_path
+        roots_helper = fs.normalize_recovery_roots
+
+        relative_path = relative_path_helper(self.container_uri)
+        if relative_path is None:
+            return ArtifactAccessibility(locations=tuple(locations))
+
+        try:
+            roots = roots_helper(self.recovery_roots)
+        except (TypeError, ValueError):
+            return ArtifactAccessibility(locations=tuple(locations))
+
+        for index, root in enumerate(roots, start=1):
+            candidate = (Path(root) / relative_path).resolve()
+            locations.append(
+                ArtifactLocationStatus(
+                    label=f"recovery_root #{index}",
+                    path=candidate,
+                    exists=candidate.exists(),
+                )
+            )
+
+        return ArtifactAccessibility(locations=tuple(locations))
 
     def as_df(
         self,

--- a/tests/integration/tracker/test_tracker_ergonomics.py
+++ b/tests/integration/tracker/test_tracker_ergonomics.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 import consist
 from consist import Tracker
 from consist.models.artifact import Artifact
@@ -148,6 +149,50 @@ def test_artifact_accessor_helpers_support_attached_and_explicit_tracker(
     assert detached.as_path(tracker=tracker) == output_path
     fallback_df = detached.as_df(tracker=tracker)
     assert fallback_df.equals(attached_df)
+
+
+def test_artifact_accessibility_reports_primary_and_recovery_root(
+    tracker: Tracker, run_dir: Path
+) -> None:
+    primary_path = run_dir / "outputs" / "results.csv"
+    primary_path.parent.mkdir(parents=True, exist_ok=True)
+    primary_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    archive_root = run_dir.parent / "archive"
+    archive_root.mkdir(parents=True, exist_ok=True)
+
+    with tracker.start_run("artifact_accessibility_run", "artifact_accessibility"):
+        tracker.log_output(primary_path, key="results")
+
+    artifact = tracker.get_artifact("results")
+    assert artifact is not None
+
+    accessibility = artifact.accessibility()
+    assert accessibility.status == "primary"
+    assert accessibility.accessible is True
+    assert accessibility.locations[0].label == "primary"
+    assert accessibility.locations[0].exists is True
+    assert artifact.locations == accessibility.locations
+
+    relative_path = tracker.fs.get_remappable_relative_path(artifact.container_uri)
+    assert relative_path is not None
+    archived_path = archive_root / relative_path
+    archived_path.parent.mkdir(parents=True, exist_ok=True)
+    archived_path.write_text("a,b\n1,2\n", encoding="utf-8")
+    tracker.set_artifact_recovery_roots(artifact, [archive_root])
+
+    primary_path.unlink()
+
+    refreshed = tracker.get_artifact("results")
+    assert refreshed is not None
+
+    refreshed_accessibility = refreshed.accessibility()
+    assert refreshed_accessibility.status == "recovery"
+    assert refreshed_accessibility.best_location is not None
+    assert refreshed_accessibility.best_location.label == "recovery_root #1"
+    assert refreshed_accessibility.locations[0].exists is False
+    assert any(location.exists for location in refreshed_accessibility.locations[1:])
+    assert refreshed.locations == refreshed_accessibility.locations
 
 
 def test_run_config_snapshot_access(tracker: Tracker):

--- a/tests/unit/cli/test_cli_artifacts_lineage_guards.py
+++ b/tests/unit/cli/test_cli_artifacts_lineage_guards.py
@@ -123,6 +123,7 @@ def test_schema_capture_file_passes_mount_overrides_to_tracker(tmp_path) -> None
     assert result.exit_code == 1
     mock_get_tracker.assert_called_once_with(
         "mock.db",
+        run_dir=None,
         mounts={"workspace": str(workspace_root.resolve())},
     )
 

--- a/tests/unit/cli/test_cli_artifacts_lineage_guards.py
+++ b/tests/unit/cli/test_cli_artifacts_lineage_guards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -183,3 +184,35 @@ def test_artifacts_query_mode_surfaces_value_errors(cli_runner) -> None:
 
     assert result.exit_code == 1
     assert "invalid --param expression" in result.stdout
+
+
+def test_artifacts_run_mode_shows_accessibility_status(
+    cli_runner, tracker, run_dir: Path
+) -> None:
+    """`artifacts` run mode should display a per-artifact accessibility indicator."""
+    primary_path = run_dir / "outputs" / "results.csv"
+    primary_path.parent.mkdir(parents=True, exist_ok=True)
+    primary_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    archive_root = run_dir.parent / "archive"
+    archive_root.mkdir(parents=True, exist_ok=True)
+
+    with tracker.start_run("accessibility_run", "accessibility_model"):
+        tracker.log_output(primary_path, key="results")
+
+    artifact = tracker.get_artifact("results")
+    assert artifact is not None
+
+    relative_path = tracker.fs.get_remappable_relative_path(artifact.container_uri)
+    assert relative_path is not None
+    archived_path = archive_root / relative_path
+    archived_path.parent.mkdir(parents=True, exist_ok=True)
+    archived_path.write_text("a,b\n1,2\n", encoding="utf-8")
+    tracker.set_artifact_recovery_roots(artifact, [archive_root])
+    primary_path.unlink()
+
+    result = cli_runner.invoke(app, ["artifacts", "accessibility_run"])
+
+    assert result.exit_code == 0
+    assert "Access" in result.stdout
+    assert "recovery" in result.stdout

--- a/tests/unit/cli/test_preview_path_resolution.py
+++ b/tests/unit/cli/test_preview_path_resolution.py
@@ -68,6 +68,14 @@ def test_preview_resolves_relative_paths_from_current_working_directory(
     assert "origin_zone" in result.stdout
 
 
+def test_preview_rejects_unbounded_rows_before_loading_artifact() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["preview", "trip_table", "--rows", "0"])
+
+    assert result.exit_code == 2
+
+
 def test_preview_accepts_run_dir_option_for_moved_run_roots(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -331,7 +339,7 @@ def test_schema_capture_file_accepts_trust_db_for_moved_relative_paths(
     assert "Captured file schema for artifact 'trip_table'" in result.stdout
 
 
-def test_preview_uses_recovery_roots_without_source_root_option(
+def test_preview_requires_trust_db_for_recovery_roots(
     tmp_path: Path, monkeypatch
 ) -> None:
     repo_root = tmp_path / "repo"
@@ -369,12 +377,28 @@ def test_preview_uses_recovery_roots_without_source_root_option(
         ],
     )
 
+    assert result.exit_code == 1
+    assert "Artifact file not found" in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "preview",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+            "--trust-db",
+            "--rows",
+            "1",
+        ],
+    )
+
     assert result.exit_code == 0
     assert "Preview: trip_table" in result.stdout
     assert "origin_zone" in result.stdout
 
 
-def test_schema_capture_file_uses_recovery_roots_without_trust_db(
+def test_schema_capture_file_requires_trust_db_for_recovery_roots(
     tmp_path: Path, monkeypatch
 ) -> None:
     repo_root = tmp_path / "repo"
@@ -412,11 +436,27 @@ def test_schema_capture_file_uses_recovery_roots_without_trust_db(
         ],
     )
 
+    assert result.exit_code == 1
+    assert "Could not resolve an existing artifact file path" in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "schema",
+            "capture-file",
+            "--artifact-key",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+            "--trust-db",
+        ],
+    )
+
     assert result.exit_code == 0
     assert "Captured file schema for artifact 'trip_table'" in result.stdout
 
 
-def test_validate_uses_recovery_roots_without_source_root_option(
+def test_validate_requires_trust_db_for_recovery_roots(
     tmp_path: Path, monkeypatch
 ) -> None:
     repo_root = tmp_path / "repo"
@@ -445,6 +485,14 @@ def test_validate_uses_recovery_roots_without_source_root_option(
     result = runner.invoke(
         app,
         ["validate", "--db-path", "db/beam_core_demo.duckdb"],
+    )
+
+    assert result.exit_code == 0
+    assert "missing artifacts" in result.stdout
+
+    result = runner.invoke(
+        app,
+        ["validate", "--db-path", "db/beam_core_demo.duckdb", "--trust-db"],
     )
 
     assert result.exit_code == 0
@@ -652,3 +700,11 @@ def test_shell_preview_uses_trust_db_mount_inference_for_workspace_uris(
     out = capsys.readouterr().out
     assert "Preview: trip_table" in out
     assert "origin_zone" in out
+    assert shell.tracker.mounts == {}
+
+    shell.do_schema_profile("trip_table")
+
+    out = capsys.readouterr().out
+    assert "Schema: trip_table" in out
+    assert "origin_zone" in out
+    assert shell.tracker.mounts == {}

--- a/tests/unit/cli/test_preview_path_resolution.py
+++ b/tests/unit/cli/test_preview_path_resolution.py
@@ -241,6 +241,398 @@ def test_validate_accepts_trust_db_option_for_moved_run_roots(
     assert "All artifacts validated successfully" in result.stdout
 
 
+def test_schema_capture_file_requires_run_dir_or_trust_for_moved_relative_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    run_dir = tmp_path / "archive" / "beam_core_demo"
+    db_dir = repo_root / "db"
+    db_dir.mkdir(parents=True)
+    run_dir.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    _create_relative_csv_artifact(run_dir=run_dir, db_path=db_path)
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "schema",
+            "capture-file",
+            "--artifact-key",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Could not resolve an existing artifact file path" in result.stdout
+
+
+def test_schema_capture_file_accepts_run_dir_for_moved_relative_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    run_dir = tmp_path / "archive" / "beam_core_demo"
+    db_dir = repo_root / "db"
+    db_dir.mkdir(parents=True)
+    run_dir.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    _create_relative_csv_artifact(run_dir=run_dir, db_path=db_path)
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "schema",
+            "capture-file",
+            "--artifact-key",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+            "--run-dir",
+            str(run_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Captured file schema for artifact 'trip_table'" in result.stdout
+
+
+def test_schema_capture_file_accepts_trust_db_for_moved_relative_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    run_dir = tmp_path / "archive" / "beam_core_demo"
+    db_dir = repo_root / "db"
+    db_dir.mkdir(parents=True)
+    run_dir.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    _create_relative_csv_artifact(run_dir=run_dir, db_path=db_path)
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "schema",
+            "capture-file",
+            "--artifact-key",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+            "--trust-db",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Captured file schema for artifact 'trip_table'" in result.stdout
+
+
+def test_preview_uses_recovery_roots_without_source_root_option(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    run_dir = tmp_path / "historical" / "beam_core_demo"
+    db_dir = repo_root / "db"
+    archive_root = tmp_path / "archive" / "beam_core_demo"
+    db_dir.mkdir(parents=True)
+    archive_root.mkdir(parents=True)
+    run_dir.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+
+    _create_relative_csv_artifact(run_dir=run_dir, db_path=db_path)
+    producer = Tracker(run_dir=run_dir, db_path=str(db_path))
+    artifact = producer.get_artifact("trip_table")
+    assert artifact is not None
+    relative_path = producer.fs.get_remappable_relative_path(artifact.container_uri)
+    assert relative_path is not None
+    archived_path = archive_root / relative_path
+    archived_path.parent.mkdir(parents=True, exist_ok=True)
+    archived_path.write_text("origin_zone,dest_zone\n1,2\n", encoding="utf-8")
+    producer.set_artifact_recovery_roots(artifact, [archive_root])
+    (run_dir / relative_path).unlink()
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "preview",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+            "--rows",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Preview: trip_table" in result.stdout
+    assert "origin_zone" in result.stdout
+
+
+def test_schema_capture_file_uses_recovery_roots_without_trust_db(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    run_dir = tmp_path / "historical" / "beam_core_demo"
+    db_dir = repo_root / "db"
+    archive_root = tmp_path / "archive" / "beam_core_demo"
+    db_dir.mkdir(parents=True)
+    archive_root.mkdir(parents=True)
+    run_dir.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+
+    _create_relative_csv_artifact(run_dir=run_dir, db_path=db_path)
+    producer = Tracker(run_dir=run_dir, db_path=str(db_path))
+    artifact = producer.get_artifact("trip_table")
+    assert artifact is not None
+    relative_path = producer.fs.get_remappable_relative_path(artifact.container_uri)
+    assert relative_path is not None
+    archived_path = archive_root / relative_path
+    archived_path.parent.mkdir(parents=True, exist_ok=True)
+    archived_path.write_text("origin_zone,dest_zone\n1,2\n", encoding="utf-8")
+    producer.set_artifact_recovery_roots(artifact, [archive_root])
+    (run_dir / relative_path).unlink()
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "schema",
+            "capture-file",
+            "--artifact-key",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Captured file schema for artifact 'trip_table'" in result.stdout
+
+
+def test_validate_uses_recovery_roots_without_source_root_option(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    run_dir = tmp_path / "historical" / "beam_core_demo"
+    db_dir = repo_root / "db"
+    archive_root = tmp_path / "archive" / "beam_core_demo"
+    db_dir.mkdir(parents=True)
+    archive_root.mkdir(parents=True)
+    run_dir.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+
+    _create_relative_csv_artifact(run_dir=run_dir, db_path=db_path)
+    producer = Tracker(run_dir=run_dir, db_path=str(db_path))
+    artifact = producer.get_artifact("trip_table")
+    assert artifact is not None
+    relative_path = producer.fs.get_remappable_relative_path(artifact.container_uri)
+    assert relative_path is not None
+    archived_path = archive_root / relative_path
+    archived_path.parent.mkdir(parents=True, exist_ok=True)
+    archived_path.write_text("origin_zone,dest_zone\n1,2\n", encoding="utf-8")
+    producer.set_artifact_recovery_roots(artifact, [archive_root])
+    (run_dir / relative_path).unlink()
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["validate", "--db-path", "db/beam_core_demo.duckdb"],
+    )
+
+    assert result.exit_code == 0
+    assert "All artifacts validated successfully" in result.stdout
+
+
+def test_validate_mount_uri_fails_without_mount_or_trust_db(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    db_dir = repo_root / "db"
+    inputs_root = tmp_path / "inputs"
+    db_dir.mkdir(parents=True)
+    inputs_root.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    data_path = inputs_root / "trip_table.csv"
+    data_path.write_text("origin_zone,dest_zone\n1,2\n", encoding="utf-8")
+
+    producer = Tracker(
+        run_dir=tmp_path / "producer",
+        db_path=str(db_path),
+        mounts={"inputs": str(inputs_root)},
+    )
+    with producer.start_run("producer_run", "preview_model"):
+        producer.log_artifact(data_path, key="trip_table", direction="output")
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(app, ["validate", "--db-path", "db/beam_core_demo.duckdb"])
+
+    assert result.exit_code == 0
+    assert "Found 1 missing artifacts" in result.stdout
+    assert "trip_table" in result.stdout
+
+
+def test_validate_accepts_mount_overrides_for_mount_uris(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    db_dir = repo_root / "db"
+    inputs_root = tmp_path / "inputs"
+    db_dir.mkdir(parents=True)
+    inputs_root.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    data_path = inputs_root / "trip_table.csv"
+    data_path.write_text("origin_zone,dest_zone\n1,2\n", encoding="utf-8")
+
+    producer = Tracker(
+        run_dir=tmp_path / "producer",
+        db_path=str(db_path),
+        mounts={"inputs": str(inputs_root)},
+    )
+    with producer.start_run("producer_run", "preview_model"):
+        producer.log_artifact(data_path, key="trip_table", direction="output")
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "validate",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+            "--mount",
+            f"inputs={inputs_root}",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "All artifacts validated successfully" in result.stdout
+
+
+def test_schema_capture_file_accepts_mount_overrides_for_mount_uris(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    db_dir = repo_root / "db"
+    inputs_root = tmp_path / "inputs"
+    db_dir.mkdir(parents=True)
+    inputs_root.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    data_path = inputs_root / "trip_table.csv"
+    data_path.write_text("origin_zone,dest_zone\n1,2\n", encoding="utf-8")
+
+    producer = Tracker(
+        run_dir=tmp_path / "producer",
+        db_path=str(db_path),
+        mounts={"inputs": str(inputs_root)},
+    )
+    with producer.start_run("producer_run", "preview_model"):
+        producer.log_artifact(data_path, key="trip_table", direction="output")
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "schema",
+            "capture-file",
+            "--artifact-key",
+            "trip_table",
+            "--db-path",
+            "db/beam_core_demo.duckdb",
+            "--mount",
+            f"inputs={inputs_root}",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Captured file schema for artifact 'trip_table'" in result.stdout
+
+
+def test_validate_infers_mounts_from_db_when_trusted(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    db_dir = repo_root / "db"
+    inputs_root = tmp_path / "inputs"
+    db_dir.mkdir(parents=True)
+    inputs_root.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    data_path = inputs_root / "trip_table.csv"
+    data_path.write_text("origin_zone,dest_zone\n1,2\n", encoding="utf-8")
+
+    producer = Tracker(
+        run_dir=tmp_path / "producer",
+        db_path=str(db_path),
+        mounts={"inputs": str(inputs_root)},
+    )
+    with producer.start_run("producer_run", "preview_model"):
+        producer.log_artifact(data_path, key="trip_table", direction="input")
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["validate", "--db-path", "db/beam_core_demo.duckdb", "--trust-db"],
+    )
+
+    assert result.exit_code == 0
+    assert "All artifacts validated successfully" in result.stdout
+
+
+def test_validate_trusted_mount_inference_is_per_artifact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    db_dir = repo_root / "db"
+    inputs_a = tmp_path / "inputs_a"
+    inputs_b = tmp_path / "inputs_b"
+    db_dir.mkdir(parents=True)
+    inputs_a.mkdir(parents=True)
+    inputs_b.mkdir(parents=True)
+    db_path = db_dir / "beam_core_demo.duckdb"
+    data_a = inputs_a / "data" / "a.csv"
+    data_b = inputs_b / "data" / "b.csv"
+    data_a.parent.mkdir(parents=True)
+    data_b.parent.mkdir(parents=True)
+    data_a.write_text("value\n1\n", encoding="utf-8")
+    data_b.write_text("value\n2\n", encoding="utf-8")
+
+    producer_a = Tracker(
+        run_dir=tmp_path / "producer_a",
+        db_path=str(db_path),
+        mounts={"inputs": str(inputs_a)},
+    )
+    with producer_a.start_run("producer_a", "preview_model"):
+        producer_a.log_artifact(data_a, key="data_a", direction="input")
+
+    producer_b = Tracker(
+        run_dir=tmp_path / "producer_b",
+        db_path=str(db_path),
+        mounts={"inputs": str(inputs_b)},
+    )
+    with producer_b.start_run("producer_b", "preview_model"):
+        producer_b.log_artifact(data_b, key="data_b", direction="input")
+
+    monkeypatch.chdir(repo_root)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["validate", "--db-path", "db/beam_core_demo.duckdb", "--trust-db"],
+    )
+
+    assert result.exit_code == 0
+    assert "All artifacts validated successfully" in result.stdout
+
+
 def test_shell_preview_uses_trust_db_mount_inference_for_workspace_uris(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:

--- a/tests/unit/cli/test_shell_ux.py
+++ b/tests/unit/cli/test_shell_ux.py
@@ -484,6 +484,7 @@ def test_shell_routed_schema_capture_file_applies_shell_defaults(tmp_path) -> No
         shell = ConsistShell(
             tracker,
             db_path="shell.db",
+            run_dir="/archive/run",
             trust_db=True,
             mount_overrides={"workspace": "/archive/workspace"},
         )
@@ -494,6 +495,34 @@ def test_shell_routed_schema_capture_file_applies_shell_defaults(tmp_path) -> No
     app_mock.assert_called_once()
     routed_args = app_mock.call_args.kwargs["args"]
     assert routed_args[:4] == ["schema", "capture-file", "--artifact-key", "trips"]
+    assert "--db-path" in routed_args
+    assert "shell.db" in routed_args
+    assert "--run-dir" in routed_args
+    assert "/archive/run" in routed_args
+    assert "--trust-db" in routed_args
+    assert "--mount" in routed_args
+    assert "workspace=/archive/workspace" in routed_args
+
+
+def test_shell_routed_validate_applies_mount_defaults(tmp_path) -> None:
+    tracker = MagicMock()
+    with (
+        patch("consist.cli.Path.home", return_value=tmp_path),
+        patch("consist.cli._READLINE", None),
+    ):
+        shell = ConsistShell(
+            tracker,
+            db_path="shell.db",
+            trust_db=True,
+            mount_overrides={"workspace": "/archive/workspace"},
+        )
+
+    with patch("consist.cli.app") as app_mock:
+        shell.do_validate("")
+
+    app_mock.assert_called_once()
+    routed_args = app_mock.call_args.kwargs["args"]
+    assert routed_args[:1] == ["validate"]
     assert "--db-path" in routed_args
     assert "shell.db" in routed_args
     assert "--trust-db" in routed_args

--- a/tests/unit/core/test_schema_export.py
+++ b/tests/unit/core/test_schema_export.py
@@ -90,6 +90,25 @@ def test_render_sqlmodel_stub_can_include_system_cols():
     assert "consist_run_id" in code
 
 
+def test_render_sqlmodel_stub_rejects_invalid_class_name():
+    schema = ArtifactSchema(
+        id="schema_bad_class",
+        summary_json={"table_name": "t"},
+        profile_json=None,
+    )
+
+    try:
+        render_sqlmodel_stub(
+            schema=schema,
+            fields=[],
+            class_name="Bad; import os",
+        )
+    except ValueError as exc:
+        assert "valid Python class identifier" in str(exc)
+    else:
+        raise AssertionError("Expected invalid class_name to be rejected")
+
+
 def test_render_sqlmodel_stub_renders_foreign_keys():
     schema = ArtifactSchema(
         id="schema_fk", summary_json={"table_name": "children"}, profile_json=None


### PR DESCRIPTION
## Summary

Improves Consist CLI artifact-path UX for archived and moved runs.

- Use artifact `recovery_roots` automatically when resolving files for `preview`, `validate`, and `schema capture-file`
- Add `--mount NAME=PATH` support to `validate`
- Add `--run-dir` support to `schema capture-file`
- Make `schema capture-file` follow the same trust-aware path resolution policy as `preview`
- Fix shell default propagation so `--db-path`, `--run-dir`, `--trust-db`, and `--mount` apply consistently to routed commands
- Prevent trusted DB mount inference from leaking between artifacts during `validate`
- Update CLI docs and help text for the new resolution behavior
- Add accessibility indicator to `artifacts` to make it visible whether/where artifacts can be found on disk

## Motivation

The previous CLI workflow was too verbose for archived runs and recovery workflows. Users often had to repeat long commands with explicit mounts and run roots, even when the DB already contained enough metadata to resolve archived artifacts safely. Some commands also handled mounts and historical paths differently, which made `preview`, `validate`, shell usage, and schema capture behave inconsistently.