### PR TITLE
Repo cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Consist
+
+Thanks for your interest in contributing! Consist is currently maintained by a [small team](https://seta.lbl.gov/innovative-transportation-systems) at LBNL, but contributions of all kinds are welcome.
+
+## Ways to Contribute
+
+**Report a bug or request a feature:** Open an [issue](https://github.com/LBNL-UCB-STI/consist/issues). Please include enough context to reproduce the problem or understand the use case.
+
+**Submit a pull request:** Fork the repo, create a branch, and open a PR. For anything beyond a small fix, it's worth opening an issue first so we can discuss the approach before you invest significant time.
+
+**Ask a question:** If something in the docs is unclear or you're unsure whether Consist fits your use case, feel free to open an issue or email me directly at zaneedell@lbl.gov.
+
+## Development Setup
+
+```bash
+# Clone and set up
+git clone https://github.com/LBNL-UCB-STI/consist.git
+cd consist
+
+# With uv (recommended)
+uv sync --group dev
+uv run pytest
+
+# Or with pip
+pip install -e ".[dev]"
+pytest
+```
+
+## Guidelines
+
+- Please include tests for new functionality.
+- Run the existing test suite before submitting a PR to make sure nothing is broken.
+- Code is formatted and linted with [Ruff](https://docs.astral.sh/ruff/) — CI will check this automatically. You can run `ruff check` and `ruff format` locally before pushing. Type annotations are strongly encouraged, and the codebase is checked with [ty](https://github.com/astral-sh/ty).
+
+## Code of Conduct
+
+Be kind and constructive. This is a small project and contributions are typically reviewed by one person, so patience is appreciated. I'll do my best to respond to issues and PRs within a couple of weeks.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [BSD 3-Clause License](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,18 +10,14 @@ requires-python = ">=3.11"
 dependencies = [
     "duckdb>=1.4.2",
     "duckdb-engine>=0.17.0",
-    "mike>=2.2.0",
     "pandas>=2.1.0",
     "pyarrow>=22.0.0",
     "pydantic>=2.12.4",
     "rich>=13.7.1",
-    "ruff>=0.15.7",
-    "sqlalchemy>=2.0.44,<2.0.45",
+    "sqlalchemy>=2.0.44,<2.0.45", # Bug: https://github.com/Mause/duckdb_engine/issues/1379
     "sqlmodel>=0.0.31",
     "tqdm>=4.67.1",
-    "ty>=0.0.15",
     "typer>=0.12.3",
-    "zensical>=0.0.39",
 ]
 keywords = ["provenance", "caching", "lineage", "reproducibility", "duckdb", "scientific-computing"]
 classifiers = [
@@ -56,11 +52,6 @@ examples = [
     "seaborn>=0.13.0",
     "ipywidgets>=8.1.8"
 ]
-typecheck = [
-    "pandas-stubs~=2.3.3",
-    "ty>=0.0.7",
-]
-
 # Convenience extras.
 all = [
     "cftime>=1.6.0",
@@ -73,34 +64,6 @@ all = [
     "openmatrix>=0.3.5.0",
     "pyhocon>=0.3.60",
     "PyYAML>=6.0",
-    "tables>=3.10.2",
-    "xarray>=2024.9.0",
-    "zarr>=2.18,<3",
-]
-bench = ["polars>=1.35.2", "psutil>6.0.0"]
-docs = ["mkdocs-material>=9.7.0", "mkdocstrings[python]>=1.0.0"]
-# Test + lint tools used by CI and local development.
-test = [
-    "h5netcdf>=1.3.0",
-    "openmatrix>=0.3.5.0",
-    "pyhocon>=0.3.60",
-    "pytest>=9.0.1",
-    "pytest-cov>=7.0.0",
-    "pytest-mock>=3.15.1",
-    "ruff>=0.14.6",
-    "xarray>=2024.9.0",
-    "zarr>=2.18,<3",
-]
-dev = [
-    "dlt>=1.21.0",
-    "h5netcdf>=1.3.0",
-    "h5py>=3.15.1",
-    "openmatrix>=0.3.5.0",
-    "pyhocon>=0.3.60",
-    "pytest>=9.0.1",
-    "pytest-cov>=7.0.0",
-    "pytest-mock>=3.15.1",
-    "ruff>=0.14.6",
     "tables>=3.10.2",
     "xarray>=2024.9.0",
     "zarr>=2.18,<3",
@@ -130,16 +93,22 @@ dev = [
     "pytest>=9.0.1",
     "pytest-cov>=7.0.0",
     "pytest-mock>=3.15.1",
-    "ruff>=0.14.6",
+    "ruff>=0.15.7",
     "tables>=3.10.2",
     "xarray>=2024.9.0",
     "zarr>=2.18,<3",
+    "ty>=0.0.15",
 ]
 docs = [
     "mkdocs-material>=9.7.0",
     "mkdocstrings[python]>=1.0.0",
     "mkdocstrings-python>=2.0.0",
     "zensical>=0.0.39",
+    "mike>=2.2.0",
+]
+typecheck = [
+    "pandas-stubs~=2.3.3",
+    "ty>=0.0.15",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

This branch adds a lightweight `CONTRIBUTING.md` and tidies `pyproject.toml` so runtime dependencies stay focused while docs, dev, and type-check tooling live in the right optional extras.

## What changed

- Add `CONTRIBUTING.md` with:
  - contribution workflow guidance
  - local setup commands
  - testing / linting expectations
  - code of conduct and license notes
- Reorganize `pyproject.toml` dependency groups:
  - keep runtime dependencies smaller
  - move docs-only tooling into `docs`
  - move dev/test tooling into `dev`
  - add/update `typecheck`
  - update Ruff / Ty versions in the relevant extras
- Preserve the existing materialization API branch as the baseline; this PR is just the repo cleanup layer on top.
